### PR TITLE
New property in JBFL language: padDecimals

### DIFF
--- a/rules.jbfl
+++ b/rules.jbfl
@@ -1,6 +1,6 @@
 .*.nodes[*][*] {
-    PadZeros: false;
     PadAmount: 8;
+    PadDecimals: 3;
 }
 
 .*.flexbodies[*] {

--- a/src/Core/Node.hs
+++ b/src/Core/Node.hs
@@ -1,5 +1,7 @@
 module Core.Node (
   isCommentNode,
+  isNumberNode,
+  isComplexNode,
   Node (..),
 ) where
 
@@ -29,3 +31,13 @@ isCommentNode :: Node -> Bool
 isCommentNode (MultilineComment _) = True
 isCommentNode (SinglelineComment _) = True
 isCommentNode _ = False
+
+isComplexNode :: Node -> Bool
+isComplexNode (Object _) = True
+isComplexNode (Array _) = True
+isComplexNode (ObjectKey (_key, val)) = isComplexNode val
+isComplexNode _ = False
+
+isNumberNode :: Node -> Bool
+isNumberNode (Number _) = True
+isNumberNode _ = False

--- a/src/Formatting/Rules.hs
+++ b/src/Formatting/Rules.hs
@@ -55,7 +55,6 @@ instance Show NodePattern where
 
 data PropertyKey a where
   NoComplexNewLine :: PropertyKey Bool
-  PadZeros :: PropertyKey Bool
   PadAmount :: PropertyKey Int
   PadDecimals :: PropertyKey Int
 
@@ -72,7 +71,6 @@ instance Eq SomeKey where
 
 eqKey :: PropertyKey a -> PropertyKey b -> Maybe (a :~: b)
 eqKey PadAmount PadAmount = Just Refl
-eqKey PadZeros PadZeros = Just Refl
 eqKey NoComplexNewLine NoComplexNewLine = Just Refl
 eqKey PadDecimals PadDecimals = Just Refl
 eqKey _ _ = Nothing
@@ -90,7 +88,6 @@ instance Show SomeProperty where
 
 propertyName :: PropertyKey a -> Text
 propertyName NoComplexNewLine = "NoComplexNewLine"
-propertyName PadZeros = "PadZeros"
 propertyName PadAmount = "PadAmount"
 propertyName PadDecimals = "PadDecimals"
 
@@ -101,7 +98,7 @@ lookupKey :: Text -> [SomeKey] -> Maybe SomeKey
 lookupKey txt = find (\(SomeKey k) -> propertyName k == txt)
 
 boolProperties :: [SomeKey]
-boolProperties = map SomeKey [NoComplexNewLine, PadZeros]
+boolProperties = [SomeKey NoComplexNewLine]
 
 intProperties :: [SomeKey]
 intProperties = map SomeKey [PadAmount, PadDecimals]
@@ -144,16 +141,12 @@ applyDecimalPadding padDecimals node =
 applyPadLogic :: (Node -> Text) -> Rule -> Node -> Text
 applyPadLogic f rs n =
   let padAmount = sum $ lookupProp PadAmount rs
-      padZeros = Just True == lookupProp PadZeros rs
       padDecimals = sum $ lookupProp PadDecimals rs
       decimalPaddedText
         | isNumberNode n = applyDecimalPadding padDecimals (f n)
         | otherwise = f n
    in if not (isComplexNode n)
-        then
-          if padZeros && isNumberNode n
-            then T.justifyRight padAmount '0' decimalPaddedText
-            else T.justifyRight padAmount ' ' decimalPaddedText
+        then T.justifyRight padAmount ' ' decimalPaddedText
         else f n
 
 noComplexNewLine :: RuleSet -> NC.NodeCursor -> Bool

--- a/src/Parsing/DSL.hs
+++ b/src/Parsing/DSL.hs
@@ -71,7 +71,6 @@ propertyParser (SomeKey key) = do
 
 parseValueForKey :: PropertyKey a -> Parser a
 parseValueForKey NoComplexNewLine = parseBool <?> "bool"
-parseValueForKey PadZeros = parseBool <?> "bool"
 parseValueForKey PadAmount = L.decimal <?> "integer"
 parseValueForKey PadDecimals = L.decimal <?> "integer"
 

--- a/src/Parsing/DSL.hs
+++ b/src/Parsing/DSL.hs
@@ -73,6 +73,7 @@ parseValueForKey :: PropertyKey a -> Parser a
 parseValueForKey NoComplexNewLine = parseBool <?> "bool"
 parseValueForKey PadZeros = parseBool <?> "bool"
 parseValueForKey PadAmount = L.decimal <?> "integer"
+parseValueForKey PadDecimals = L.decimal <?> "integer"
 
 keyPropertyPairParser :: Parser (SomeKey, SomeProperty)
 keyPropertyPairParser = do


### PR DESCRIPTION
This adds a JBFL property which lets users pad numbers to have at least a certain number of decimals.

Example:
**PadDecimals value:** 3
**Input:** "10.1"
**Output:** "10.100"