### PR TITLE
Reimplement transformation, handle Meta Nodes interrupting vertex grouping

### DIFF
--- a/src/Core/Node.hs
+++ b/src/Core/Node.hs
@@ -1,5 +1,6 @@
 module Core.Node (
   isCommentNode,
+  isObjectNode,
   Node (..),
 ) where
 
@@ -29,3 +30,7 @@ isCommentNode :: Node -> Bool
 isCommentNode (MultilineComment _) = True
 isCommentNode (SinglelineComment _) = True
 isCommentNode _ = False
+
+isObjectNode :: Node -> Bool
+isObjectNode (Object _) = True
+isObjectNode _ = False

--- a/src/Transformation.hs
+++ b/src/Transformation.hs
@@ -2,23 +2,18 @@ module Transformation (
   transform,
 ) where
 
-import Control.Arrow ((&&&))
-import Control.Monad (guard)
 import Core.Node
 import Data.Char (isDigit)
-import Data.Foldable1 (maximumBy)
 import Data.Function (on)
-import Data.List.NonEmpty (NonEmpty, (<|))
-import Data.Map (Map)
-import Data.Maybe (fromJust, fromMaybe, isJust, isNothing, mapMaybe)
+import Data.List (partition)
+import Data.List.NonEmpty (NonEmpty, toList)
+import Data.Maybe (fromJust, isJust, isNothing, mapMaybe)
 import Data.Scientific (Scientific)
-import Data.Sequence (Seq (..))
 import Data.Text (Text)
