### PR TITLE
add job to fail on overly lax dependency bounds

### DIFF
--- a/.github/workflows/build-and-test-ubuntu.yaml
+++ b/.github/workflows/build-and-test-ubuntu.yaml
@@ -80,3 +80,33 @@ jobs:
         run: cabal build --ghc-options="-Werror"
       - name: Run tests (GHC ${{ matrix.ghc }})
         run: cabal test --test-show-details=direct
+  build-on-latest:
+    name: Build-and-and-test-with-ghc-latest
+    needs: build-with-cabal
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Cache GHC, Cabal store, and build artifacts
+        uses: actions/cache@v4.2.3
+        with:
+          path: |
+            ~/.ghcup
+            ~/.cabal/store
+            dist-newstyle
+          key: ${{ runner.os }}-ghc-latest-store-${{ hashFiles('**/*.cabal','**/package.yaml','cabal.project')
+            }}
+          restore-keys: |
+            ${{ runner.os }}-ghc-latest-store-
+      - name: Set up GHC latest and Cabal
+        uses: haskell-actions/setup@v2.8.0
+        with:
+          ghc-version: latest
+          cabal-version: latest
+          cabal-update: true
+      - name: Configure with dump-ast flag
+        run: cabal configure --enable-test --allow-newer=base --flags=dump-ast
+      - name: Build
+        run: cabal build
+      - name: Run tests
+        run: cabal test --test-show-details=direct

--- a/.github/workflows/build-and-test-ubuntu.yaml
+++ b/.github/workflows/build-and-test-ubuntu.yaml
@@ -17,6 +17,7 @@ jobs:
           path: |
             ~/.ghcup
             ~/.stack
+            ~/.ghc
             .stack-work
           key: >-
             ${{ runner.os }}-stack-${{ hashFiles(
@@ -63,19 +64,21 @@ jobs:
         with:
           path: |
             ~/.ghcup
+            ~/.ghc
             ~/.cabal/store
             dist-newstyle
-          key: >-
-            ${{ runner.os }}-ghc-${{ matrix.ghc }}-store-${{ hashFiles('**/*.cabal',
-            '**/package.yaml', 'cabal.project') }}
+          key: ${{ runner.os }}-cabal-${{ matrix.ghc }}-${{ hashFiles('**/package.yaml')
+            }}
           restore-keys: |
-            ${{ runner.os }}-ghc-${{ matrix.ghc }}-store-
+            ${{ runner.os }}-cabal-${{ matrix.ghc }}-
+            ${{ runner.os }}-cabal-
       - name: Set up GHC ${{ matrix.ghc }} and Cabal
         uses: haskell-actions/setup@v2.8.0
         with:
           ghc-version: ${{ matrix.ghc }}
           cabal-version: latest
           cabal-update: true
+      - run: cabal configure --enable-tests
       - name: Build project (GHC ${{ matrix.ghc }})
         run: cabal build --ghc-options="-Werror"
       - name: Run tests (GHC ${{ matrix.ghc }})
@@ -92,12 +95,13 @@ jobs:
         with:
           path: |
             ~/.ghcup
+            ~/.ghc
             ~/.cabal/store
             dist-newstyle
-          key: ${{ runner.os }}-ghc-latest-store-${{ hashFiles('**/*.cabal','**/package.yaml','cabal.project')
-            }}
+          key: ${{ runner.os }}-cabal-latest-store-${{ hashFiles('**/package.yaml')}}
           restore-keys: |
-            ${{ runner.os }}-ghc-latest-store-
+            ${{ runner.os }}-cabal-latest-store-
+            ${{ runner.os }}-cabal-
       - name: Set up GHC latest and Cabal
         uses: haskell-actions/setup@v2.8.0
         with:

--- a/.github/workflows/build-and-test-windows.yaml
+++ b/.github/workflows/build-and-test-windows.yaml
@@ -11,18 +11,16 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Cache Stack and binaries
+      - name: Cache Stack state and GHC install
         uses: actions/cache@v4.2.3
         with:
           path: |
-            ${{ env.LOCALAPPDATA }}\Programs\stack
-            ${{ env.APPDATA }}\stack
+            ~\AppData\Local\Programs\stack
+            ~\AppData\Roaming\stack
             .stack-work
-          key: >-
-            ${{ runner.os }}-stack-${{ hashFiles(
-              '**/stack.yaml.lock',
-              '**/package.yaml'
-            ) }}
+          key: ${{ runner.os }}-stack-ghc-${{ hashFiles('stack.yaml.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-stack-ghc-
       - name: Set up GHC with Stack
         run: stack setup
       - name: Build project

--- a/.github/workflows/build-and-test-windows.yaml
+++ b/.github/workflows/build-and-test-windows.yaml
@@ -18,7 +18,7 @@ jobs:
             ~\AppData\Local\Programs\stack
             ~\AppData\Roaming\stack
             .stack-work
-          key: ${{ runner.os }}-stack-ghc-${{ hashFiles('stack.yaml.lock') }}
+          key: ${{ runner.os }}-stack-${{ hashFiles('stack.yaml.lock') }}
           restore-keys: |
             ${{ runner.os }}-stack-ghc-
       - name: Set up GHC with Stack


### PR DESCRIPTION
Adds a CI job that builds and tests the project using the latest GHC with --allow-newer=base enabled. This helps detect overly lax version bounds by surfacing breakages caused by newer upstream versions. Failures in this job indicate upper bounds should be tightened.

The job also enables the `dump-ast` flag to include internal tooling in the build, helping ensure all parts of the codebase remain compatible with future versions of dependencies.