### PR TITLE
Safe extending of haskell-process-args-cabal-repl in .dir-locals.el

### DIFF
--- a/test/.dir-locals.el
+++ b/test/.dir-locals.el
@@ -1,4 +1,3 @@
 ((haskell-mode
-  . ((haskell-process-args-cabal-repl . ("jbeam-edit:test:jbeam-edit-test")))))
-
-
+  . ((eval . (setq-local haskell-process-args-cabal-repl
+                     (append '("jbeam-edit:test:jbeam-edit-test") haskell-process-args-cabal-repl))))))

--- a/tools/dump_ast/.dir-locals.el
+++ b/tools/dump_ast/.dir-locals.el
@@ -1,4 +1,3 @@
 ((haskell-mode
-  . ((haskell-process-args-cabal-repl . ("jbeam-edit:exe:jbeam-edit-dump-ast" "-f" "dump-ast")))))
-
-
+  . ((eval . (setq-local haskell-process-args-cabal-repl
+                     (append '("jbeam-edit:exe:jbeam-edit-dump-ast" "-f" "dump-ast") haskell-process-args-cabal-repl))))))


### PR DESCRIPTION
- Update .dir-locals.el to extend haskell-process-args-cabal-repl using setq-local and append
- This requires a corresponding update in dotfiles to mark this pattern as a safe local variable expression
- See dotfiles commit https://github.com/webdevred/dotfiles/commit/86b84492cc7cf927b0608589646ee3515da35442
- This allows flexible per-project REPL argument customization without Emacs safety warnings