-import Data.Vector (Vector, (!), (!?), (//))
 import GHC.IsList (fromList)
 
-import Core.NodeCursor qualified as NC
 import Core.NodePath qualified as NP
+import Data.Foldable qualified as F (foldr, maximumBy)
 import Data.List.NonEmpty qualified as NE
 import Data.Map qualified as M
 import Data.Text qualified as T
@@ -34,13 +29,15 @@ data VertexTreeType
 data VertexTreeEntry
   = VertexEntry Vertex
   | MetaEntry Node
-  | MiscEntry Node
+  | HeaderEntry Node
+  deriving (Show)
 
 data VertexTree = VertexTree
   { tNodes :: NonEmpty VertexTreeEntry
   , tRest :: Maybe VertexTree
   , tType :: VertexTreeType
   }
+  deriving (Show)
 
 data Vertex = Vertex
   { vName :: Text
@@ -69,45 +66,50 @@ hasVerticePrefix verticePrefix node =
   let verticeName = vName <$> newVertice node
    in verticeName == Just verticePrefix
 
-getFirstVerticeName :: [Node] -> Text
-getFirstVerticeName (node : _) = vName . fromJust . newVertice $ node
+getFirstVerticeName :: [Node] -> Maybe Text
+getFirstVerticeName (node : _) = vName <$> newVertice node
+getFirstVerticeName _ = Nothing
 
-breakVertices :: Text -> [Node] -> ([Node], [Node])
-breakVertices verticePrefix = f []
+breakVertices :: Maybe Text -> [Node] -> ([Node], [Node])
+breakVertices Nothing = error "expected at least one Vertex"
+breakVertices (Just verticePrefix) = go []
   where
-    typeForVerticeList = mostCommon . NE.map (determineGroup . vX)
-    f acc nodes =
-      case nodes of
-        [] -> (acc, [])
-        (node : rest)
-          | hasVerticePrefix verticePrefix node -> (node : acc, nodes)
-          | isNonVertice node -> (node : acc, nodes)
-          | isVertice node ->
-              let (metaNodesNext, currentNodes) = span isNonVertice acc
-               in (currentNodes, metaNodesNext ++ (node : rest))
+    go acc [] = (reverse acc, [])
+    go acc (node : rest)
+      | isNonVertice node = go (node : acc) rest
+      | hasVerticePrefix verticePrefix node = go (node : acc) rest
+      | isVertice node =
+          let (metaBefore, currentTree) = span isNonVertice acc
+           in if null currentTree
+                then ([node], reverse metaBefore ++ rest)
+                else (reverse currentTree, reverse metaBefore ++ (node : rest))
+      | otherwise = go (node : acc) rest
 
 toVertexTreeEntry :: Node -> VertexTreeEntry
-toVertexTreeEntry node
-  | isJust vertice = VertexEntry (fromJust vertice)
-  | isNothing vertice && isObjectNode node = MetaEntry node
-  | otherwise = MiscEntry node
-  where
-    vertice = newVertice node
+toVertexTreeEntry node =
+  case newVertice node of
+    Just vertice -> VertexEntry vertice
+    Nothing
+      | isObjectNode node -> MetaEntry node
+      | otherwise -> HeaderEntry node
 
-typeForNodes = undefined
+mostCommon :: NonEmpty VertexTreeType -> VertexTreeType
+mostCommon = NE.head . F.maximumBy (compare `on` length) . NE.group1 . NE.sort
 
 nodesListToTree :: NonEmpty Node -> VertexTree
 nodesListToTree nodes =
-  let (nonVertices, rest) = NE.break isNonVertice nodes
-      verticePrefix = T.dropWhileEnd isDigit $ getFirstVerticeName rest
-      (vertices, rest') = breakVertices verticePrefix rest
-   in VertexTree
-        { tNodes =
-            NE.fromList
-              (map toVertexTreeEntry (nonVertices ++ reverse vertices))
-        , tRest = nodesListToTree <$> NE.nonEmpty rest'
-        , tType = typeForNodes vertices
-        }
+  let (nonVertices, rest) = NE.span isNonVertice nodes
+      verticePrefix = T.dropWhileEnd isDigit <$> getFirstVerticeName rest
+      (vertexNodes, rest') = breakVertices verticePrefix rest
+      vertices = mapMaybe newVertice vertexNodes
+   in case NE.nonEmpty vertices of
+        Nothing -> error "expected at least one Vertex"
+        Just vs ->
+          VertexTree
+            { tNodes = NE.fromList (map toVertexTreeEntry (nonVertices ++ vertexNodes))
+            , tRest = nodesListToTree <$> NE.nonEmpty rest'
+            , tType = mostCommon $ NE.map (determineGroup . vX) vs
+            }
 
 getVertexTree :: Node -> VertexTree
 getVertexTree topNode =
@@ -122,14 +124,61 @@ getVertexTree topNode =
           | otherwise -> nodesListToTree . NE.fromList . V.toList $ ns
         bad -> error $ show bad
 
-updateVertices = undefined
+vertexInCorrectTree :: VertexTreeType -> Vertex -> Bool
+vertexInCorrectTree ttype vertex =
+  ttype == determineGroup (vX vertex)
+
+determineGroup :: Scientific -> VertexTreeType
+determineGroup x
+  | x < -0.09 = RightTree
+  | x < 0.09 = MiddleTree
+  | otherwise = LeftTree
+
+filterVerticesToMove :: VertexTree -> ([Vertex], Maybe VertexTree)
+filterVerticesToMove (VertexTree entries maybeRest ttype) =
+  let (removedHere, keptHere) = F.foldr step ([], []) (toList entries)
+      step entry (remAcc, keepAcc) = case entry of
+        VertexEntry v ->
+          if vertexInCorrectTree ttype v
+            then (remAcc, entry : keepAcc)
+            else (v : remAcc, keepAcc)
+        _ -> (remAcc, entry : keepAcc)
+      (removedRest, newRest) = case maybeRest of
+        Nothing -> ([], Nothing)
+        Just subTree ->
+          let (rs, newSub) = filterVerticesToMove subTree
+           in (rs, newSub)
+      allRemoved = removedHere ++ removedRest
+   in case NE.nonEmpty keptHere of
+        Nothing -> (allRemoved, newRest)
+        Just kept -> (allRemoved, Just (VertexTree kept newRest ttype))
+
+moveVertices :: [Vertex] -> VertexTree -> VertexTree
+moveVertices vsToMove (VertexTree nodes restTree ttype) =
+  let sameTreeType vertex = determineGroup (vX vertex) == ttype
+      (toThisGroup, toOtherGroup) = partition sameTreeType vsToMove
+      vertexEntries = map VertexEntry toThisGroup
+   in VertexTree
+        { tNodes = nodes `NE.appendList` vertexEntries
+        , tRest = moveVertices toOtherGroup <$> restTree
+        , tType = ttype
+        }
+
+updateVertices :: VertexTree -> VertexTree
+updateVertices vertexTree =
+  let (vsToMove, vertexTree') = filterVerticesToMove vertexTree
+   in moveVertices vsToMove (fromJust vertexTree')
 
 verticeQuery :: NP.NodePath
 verticeQuery = fromList [NP.ObjectIndex 0, NP.ObjectKey "nodes"]
 
+possiblyVertice :: VertexTreeEntry -> Maybe Vertex
 possiblyVertice (VertexEntry v) = Just v
 possiblyVertice _ = Nothing
 
+getVertexNamesInTree
+  :: VertexTree
+  -> M.Map (Scientific, Scientific, Scientific) Text
 getVertexNamesInTree vertexTree@(VertexTree {tNodes = vs}) =
   let verticeCordNamePair vertice = ((vX vertice, vY vertice, vZ vertice), vName vertice)
       getVertexNames =
@@ -140,9 +189,10 @@ getVertexNamesInTree vertexTree@(VertexTree {tNodes = vs}) =
           VertexTree {tRest = Nothing} -> M.empty
    in M.union (getVertexNames vs) restNames
 
+transform :: Node -> Node
 transform topNode =
   let vertexTree = getVertexTree topNode
       vertexNames = getVertexNamesInTree vertexTree
       updatedVertexTree = updateVertices vertexTree
       updatedVertexNames = getVertexNamesInTree vertexTree
-   in undefined
+   in error $ show updatedVertexTree

--- a/src/Transformation.hs
+++ b/src/Transformation.hs
@@ -4,6 +4,7 @@ module Transformation (
 
 import Control.Arrow ((&&&))
 import Control.Monad (guard)
+import Core.Node
 import Core.Node (Node (..), isCommentNode)
 import Data.Char (isDigit)
 import Data.Foldable1 (maximumBy)
@@ -24,32 +25,23 @@ import Data.Map qualified as M
 import Data.Text qualified as T
 import Data.Vector qualified as V
 
-data VertexGroupType
-  = LeftGroup
-  | MiddleGroup
-  | RightGroup
+data VertexTreeType
+  = LeftTree
+  | MiddleTree
+  | RightTree
+  | SupportTree
   deriving (Eq, Ord, Show)
 
-type VertexIndex = Int
+data VertexTreeEntry
+  = VertexEntry Vertex
+  | MetaEntry Node
+  | MiscEntry Node
 
-type VertexGroupMap = Map VertexGroupType VertexGroup
-
-type UpdateMap = Map (Scientific, Scientific, Scientific) Text
-
-data VertexBlock = VertexBlock
-  { bPreNodes :: [Node]
-  , bVertices :: Maybe (NonEmpty Vertex)
+data VertexTree = VertexTree
+  { tNodes :: NonEmpty VertexTreeEntry
+  , tRest :: Maybe VertexTree
+  , tType :: VertexTreeType
   }
-  deriving (Show)
-
-data VertexGroup = VertexGroup
-  { gName :: Text
-  , gStartIndex :: VertexIndex
-  , gSize :: VertexIndex
-  , gVertices :: Maybe (NonEmpty Vertex)
-  , gFresh :: Bool
-  }
-  deriving (Show)
 
 data Vertex = Vertex
   { vName :: Text
@@ -59,268 +51,67 @@ data Vertex = Vertex
   }
   deriving (Show)
 
-verticeQuery :: NP.NodePath
-verticeQuery = fromList [NP.ObjectIndex 0, NP.ObjectKey "nodes"]
-
-dropIndex :: Text -> Text
-dropIndex = T.dropWhileEnd isDigit
-
-groupName :: Node -> Maybe Text
-groupName n =
-  case NP.select (NP.ArrayIndex 0) n of
-    Just (String s) -> Just $ dropIndex s
-    _ -> Nothing
-
-newVertex :: Node -> Maybe Vertex
-newVertex (Array n) = f . V.toList $ n
+newVertice (Array ns) = f (V.toList ns)
   where
     f [String name, Number x, Number y, Number z] =
-      guard (isDigit $ T.last name)
-        >> Just (Vertex {vName = name, vX = x, vY = y, vZ = z})
+      Just (Vertex {vName = name, vX = x, vY = y, vZ = z})
     f _ = Nothing
-newVertex _ = Nothing
+newVertice _ = Nothing
 
-determineGroup :: Scientific -> VertexGroupType
-determineGroup x
-  | x < -0.09 = RightGroup
-  | x < 0.09 = MiddleGroup
-  | otherwise = LeftGroup
+isVertice node = isJust (newVertice node)
 
-mostCommon :: NonEmpty VertexGroupType -> VertexGroupType
-mostCommon = NE.head . maximumBy (compare `on` length) . NE.group1 . NE.sort
+isNonVertice node = isNothing (newVertice node)
 
-setGroupAcc :: VertexGroup -> VertexGroupMap -> VertexGroupMap
-setGroupAcc g acc =
-  maybe acc (\vs -> M.insert (typeForVerticeList vs) g acc) (gVertices g)
+hasVerticePrefix verticePrefix node =
+  let verticeName = vName <$> newVertice node
+   in verticeName == Just verticePrefix
+
+getFirstVerticeName (node : _) = vName . fromJust . newVertice $ node
+
+breakVertices verticePrefix = f []
   where
     typeForVerticeList = mostCommon . NE.map (determineGroup . vX)
+    f acc nodes =
+      case nodes of
+        [] -> (acc, [])
+        (node : rest)
+          | hasVerticePrefix verticePrefix node -> (node : acc, nodes)
+          | isNonVertice node -> (node : acc, nodes)
+          | isVertice node ->
+              let (metaNodesNext, currentNodes) = span isNonVertice acc
+               in (currentNodes, metaNodesNext ++ (node : rest))
 
-newVertexGroup :: VertexIndex -> Text -> Vertex -> VertexGroup
-newVertexGroup i name vertice =
-  VertexGroup
-    { gFresh = False
-    , gStartIndex = i
-    , gSize = 1
-    , gName = dropIndex name
-    , gVertices = Just $ NE.singleton vertice
-    }
-
-nodeBelongsToGroup :: VertexGroup -> Node -> Bool
-nodeBelongsToGroup (VertexGroup {gName = name}) n = Just name == groupName n
-
-validateNodeVertices
-  :: ([VertexGroupType], Maybe (NonEmpty Scientific, Text)) -> [Node] -> Bool
-validateNodeVertices state (n : rest) =
-  case state of
-    (groups, Nothing)
-      | isVertex ->
-          validateNodeVertices
-            (groups, Just (NE.singleton xCord, groupName'))
-            rest
-      | otherwise -> validateNodeVertices (groups, Nothing) rest
-    (groups, Just (xs, currentGroupName))
-      | isNeitherVertexNorComment && typeForXCordList xs `elem` groups -> False
-      | isNeitherVertexNorComment ->
-          validateNodeVertices (typeForXCordList xs : groups, Nothing) rest
-      | isCommentNode n ->
-          validateNodeVertices (groups, Just (xs, currentGroupName)) rest
-      | Just currentGroupName == groupName n ->
-          validateNodeVertices (groups, Just (xCord <| xs, currentGroupName)) rest
-      | otherwise -> False
+toVertexTreeEntry node
+  | isJust vertice = VertexEntry (fromJust vertice)
+  | isNothing vertice && isObjectNode node = MetaEntry node
+  | otherwise = MiscEntry node
   where
-    typeForXCordList = mostCommon . NE.map determineGroup
-    xCord = vX (fromJust vertex)
-    groupName' = dropIndex . vName $ fromJust vertex
-    vertex = newVertex n
-    isVertex = isJust vertex
-    isNeitherVertexNorComment = isNothing vertex && not (isCommentNode n)
-validateNodeVertices _ [] = True
+    vertice = newVertice node
 
-nodeToVertexGroupList :: [VertexGroup] -> Int -> Node -> [VertexGroup]
-nodeToVertexGroupList acc i n =
-  case newVertex n of
-    Just vertice ->
-      case acc of
-        [] -> [newVertexGroup i (vName vertice) vertice]
-        (first : accRest) ->
-          if nodeBelongsToGroup first n
-            then
-              first
-                { gSize = i - gStartIndex first
-                , gVertices = (vertice <|) <$> gVertices first
-                }
-                : accRest
-            else newVertexGroup i (vName vertice) vertice : acc
-    Nothing -> acc
+typeForNodes = undefined
 
-getVertexGroups :: NP.NodePath -> Node -> VertexGroupMap
-getVertexGroups q n =
-  case NP.queryNodes q n of
-    Just (Array n')
-      | validateNodeVertices ([], Nothing) (V.toList n') ->
-          foldr setGroupAcc M.empty . V.ifoldl' nodeToVertexGroupList [] $ n'
-      | otherwise ->
-          error
-            "the nodes needs to restructured but restructuring is not implemented"
-    _ -> error "cannot find node with vertices"
+applyIfNonEmpty _ [] = Nothing
+applyIfNonEmpty f xs = f <$> LV.nonEmpty xs
 
-isObjectKeyEqual :: NP.NodeSelector -> Node -> Bool
-isObjectKeyEqual (NP.ObjectKey a) (ObjectKey (String b, _)) = a == b
-isObjectKeyEqual _ _ = False
+nodesListToTree :: NonEmpty Node -> VertexTree
+nodesListToTree nodes =
+  let (nonVertices, rest) = LV.break isNonVertice nodes
+      verticePrefix = getFirstVerticeName rest
+      (vertices, rest') = breakVertices verticePrefix rest
+   in VertexTree
+        { tNodes =
+            LV.fromList
+              (map toVertexTreeEntry (nonVertices ++ reverse vertices))
+        , tRest = applyIfNonEmpty nodesListToTree rest'
+        , tType = typeForNodes vertices
+        }
 
-findAndUpdateTextInNode :: Map Text Text -> NC.NodeCursor -> Node -> Node
-findAndUpdateTextInNode m cursor node =
+getVertexTree :: Node -> Either Node VertexTree
+getVertexTree node =
   case node of
-    Array arr
-      | NC.comparePathAndCursor verticeQuery cursor -> Array arr
-      | otherwise -> Array $ V.imap applyBreadcrumbAndUpdateText arr
-    Object obj -> Object $ V.imap applyBreadcrumbAndUpdateText obj
-    ObjectKey (key, value) ->
-      ObjectKey
-        (key, NC.applyObjCrumb key cursor (findAndUpdateTextInNode m) value)
-    String s -> String $ M.findWithDefault s s m
-    _ -> node
-  where
-    applyBreadcrumbAndUpdateText index =
-      NC.applyCrumb (NC.ArrayIndex index) cursor (findAndUpdateTextInNode m)
+    Array ns
+      | null ns -> Left node
+      | otherwise -> Right . nodesListToTree . LV.fromList . V.toList $ ns
+    bad -> Left bad
 
-newGroupIndex
-  :: [(VertexGroupType, VertexGroup)] -> VertexGroupType -> VertexIndex
-newGroupIndex groups newGroupType =
-  case newGroupType of
-    LeftGroup ->
-      case groups of
-        ((_, g) : _) -> gStartIndex g - 1
-        _ -> error "expected to find MiddleGroup or RightGroup in groups"
-    RightGroup ->
-      case reverse groups of
-        ((_, g) : _) -> gStartIndex g + gSize g + 1
-        _ -> error "expected to find LeftGroup or MiddleGroup in groups"
-    MiddleGroup ->
-      case groups of
-        ((LeftGroup, g) : _) -> gStartIndex g + gSize g + 1
-        [(RightGroup, g)] -> gStartIndex g - 1
-        [_, (RightGroup, g)] -> gStartIndex g - 1
-        _ -> error "expected to find LeftGroup or RightGroup in groups"
-
-groupTypeToChar :: VertexGroupType -> Text
-groupTypeToChar LeftGroup = "l"
-groupTypeToChar MiddleGroup = "m"
-groupTypeToChar RightGroup = "r"
-
-newGroupName :: [(VertexGroupType, VertexGroup)] -> VertexGroupType -> Text
-newGroupName [(_, g)] groupType = gName g <> groupTypeToChar groupType
-newGroupName ((_, g1) : (_, g2) : _) groupType =
-  case on T.commonPrefixes gName g1 g2 of
-    Just (prefix, _, _) -> prefix <> groupTypeToChar groupType
-    _ -> gName g1 <> groupTypeToChar groupType
-newGroupName [] groupType = groupTypeToChar groupType
-
-addVertex :: Vertex -> Maybe (NonEmpty Vertex) -> Maybe (NonEmpty Vertex)
-addVertex vertice Nothing = Just $ NE.singleton vertice
-addVertex vertice (Just vs) = Just $ vertice <| vs
-
-moveVertexToGroup
-  :: VertexGroupType -> Vertex -> VertexGroupMap -> VertexGroupMap
-moveVertexToGroup gType vert gs
-  | gType == destGroup = gs
-  | M.member destGroup gs = M.update addVertexToGroup destGroup gs
-  | otherwise =
-      let currentGroupList = M.toList gs
-          i = newGroupIndex currentGroupList destGroup
-          name = newGroupName currentGroupList destGroup
-          group = newVertexGroup i name vert
-       in M.insert destGroup group {gFresh = True, gSize = 0} gs
-  where
-    destGroup = determineGroup . vX $ vert
-    addVertexToGroup g = Just g {gVertices = addVertex vert $ gVertices g}
-
-rejectVertices :: VertexGroupType -> VertexGroup -> VertexGroup
-rejectVertices t g =
-  g
-    { gVertices =
-        gVertices g >>= NE.nonEmpty . NE.filter ((==) t . determineGroup . vX)
-    }
-
-moveVertices
-  :: VertexGroupType -> VertexGroup -> VertexGroupMap -> VertexGroupMap
-moveVertices gType g gs =
-  M.mapWithKey rejectVertices
-    . foldr (moveVertexToGroup gType) gs
-    . maybe [] NE.toList
-    $ gVertices g
-
-updateVertexName :: Text -> (VertexIndex, Vertex) -> Vertex
-updateVertexName name (index, vertice) =
-  vertice {vName = name <> T.pack (show index)}
-
-updateVertexNames :: VertexGroup -> VertexGroup
-updateVertexNames g =
-  let vertices = NE.sortBy (on compare $ vZ &&& vY) <$> gVertices g
-      indexVertices = NE.zip (NE.fromList [0 ..])
-      updatedVertices =
-        NE.map (updateVertexName $ gName g) . indexVertices <$> vertices
-   in g {gVertices = updatedVertices}
-
-updateVerticesInGroup :: VertexGroupMap -> VertexGroupMap
-updateVerticesInGroup gs =
-  M.map updateVertexNames $ M.foldrWithKey moveVertices gs gs
-
-verticeToNode :: Vertex -> Node
-verticeToNode (Vertex {vName = name, vX = x, vY = y, vZ = z}) =
-  Array $ V.fromList [String name, Number x, Number y, Number z]
-
-newGroupHeader :: VertexGroup -> Vector Node
-newGroupHeader (VertexGroup {gFresh = True}) =
-  V.fromList [SinglelineComment "ny grupp", Object objKey]
-  where
-    objKey = V.singleton $ ObjectKey (String "group", String "new_group")
-newGroupHeader _ = V.empty
-
-succIfNonZero :: Int -> Int
-succIfNonZero 0 = 0
-succIfNonZero i = i + 1
-
-updateNode :: NP.NodePath -> VertexGroup -> Node -> Node
-updateNode (NP.NodePath Empty) g (Array a) =
-  let vertices = gVertices g
-      startIndex =
-        fromMaybe (gStartIndex g) $ V.findIndex (nodeBelongsToGroup g) a
-      endIndex = startIndex + succIfNonZero (gSize g)
-      beginNodes = V.slice 0 startIndex a
-      groupHeader = newGroupHeader g
-      verticeNodes =
-        V.fromList (maybe [] (map verticeToNode . NE.toList) vertices)
-      endNodes = V.slice endIndex (V.length a - endIndex) a
-   in Array $ V.concat [beginNodes, groupHeader, verticeNodes, endNodes]
-updateNode (NP.NodePath ((NP.ArrayIndex i) :<| qrest)) g (Array children) =
-  let updateInNode nodeToUpdate =
-        children // [(i, updateNode (NP.NodePath qrest) g nodeToUpdate)]
-   in Array $ maybe children updateInNode (children !? i)
-updateNode (NP.NodePath ((NP.ObjectIndex i) :<| qrest)) g (Object children) =
-  let updateInNode _ =
-        children // [(i, updateNode (NP.NodePath qrest) g (children ! i))]
-   in Object $ maybe children updateInNode (children !? i)
-updateNode (NP.NodePath (k@(NP.ObjectKey _) :<| qrest)) g (Object children) =
-  let updateInNode i =
-        children // [(i, updateNode (NP.NodePath qrest) g (children ! i))]
-   in Object . maybe children updateInNode $
-        V.findIndex (isObjectKeyEqual k) children
-updateNode query g (ObjectKey (k, v)) = ObjectKey (k, updateNode query g v)
-updateNode _ _ a = a
-
-verticeNameMap :: VertexGroup -> UpdateMap -> UpdateMap
-verticeNameMap g acc =
-  let sortKeys = map (\v -> ((vX v, vY v, vZ v), vName v)) . NE.toList
-      vertices = gVertices g
-   in M.union acc . M.fromList $ maybe [] sortKeys vertices
-
-transform :: Node -> Node
-transform ns =
-  let verticeGroups = getVertexGroups verticeQuery ns
-      verticeNames = M.foldr verticeNameMap M.empty verticeGroups
-      updatedGroups = updateVerticesInGroup verticeGroups
-      updatedVertexNames = M.foldr verticeNameMap M.empty updatedGroups
-      updateMap = M.fromList $ on zip M.elems verticeNames updatedVertexNames
-   in findAndUpdateTextInNode updateMap NC.newCursor $
-        foldr (updateNode verticeQuery) ns updatedGroups
+transform = undefined


### PR DESCRIPTION
This update improves the way jbeam_edit processes meta nodes (such as {"group":"..."}) that interrupt vertex groupings within .jbeam files.  Previously, encountering these meta nodes resulted in an explicit error message indicating unsupported input, preventing further processing.

Key changes:
- Extract all vertices from sections interrupted by meta nodes.
-  Sort vertices within their respective groups while preserving the original order relative to meta nodes. 
- Move and reinsert vertices back into their original nodes, maintaining file structure integrity.
- Enhance logic to gracefully handle meta nodes interrupting vertex lists.

Example of the previous grouping logic being broken by meta nodes:

```
{"group": "group1"}
["fr0", -0.426, -2.084, 0.235]
["fr1", 0.487, -2.072, 0.235]
{"group": "group2"}
["fr2", -0.418, -2.034, 0.300]
```

With this update, jbeam_edit properly handles such cases by treating meta nodes as separators, allowing vertices to be grouped and sorted correctly within their respective groups.