### PR TITLE
Add command line options

### DIFF
--- a/README.org
+++ b/README.org
@@ -55,21 +55,21 @@ This will create a file named =rules.jbfl= in your XDG config directory:
 - On **Linux/macOS**: =$HOME/.config/jbeam-edit/rules.jbfl=
 - On **Windows**: =%APPDATA%\jbeam-edit\rules.jbfl=
 
-This configuration will be used automatically when formatting files, unless a local =jbeam-edit.jbfl= file is present in the current working directory.
+This configuration will be used automatically when formatting files, unless a local =.jbeam_edit.jbfl= file is present in the current working directory.
 
 *** Project-Specific Configuration
 
-You can override the global configuration on a per-project basis by placing a =jbeam-edit.jbfl= file in the root of your project.
+You can override the global configuration on a per-project basis by placing a .jbeam_edit.jbfl= file in the root of your project.
 After creating the user configuration with =jbeam-edit -cminimal= or =jbeam-edit -ccomplex=, you can copy that to your project if you want to apply specific rules on a per-project basis.
 
 #+BEGIN_SRC bash
-cp ~/.config/jbeam-edit/rules.jbfl ./jbeam-edit.jbfl
+cp ~/.config/jbeam-edit/rules.jbfl ./.jbeam_edit.jbfl
 #+END_SRC
 
 On Windows:
 
 #+BEGIN_SRC powershell
-copy "%APPDATA%\jbeam-edit\rules.jbfl" .\jbeam-edit.jbfl
+copy "%APPDATA%\jbeam-edit\rules.jbfl" .\.jbeam_edit.jbfl
 #+END_SRC
 
 The presence of this file takes precedence over the global configuration and allows for project-specific formatting preferences.

--- a/README.org
+++ b/README.org
@@ -116,7 +116,7 @@ For now, the project remains a Haskell-based tool, but the idea of a C/C++ port 
 
 *** Prerequisites
 
