### PR TITLE
Add per-directory .dir-locals.el for Haskell REPL targets in Emacs

### DIFF
--- a/test/.dir-locals.el
+++ b/test/.dir-locals.el
@@ -1,0 +1,4 @@
+((haskell-mode
+  . ((haskell-process-args-cabal-repl . ("jbeam-edit:test:jbeam-edit-test")))))
+
+

--- a/tools/dump_ast/.dir-locals.el
+++ b/tools/dump_ast/.dir-locals.el
@@ -1,0 +1,4 @@
+((haskell-mode
+  . ((haskell-process-args-cabal-repl . ("jbeam-edit:exe:jbeam-edit-dump-ast" "-f" "dump-ast")))))
+
+


### PR DESCRIPTION
- Added test/.dir-locals.el to set haskell-process-args-cabal-repl for test suite
- Added tools/dump_ast/.dir-locals.el to set args for dump-ast executable with -f dump-ast flag