### PR TITLE
Add GHC version matrix (9.4.7 and 9.6.6) and split workflows for lint, Ubuntu, and Windows build

### DIFF
--- a/.github/workflows/build-and-test-ubuntu.yaml
+++ b/.github/workflows/build-and-test-ubuntu.yaml
@@ -1,4 +1,4 @@
-name: Haskell Stack CI
+name: Build and test on Ubuntu
 
 on:
   push:
@@ -6,29 +6,8 @@ on:
   pull_request:
 
 jobs:
-  lint-and-format:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Set up HLint
-        uses: haskell-actions/hlint-setup@v2
-        with:
-          version: latest
-      - name: Run hlint
-        uses: haskell-actions/hlint-run@v2.4.10
-        with:
-          fail-on: warning
-      - name: Run fourmolu
-        uses: haskell-actions/run-fourmolu@v11
-        with:
-          pattern: |
-            **/*.hs
-            !examples/ast/*/*.hs
-          version: latest
   build-with-stack:
     runs-on: ubuntu-latest
-    needs: lint-and-format
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -73,7 +52,6 @@ jobs:
         run: stack test --fast
   build-with-cabal:
     runs-on: ubuntu-latest
-    needs: lint-and-format
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -98,29 +76,3 @@ jobs:
         run: cabal build --ghc-options="-Werror"
       - name: Run tests
         run: cabal test --test-show-details=direct
-  build-with-stack-windows:
-    runs-on: windows-latest
-    needs: lint-and-format
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Cache Stack and binaries
-        uses: actions/cache@v4.2.3
-        with:
-          path: |
-            ${{ env.LOCALAPPDATA }}\Programs\stack
-            ${{ env.APPDATA }}\stack
-            .stack-work
-          key: >-
-            ${{ runner.os }}-stack-${{ hashFiles(
-              '**/stack.yaml.lock',
-              '**/package.yaml'
-            ) }}
-      - name: Set up GHC with Stack
-        run: stack setup
-      - name: Build project
-        run: >
-          stack build --fast --hpack-force --lock-file=error-on-write
-          --ghc-options="-Werror"
-      - name: Run tests
-        run: stack test --fast

--- a/.github/workflows/build-and-test-ubuntu.yaml
+++ b/.github/workflows/build-and-test-ubuntu.yaml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc: [8.8.4, 9.4.7, 9.6.6]
+        ghc: [9.2.7, 9.4.7, 9.6.6]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/build-and-test-ubuntu.yaml
+++ b/.github/workflows/build-and-test-ubuntu.yaml
@@ -52,27 +52,31 @@ jobs:
         run: stack test --fast
   build-with-cabal:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ghc: [8.8.4, 9.4.7, 9.6.6]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Cache GHC, Cabal, and build artifacts
+      - name: Cache GHC, Cabal store, and build artifacts
         uses: actions/cache@v4.2.3
         with:
           path: |
             ~/.ghcup
-            ~/.cabal
+            ~/.cabal/store
             dist-newstyle
           key: >-
-            ${{ runner.os }}-cabal-ghc966-${{ hashFiles(
-              '**/package.yaml'
-            ) }}
-      - name: Set up GHC and Cabal (GHC 9.6.6)
+            ${{ runner.os }}-ghc-${{ matrix.ghc }}-store-${{ hashFiles('**/*.cabal',
+            '**/package.yaml', 'cabal.project') }}
+          restore-keys: |
+            ${{ runner.os }}-ghc-${{ matrix.ghc }}-store-
+      - name: Set up GHC ${{ matrix.ghc }} and Cabal
         uses: haskell-actions/setup@v2.8.0
         with:
-          ghc-version: 9.6.6
+          ghc-version: ${{ matrix.ghc }}
           cabal-version: latest
           cabal-update: true
-      - name: Build project
+      - name: Build project (GHC ${{ matrix.ghc }})
         run: cabal build --ghc-options="-Werror"
-      - name: Run tests
+      - name: Run tests (GHC ${{ matrix.ghc }})
         run: cabal test --test-show-details=direct

--- a/.github/workflows/build-and-test-ubuntu.yaml
+++ b/.github/workflows/build-and-test-ubuntu.yaml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc: [9.2.7, 9.4.7, 9.6.6]
+        ghc: [9.4.7, 9.6.6]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/build-and-test-windows.yaml
+++ b/.github/workflows/build-and-test-windows.yaml
@@ -1,0 +1,33 @@
+name: Build and test on Windows
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  build-with-stack-windows:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Cache Stack and binaries
+        uses: actions/cache@v4.2.3
+        with:
+          path: |
+            ${{ env.LOCALAPPDATA }}\Programs\stack
+            ${{ env.APPDATA }}\stack
+            .stack-work
+          key: >-
+            ${{ runner.os }}-stack-${{ hashFiles(
+              '**/stack.yaml.lock',
+              '**/package.yaml'
+            ) }}
+      - name: Set up GHC with Stack
+        run: stack setup
+      - name: Build project
+        run: >
+          stack build --fast --hpack-force --lock-file=error-on-write
+          --ghc-options="-Werror"
+      - name: Run tests
+        run: stack test --fast

--- a/.github/workflows/lint-and-format.yaml
+++ b/.github/workflows/lint-and-format.yaml
@@ -1,0 +1,28 @@
+name: Lint and format Haskell code
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  lint-and-format:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up HLint
+        uses: haskell-actions/hlint-setup@v2
+        with:
+          version: latest
+      - name: Run hlint
+        uses: haskell-actions/hlint-run@v2.4.10
+        with:
+          fail-on: warning
+      - name: Run fourmolu
+        uses: haskell-actions/run-fourmolu@v11
+        with:
+          pattern: |
+            **/*.hs
+            !examples/ast/*/*.hs
+          version: latest

--- a/jbeam-edit.cabal
+++ b/jbeam-edit.cabal
@@ -65,7 +65,7 @@ library
     , foldable1-classes-compat
     , megaparsec
     , scientific
-    , text
+    , text >=2.0
     , vector
   default-language: Haskell2010
 
@@ -91,7 +91,7 @@ executable jbeam-edit
     , jbeam-edit
     , megaparsec
     , scientific
-    , text
+    , text >=2.0
     , vector
   default-language: Haskell2010
 
@@ -118,7 +118,7 @@ executable jbeam-edit-dump-ast
     , megaparsec
     , pretty-simple
     , scientific
-    , text
+    , text >=2.0
     , vector
   default-language: Haskell2010
   if flag(dump-ast)
@@ -155,7 +155,7 @@ test-suite jbeam-edit-test
     , jbeam-edit
     , megaparsec
     , scientific
-    , text
+    , text >=2.0
     , vector
   build-tool-depends:
       hspec-discover:hspec-discover

--- a/package.yaml
+++ b/package.yaml
@@ -23,10 +23,9 @@ dependencies:
   - base >= 4.7 && < 5
   - bytestring
   - vector
-  - text
+  - text >= 2.0
   - containers
   - megaparsec
-  - text
   - scientific
   - foldable1-classes-compat
   - directory


### PR DESCRIPTION
Introduced a build matrix for build-with-cabal to test against GHC versions 9.4.7, and 9.6.6, ensuring compatibility across a broad range of compilers.

Split the original monolithic workflow into three separate workflows for better clarity and maintainability:
- lint-and-format.yaml runs HLint and Fourmolu checks
- build-and-test-ubuntu.yaml handles Ubuntu stack and cabal builds and tests
- build-and-test-windows.yaml runs Stack builds and tests on Windows