-- Haskell Compiler: GHC (https://www.haskell.org/ghc/)  
+- Haskell Compiler: GHC (https://www.haskell.org/ghc/)
 - Build Tool: Stack (https://docs.haskellstack.org)
 
 *** Installation
@@ -124,8 +124,8 @@ For now, the project remains a Haskell-based tool, but the idea of a C/C++ port 
 Clone the repository and build the project using your preferred Haskell build tool:
 
 #+BEGIN_SRC bash
-git clone https://github.com/webdevred/jbeam-tool.git  
-cd jbeam-tool  
+git clone https://github.com/webdevred/jbeam-tool.git
+cd jbeam-tool
 stack build
 #+END_SRC
 
@@ -139,11 +139,22 @@ stack exec jbeam-tool -- [options] <input-file>
 
 The tool will:
 
-- Parse the provided jbeam file.  
-- Format it according to the default or user-defined rules.  
+- Parse the provided jbeam file.
+- Format it according to the default or user-defined rules.
 - Automatically sort nodes, rename them sequentially, and update all related references.
+- By default, write the formatted output back to the file and create a backup file named <input-file>.bak.
+- Use the `-i` or `--in-place` option to modify files directly **without** creating a backup.
+
+Example:
+
+#+BEGIN_SRC bash
+jbeam-edit -i example.jbeam
+#+END_SRC
+
+This will update `example.jbeam` in place, skipping the backup creation step.
 
 For full usage details and configuration options, please refer to [[EXPLANATION_OF_SOURCE_CODE.org][EXPLANATION_OF_SOURCE_CODE.org]]
+
 
 *** Contributing
 

--- a/README.org
+++ b/README.org
@@ -3,7 +3,7 @@ A Parser, Formatter, and Editor for jbeam Files
 
 This project is a command-line tool designed to work with jbeam files (the structured, JSON-like format used in BeamNG to define vehicles, physics, and structures). Initially implemented in Haskell as a fast and robust demo, it has grown into a comprehensive utility for manipulating jbeam data.
 
-** Features
+** Features at a glance
 
 *** Complete File Parsing
 - Parses entire =.jbeam= files, including comments.
@@ -18,8 +18,8 @@ This project is a command-line tool designed to work with jbeam files (the struc
 - Sorts and sequentially renames all nodes (e.g., =["bf1", ...]= becomes =["bf0", "bf1", "bf2"]=).
 - Updates all references to renamed nodes throughout the file to prevent inconsistencies.
 
-*** Configurable Formatting Rules — Powered by JBFL
-=jbeam_edit= supports user-defined rule files in JBFL (JBeam Formatting Language), a declarative mini-language for specifying formatting behavior.
+*** Configurable Formatting Rules, Powered by JBFL
+=jbeam-edit= supports user-defined rule files in JBFL (JBeam Formatting Language), a declarative mini-language for specifying formatting behavior.
 
 **** Example rule file (rules.jbfl)
 
@@ -38,6 +38,49 @@ This project is a command-line tool designed to work with jbeam files (the struc
 - Target specific parts of the data tree using wildcard patterns.
 - Control indentation, spacing, padding, and decimal precision.
 - As a maintainer, enforce customized formatting rules to fit your preference.
+
+** Configuration
+
+When using =jbeam-edit= for the first time, you should generate a default formatting configuration file.
+
+Run one of the following:
+
+#+BEGIN_SRC bash
+jbeam-edit -cminimal   # Generates a simple, clean formatting config
+jbeam-edit -ccomplex   # Generates a more detailed and explicit config
+#+END_SRC
+
+This will create a file named =rules.jbfl= in your XDG config directory:
+
+- On **Linux/macOS**: =$HOME/.config/jbeam-edit/rules.jbfl=
+- On **Windows**: =%APPDATA%\jbeam-edit\rules.jbfl=
+
+This configuration will be used automatically when formatting files, unless a local =jbeam-edit.jbfl= file is present in the current working directory.
+
+*** Project-Specific Configuration
+
+You can override the global configuration on a per-project basis by placing a =jbeam-edit.jbfl= file in the root of your project.
+After creating the user configuration with =jbeam-edit -cminimal= or =jbeam-edit -ccomplex=, you can copy that to your project if you want to apply specific rules on a per-project basis.
+
+#+BEGIN_SRC bash
+cp ~/.config/jbeam-edit/rules.jbfl ./jbeam-edit.jbfl
+#+END_SRC
+
+On Windows:
+
+#+BEGIN_SRC powershell
+copy "%APPDATA%\jbeam-edit\rules.jbfl" .\jbeam-edit.jbfl
+#+END_SRC
+
+The presence of this file takes precedence over the global configuration and allows for project-specific formatting preferences.
+
+** Examples
+
+For detailed example files and usage instructions, please see the dedicated examples documentation:
+
+[[examples/README.org][Examples Directory README]]
+
+This contains sample =.jbeam= files and formatting rules to help you explore and test jbeam-edit’s features
 
 ** Planned Features / TODO
 
@@ -80,17 +123,19 @@ For now, the project remains a Haskell-based tool, but the idea of a C/C++ port 
 
 Clone the repository and build the project using your preferred Haskell build tool:
 
+#+BEGIN_SRC bash
 git clone https://github.com/webdevred/jbeam-tool.git  
 cd jbeam-tool  
 stack build
+#+END_SRC
 
 *** Usage
 
 Run the tool from the command line as follows:
 
-#+begin_src 
+#+BEGIN_SRC bash
 stack exec jbeam-tool -- [options] <input-file>
-#+end_src
+#+END_SRC
 
 The tool will:
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -24,9 +24,8 @@ main :: IO ()
 main = do
   args <- getArgs
   opts <- parseOptions args
-  configDir <- getConfigDir
   case opts of
-    Options { optCopyJbflConfig = Just configType } -> copyConfigFile configDir configType
+    Options {optCopyJbflConfig = Just configType} -> copyToConfigDir configType
     _ -> editFile opts
 
 editFile :: Options -> IO ()

--- a/examples/README.org
+++ b/examples/README.org
@@ -1,0 +1,55 @@
+* Examples Directory
+
+This file guides you through example files and formatting rules to help you learn and test jbeam-edit’s features hands-on. It includes example JBeam files and JBFL rule files to explore the tool’s capabilities.
+
+** Example JBeam Files
+
+- =minimal.jbeam=
+  - A simple, clean example JBeam file demonstrating basic parsing and formatting. Running jbeam-edit on this file will:
+    - Parse the entire structure including comments
+    - Format the file with consistent indentation and spacing
+    - Automatically sort and rename nodes sequentially (e.g., "bf1" becomes "bf0", etc.)
+    - Update all references accordingly
+    - Automatically move vertices into their correct groups (e.g., LeftTree, MiddleTree, RightTree) to maintain proper structure
+
+** JBFL Configuration Files
+
+- =minimal.jbfl=
+  Defines a minimal set of formatting rules, focusing on basic indentation and spacing. Ideal for quick, clean formatting without much customization.
+
+- =complex.jbfl=
+  Contains detailed rules demonstrating advanced formatting capabilities such as controlling padding, decimal precision, and line breaks using JBFL patterns.
+
+** How JBFL Affects Formatting
+
+JBFL (JBeam Formatting Language) is a declarative mini-language that lets you specify how different parts of the JBeam file should be formatted:
+
+- Match sections of the data tree with wildcard patterns
+- Control padding amounts, decimal precision, and newline behavior
+- Customize formatting to fit your preferences or project standards
+
+By swapping between the minimal and complex JBFL configs, you can see how formatting behavior changes, making the tool flexible for different workflows.
+
+** Using These Examples
+
+To format an example file with the minimal configuration:
+
+#+BEGIN_SRC bash
+jbeam-edit -cminimal
+stack exec jbeam-edit -- examples/jbeam/minimal.jbeam
+#+END_SRC
+
+To try the complex configuration, generate it first and run:
+
+#+BEGIN_SRC bash
+jbeam-edit -ccomplex
+stack exec jbeam-edit -- examples/jbeam/complex.jbeam
+#+END_SRC
+
+Feel free to modify these examples or create your own to better suit your projects.
+
+These examples provide a practical way to understand and customize how jbeam-edit handles your JBeam files.
+
+For complete documentation and usage, please refer to the root [[file:README.org][README.org]].
+
+There is also [[file:JBFL_DOCS.org][JBFL_DOCS.org]] for detailed information on the JBFL formatting language.

--- a/examples/ast/jbfl/complex.hs
+++ b/examples/ast/jbfl/complex.hs
@@ -6,6 +6,24 @@ RuleSet
                     [ AnyObjectKey
                     , Selector
                         ( ObjectKey "nodes" )
+                    , Selector
+                        ( ArrayIndex 0 )
+                    , AnyArrayIndex
+                    ]
+                )
+            , fromList
+                [
+                    ( SomeKey PadAmount
+                    , SomeProperty PadAmount 0
+                    )
+                ]
+            )
+        ,
+            ( NodePattern
+                ( fromList
+                    [ AnyObjectKey
+                    , Selector
+                        ( ObjectKey "nodes" )
                     , AnyArrayIndex
                     , Selector
                         ( ArrayIndex 0 )

--- a/examples/jbfl/complex.jbfl
+++ b/examples/jbfl/complex.jbfl
@@ -1,35 +1,27 @@
-// Apply default padding and decimal formatting to all node elements
-.*.nodes[*][*] {
-    // Show numbers with exactly 3 decimal places (e.g., 1.000)
-    PadDecimals: 3;
-
-    // Pad numeric values to 6 characters wide for alignment
-    PadAmount: 6;
+// Disable padding for header row (column names)
+.*.nodes[0][*] {
+    PadAmount: 0; // no padding here
+    // This row has string headers, so no numeric formatting needed
 }
 
-// Special padding for the first element in each node list (vertex names)
+/* Default formatting for all numeric node values */
+.*.nodes[*][*] {
+    PadDecimals: 3;  // Show 3 decimal places for uniformity
+    PadAmount: 6;    // Align numeric columns
+}
+
+// Padding for vertex names (first element in nodes Array)
 .*.nodes[*][0] {
-    /*
-      Vertex names can be up to 8 characters long,
-      so we pad them to width 8 for neat column alignment.
-      This improves readability by lining up numeric columns.
-    */
     PadAmount: 8;
+    // Wider for typical vertex IDs
 }
 
 .*.nodes[*] {
-    /*
-      Prevent inserting newlines inside node elements with complex children.
-      Disable complex newlines here to keep nested structures inline.
-      This avoids cluttering the output with unnecessary line breaks,
-      making it easier to scan.
-    */
     NoComplexNewLine: true;
+    // Keep nodes inline for easier reading
 }
 
-// Flexbodies typically contain nested lists representing grouped geometry or materials
-// Keep complex nested content inline rather than breaking into multiple lines
-// This makes output more compact and easier to scan given typical data patterns
+// Flexbodies usually contain nested data structures
 .*.flexbodies[*] {
-    NoComplexNewLine: true;
+    NoComplexNewLine: true; /* compact formatting for flexbodies */
 }

--- a/jbeam-edit.cabal
+++ b/jbeam-edit.cabal
@@ -32,6 +32,7 @@ flag dump-ast
 
 library
   exposed-modules:
+      CommandLineOptions
       Core.Node
       Core.NodeCursor
       Core.NodePath

--- a/src/CommandLineOptions.hs
+++ b/src/CommandLineOptions.hs
@@ -9,13 +9,13 @@ import Paths_jbeam_edit (version)
 import System.Console.GetOpt
 import System.Environment
 import System.Exit
-import System.IO
 
 data Options = Options
   { optInPlace :: Bool
   , optCopyJbflConfig :: Maybe ConfigType
   , optInputFile :: Maybe FilePath
-  } deriving Show
+  }
+  deriving (Show)
 
 startOptions :: Options
 startOptions =
@@ -69,11 +69,12 @@ options =
       ( NoArg
           ( \_ -> do
               prg <- getProgName
-              let header = unlines
-                    [ "Usage:"
-                    , "  " ++ prg ++ " [OPTIONS] [INPUT-FILE]"
-                    , ""
-                    ]
+              let header =
+                    unlines
+                      [ "Usage:"
+                      , "  " ++ prg ++ " [OPTIONS] [INPUT-FILE]"
+                      , ""
+                      ]
               putStrLn (usageInfo header options)
               exitSuccess
           )

--- a/src/CommandLineOptions.hs
+++ b/src/CommandLineOptions.hs
@@ -1,0 +1,82 @@
+module CommandLineOptions (
+  parseOptions,
+  Options (..),
+) where
+
+import Data.Version (showVersion)
+import Formatting.Config (ConfigType (..))
+import Paths_jbeam_edit (version)
+import System.Console.GetOpt
+import System.Environment
+import System.Exit
+import System.IO
+
+data Options = Options
+  { optInPlace :: Bool
+  , optCopyJbflConfig :: Maybe ConfigType
+  , optInputFile :: Maybe FilePath
+  } deriving Show
+
+startOptions :: Options
+startOptions =
+  Options
+    { optInPlace = False
+    , optInputFile = Nothing
+    , optCopyJbflConfig = Nothing
+    }
+
+parseOptions :: [String] -> IO Options
+parseOptions args = do
+  let (actions, nonOptions, _) = getOpt RequireOrder options args
+  opts <- foldl (>>=) (pure startOptions) actions
+  case (optInputFile opts, nonOptions) of
+    (Nothing, filename : _) -> pure $ opts {optInputFile = Just filename}
+    (_, _) -> pure opts
+
+maybeConfigType :: Maybe String -> Maybe ConfigType
+maybeConfigType (Just "complex") = Just ComplexConfig
+maybeConfigType (Just "minimal") = Just MinimalConfig
+maybeConfigType _ = Nothing
+
+options :: [OptDescr (Options -> IO Options)]
+options =
+  [ Option
+      "I"
+      ["in-place"]
+      (NoArg (\opt -> pure opt {optInPlace = True}))
+      "Perform editing in-place"
+  , Option
+      "c"
+      ["install-jbfl-config"]
+      ( OptArg
+          (\config opt -> pure opt {optCopyJbflConfig = maybeConfigType config})
+          "JBFL-CONFIG"
+      )
+      "Copy rules file to config directory"
+  , Option
+      "V"
+      ["version"]
+      ( NoArg
+          ( \_ -> do
+              putStrLn ("Version " <> showVersion version)
+              exitSuccess
+          )
+      )
+      "Print version"
+  , Option
+      "h"
+      ["help"]
+      ( NoArg
+          ( \_ -> do
+              prg <- getProgName
+              let header = unlines
+                    [ "Usage:"
+                    , "  " ++ prg ++ " [OPTIONS] [INPUT-FILE]"
+                    , ""
+                    ]
+              putStrLn (usageInfo header options)
+              exitSuccess
+          )
+      )
+      "Show help"
+  ]

--- a/src/CommandLineOptions.hs
+++ b/src/CommandLineOptions.hs
@@ -41,7 +41,7 @@ maybeConfigType _ = Nothing
 options :: [OptDescr (Options -> IO Options)]
 options =
   [ Option
-      "I"
+      "i"
       ["in-place"]
       (NoArg (\opt -> pure opt {optInPlace = True}))
       "Perform editing in-place"

--- a/src/Formatting/Config.hs
+++ b/src/Formatting/Config.hs
@@ -1,4 +1,4 @@
-module Formatting.Config (readFormattingConfig, getConfigDir, copyConfigFile, ConfigType (..)) where
+module Formatting.Config (readFormattingConfig, copyToConfigDir, ConfigType (..)) where
 
 import Control.Monad (when)
 import Data.ByteString.Lazy as BL
@@ -9,7 +9,7 @@ import IOUtils
 import Parsing.DSL (parseDSL)
 import Paths_jbeam_edit
 import System.Directory
-import System.FilePath ((</>),takeDirectory)
+import System.FilePath (takeDirectory, (</>))
 
 import Data.Text.IO qualified as TIO (putStrLn)
 
@@ -38,6 +38,11 @@ copyConfigFile dest configType = do
   source <- getDataFileName (getJbflSourcePath configType)
   putStrLn ("installing " ++ show configType ++ " config file to " ++ dest)
   copyFile source dest
+
+copyToConfigDir :: ConfigType -> IO ()
+copyToConfigDir configType = do
+  configDir <- getConfigDir
+  copyConfigFile configDir configType
 
 createRuleFileIfDoesNotExist :: FilePath -> IO ()
 createRuleFileIfDoesNotExist configPath = do

--- a/src/Formatting/Config.hs
+++ b/src/Formatting/Config.hs
@@ -1,6 +1,7 @@
-module Formatting.Config (readFormattingConfig) where
+module Formatting.Config (readFormattingConfig, getConfigDir, copyConfigFile, ConfigType (..)) where
 
 import Control.Monad (when)
+import Data.ByteString.Lazy as BL
 import Data.Functor (($>))
 import Formatting.Rules
 import GHC.IO.Exception (IOErrorType (NoSuchThing))
@@ -8,11 +9,8 @@ import IOUtils
 import Parsing.DSL (parseDSL)
 import Paths_jbeam_edit
 import System.Directory
-import System.FilePath ((</>))
+import System.FilePath ((</>),takeDirectory)
 
-import Data.ByteString.Lazy qualified as BL (
-  toStrict,
- )
 import Data.Text.IO qualified as TIO (putStrLn)
 
 data ConfigType = MinimalConfig | ComplexConfig deriving (Show)
@@ -24,25 +22,34 @@ getJbflSourcePath ComplexConfig = "examples" </> "jbfl" </> "complex.jbfl"
 getConfigDir :: IO FilePath
 getConfigDir = getXdgDirectory XdgConfig "jbeam_edit"
 
-copyConfigFile :: FilePath -> ConfigType -> IO ()
-copyConfigFile destDir configType = do
-  createDirectoryIfMissing True destDir
-  source <- getDataFileName (getJbflSourcePath configType)
-  copyFile source (destDir </> "rules.jbfl")
+getConfigPath :: FilePath -> IO FilePath
+getConfigPath userConfigDir = do
+  projectConfigPath <- fmap (</> ".jbeam_edit.jbfl") getCurrentDirectory
+  projectConfigExists <- doesFileExist projectConfigPath
+  if projectConfigExists
+    then
+      pure projectConfigPath
+    else
+      pure $ userConfigDir </> "rules.jbfl"
 
-appendRuleFilename :: FilePath -> FilePath
-appendRuleFilename configDir = configDir </> "rules.jbfl"
+copyConfigFile :: FilePath -> ConfigType -> IO ()
+copyConfigFile dest configType = do
+  createDirectoryIfMissing True (takeDirectory dest)
+  source <- getDataFileName (getJbflSourcePath configType)
+  putStrLn ("installing " ++ show configType ++ " config file to " ++ dest)
+  copyFile source dest
 
 createRuleFileIfDoesNotExist :: FilePath -> IO ()
-createRuleFileIfDoesNotExist configDir =
-  doesFileExist (appendRuleFilename configDir)
-    >>= (`when` copyConfigFile configDir MinimalConfig) . not
+createRuleFileIfDoesNotExist configPath = do
+  doesFileExist configPath
+    >>= (`when` copyConfigFile configPath MinimalConfig) . not
 
 readFormattingConfig :: IO RuleSet
 readFormattingConfig = do
   configDir <- getConfigDir
-  createRuleFileIfDoesNotExist configDir
-  contents <- tryReadFile [NoSuchThing] (appendRuleFilename configDir)
+  createRuleFileIfDoesNotExist (configDir </> "rules.jbfl")
+  configPath <- getConfigPath configDir
+  contents <- tryReadFile [NoSuchThing] configPath
   case contents >>= parseDSL . BL.toStrict of
     Right rs -> pure rs
     Left err -> TIO.putStrLn err $> newRuleSet

--- a/tools/dump_ast/Main.hs
+++ b/tools/dump_ast/Main.hs
@@ -7,7 +7,7 @@ import Parsing.DSL (parseDSL)
 import Parsing.Jbeam (parseNodes)
 import System.Directory (getDirectoryContents)
 import System.FilePath ((</>))
-import Text.Pretty.Simple(pStringOpt, defaultOutputOptionsNoColor)
+import Text.Pretty.Simple (defaultOutputOptionsNoColor, pStringOpt)
 
 import Data.ByteString.Lazy qualified as BL (
   readFile,

--- a/tools/dump_ast/Main.hs
+++ b/tools/dump_ast/Main.hs
@@ -6,7 +6,8 @@ import Data.List (isSuffixOf)
 import Parsing.DSL (parseDSL)
 import Parsing.Jbeam (parseNodes)
 import System.Directory (getDirectoryContents)
-import Text.Pretty.Simple
+import System.FilePath ((</>))
+import Text.Pretty.Simple(pStringOpt, defaultOutputOptionsNoColor)
 
 import Data.ByteString.Lazy qualified as BL (
   readFile,
@@ -16,8 +17,8 @@ import Data.Text.Lazy.IO qualified as TLIO (writeFile)
 
 main :: IO ()
 main =
-  let jbflInputDir = "examples/jbfl"
-      jbeamInputDir = "examples/jbeam"
+  let jbflInputDir = "examples" </> "jbfl"
+      jbeamInputDir = "examples" </> "jbeam"
    in do
         jbeamFiles <-
           filter (isSuffixOf ".jbeam") <$> getDirectoryContents jbeamInputDir
@@ -31,24 +32,27 @@ saveDump outFile contents =
    in putStrLn ("creating " ++ outFile)
         >> TLIO.writeFile outFile formatted
 
+astDir :: FilePath
+astDir = "examples" </> "ast"
+
 dumpJbflAST :: String -> String -> IO ()
 dumpJbflAST dir filename = do
-  contents <- BL.readFile (dir ++ "/" ++ filename)
+  contents <- BL.readFile (dir </> filename)
   case parseDSL (BL.toStrict contents) of
     Right rs -> dump rs
     Left _ -> error $ "error " ++ filename
   where
     dump contents =
-      let outFile = "examples/ast/jbfl/" ++ takeWhile (/= '.') filename ++ ".hs"
+      let outFile = astDir </> "jbfl" </> takeWhile (/= '.') filename ++ ".hs"
        in saveDump outFile contents
 
 dumpJbeamAST :: String -> String -> IO ()
 dumpJbeamAST dir filename = do
-  contents <- BL.readFile (dir ++ "/" ++ filename)
+  contents <- BL.readFile (dir </> filename)
   case parseNodes (BL.toStrict contents) of
     Right rs -> dump rs
     Left _ -> error $ "error " ++ filename
   where
     dump contents =
-      let outFile = "examples/ast/jbeam/" ++ takeWhile (/= '.') filename ++ ".hs"
+      let outFile = astDir </> "jbeam" </> takeWhile (/= '.') filename ++ ".hs"
        in saveDump outFile contents


### PR DESCRIPTION
- Use System.FilePath.(</>) to build platform-agnostic paths
- Improve comments and structure in examples/jbfl/complex.jbfl:
  - Demonstrate flexible comment placement
  - Enhance readability for users and maintainers
- Ensure AST dumps go to consistent locations: examples/ast/{jbfl|jbeam}/{filename}.hs
- Rework README.org:
  - Add new "Configuration" section explaining how to generate and use formatting config files
  - Detail project-specific configuration via jbeam-edit.jbfl
  - Add "Examples" section with reference to examples/README.org