### PR TITLE
Added test for minimal jbeam and improve error reporting

### DIFF
--- a/src/Core/Node.hs
+++ b/src/Core/Node.hs
@@ -25,7 +25,7 @@ data Node
   | SinglelineComment Text
   | MultilineComment Text
   | Null
-  deriving (Eq, Show)
+  deriving (Eq, Read, Show)
 
 isCommentNode :: Node -> Bool
 isCommentNode (MultilineComment _) = True

--- a/test/Parsing/DSLSpec.hs
+++ b/test/Parsing/DSLSpec.hs
@@ -2,7 +2,6 @@ module Parsing.DSLSpec (
   spec,
 ) where
 
-import Control.Monad (forM_)
 import Data.ByteString (ByteString)
 import Data.List (isSuffixOf)
 import Data.String (fromString)
@@ -59,10 +58,9 @@ ruleSetSpecs :: Spec
 ruleSetSpecs = do
   inputFiles <-
     runIO $ filter (isSuffixOf ".jbfl") <$> getDirectoryContents "examples/jbfl"
-  let outputFile f = "examples/ast/jbfl/" ++ takeWhile (/= '.') f ++ ".hs"
-  forM_ inputFiles $ \inFile -> do
-    let outFile = outputFile inFile
-    ruleSetSpec inFile outFile
+  let outputFile inFile = "examples/ast/jbfl/" ++ takeWhile (/= '.') inFile ++ ".hs"
+      testInputFile inFile = ruleSetSpec inFile (outputFile inFile)
+  mapM_ testInputFile inputFiles
 
 expLabels :: [String] -> ET ByteString
 expLabels = foldMap elabel

--- a/tools/dump_ast/Main.hs
+++ b/tools/dump_ast/Main.hs
@@ -36,7 +36,7 @@ dumpJbflAST dir filename = do
   contents <- BL.readFile (dir ++ "/" ++ filename)
   case parseDSL (BL.toStrict contents) of
     Right rs -> dump rs
-    Left _ -> error "error :("
+    Left _ -> error $ "error " ++ filename
   where
     dump contents =
       let outFile = "examples/ast/jbfl/" ++ takeWhile (/= '.') filename ++ ".hs"
@@ -47,7 +47,7 @@ dumpJbeamAST dir filename = do
   contents <- BL.readFile (dir ++ "/" ++ filename)
   case parseNodes (BL.toStrict contents) of
     Right rs -> dump rs
-    Left _ -> error "error :("
+    Left _ -> error $ "error " ++ filename
   where
     dump contents =
       let outFile = "examples/ast/jbeam/" ++ takeWhile (/= '.') filename ++ ".hs"


### PR DESCRIPTION
- Derive Read for Node to support loading expected ASTs from .hs files
- Add golden tests: Automatically test all examples/jbeam/*.jbeam files against expected ASTs in examples/ast/jbeam/*.hs
- Improve parse error reporting: dump_ast now includes the filename in error messages
- Minor cleanup in DSLSpec test discovery logic (functionally unchanged)