### PR TITLE
Improve GitHub Actions workflows: add job names, refine caching, and enhance Cabal matrix

### DIFF
--- a/.github/workflows/build-and-test-ubuntu.yaml
+++ b/.github/workflows/build-and-test-ubuntu.yaml
@@ -79,6 +79,10 @@ jobs:
           ghc-version: ${{ matrix.ghc }}
           cabal-version: latest
           cabal-update: true
+      - name: Log GHC and Cabal outputs
+        run: |
+          echo "GHC Version: ${{ steps.setup-ghc.outputs.ghc-version }}"
+          echo "Cabal Store Path: ${{ steps.setup-ghc.outputs.cabal-store }}"
       - name: Cache GHC, Cabal store, and build artifacts
         uses: actions/cache@v4.2.3
         with:

--- a/.github/workflows/build-and-test-ubuntu.yaml
+++ b/.github/workflows/build-and-test-ubuntu.yaml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build-with-stack:
+    name: Build and test with Stack
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -24,13 +25,13 @@ jobs:
             }}-${{
               hashFiles('**/package.yaml')
             }}
-          restore-keys: |
+          restore-keys: |-
             ${{ runner.os }}-stack-${{ hashFiles('**/stack.yaml.lock') }}-
             ${{ runner.os }}-stack-
       - name: Set up GHC with Stack
         run: stack setup
       - name: Build project
-        run: >
+        run: >-
           stack build --fast --hpack-force --lock-file=error-on-write
           --ghc-options="-Werror"
       - name: Check that .cabal file has not changed except hpack comment

--- a/.github/workflows/build-and-test-ubuntu.yaml
+++ b/.github/workflows/build-and-test-ubuntu.yaml
@@ -15,16 +15,17 @@ jobs:
         uses: actions/cache@v4.2.3
         with:
           path: |
-            ~/.ghcup
             ~/.stack
             ~/.ghc
             .stack-work
           key: >-
-            ${{ runner.os }}-stack-${{ hashFiles(
-              '**/stack.yaml.lock',
-              '**/package.yaml'
-            ) }}
+            ${{ runner.os }}-stack-${{
+              hashFiles('**/stack.yaml.lock')
+            }}-${{
+              hashFiles('**/package.yaml')
+            }}
           restore-keys: |
+            ${{ runner.os }}-stack-${{ hashFiles('**/stack.yaml.lock') }}-
             ${{ runner.os }}-stack-
       - name: Set up GHC with Stack
         run: stack setup

--- a/.github/workflows/build-and-test-ubuntu.yaml
+++ b/.github/workflows/build-and-test-ubuntu.yaml
@@ -54,67 +54,52 @@ jobs:
       - name: Run tests
         run: stack test --fast
   build-with-cabal:
+    # Cabal matrix build:
+    # This job builds and tests the project using multiple GHC versions.
+    # - Ensures compatibility with stable compiler versions (e.g. 9.4.7, 9.6.6).
+    # - Tests with 'latest' GHC to catch breaking changes early.
+    # - Uses '--allow-newer=base' with 'latest' to relax bounds for future compatibility.
+    # - Enables the 'dump-ast' flag to ensure internal tooling builds correctly.
+    name: Build and test with Cabal (GHC ${{ matrix.ghc }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc: [9.4.7, 9.6.6]
+        ghc: [9.4.7, 9.6.6, latest]
+    env:
+      MATRIX_GHC: ${{ matrix.ghc }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Cache GHC, Cabal store, and build artifacts
-        uses: actions/cache@v4.2.3
-        with:
-          path: |
-            ~/.ghcup
-            ~/.ghc
-            ~/.cabal/store
-            dist-newstyle
-          key: >-
-            ${{ runner.os }}-cabal-${{ matrix.ghc }}-${{
-              hashFiles('**/package.yaml')
-            }}
-          restore-keys: |
-            ${{ runner.os }}-cabal-${{ matrix.ghc }}-
-            ${{ runner.os }}-cabal-
       - name: Set up GHC ${{ matrix.ghc }} and Cabal
+        id: setup-ghc
         uses: haskell-actions/setup@v2.8.0
         with:
           ghc-version: ${{ matrix.ghc }}
           cabal-version: latest
           cabal-update: true
-      - run: cabal configure --enable-tests
-      - name: Build project (GHC ${{ matrix.ghc }})
-        run: cabal build --ghc-options="-Werror"
-      - name: Run tests (GHC ${{ matrix.ghc }})
-        run: cabal test --test-show-details=direct
-  build-on-latest:
-    name: Build-and-and-test-with-ghc-latest
-    needs: build-with-cabal
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
       - name: Cache GHC, Cabal store, and build artifacts
         uses: actions/cache@v4.2.3
         with:
           path: |
-            ~/.ghcup
             ~/.ghc
             ~/.cabal/store
             dist-newstyle
-          key: ${{ runner.os }}-cabal-latest-store-${{ hashFiles('**/package.yaml')}}
+          key: >-
+            ${{ runner.os }}-cabal-${{
+              steps.setup-ghc.outputs.ghc-version
+            }}-${{
+              hashFiles('**/package.yaml')
+            }}
           restore-keys: |
-            ${{ runner.os }}-cabal-latest-store-
-            ${{ runner.os }}-cabal-
-      - name: Set up GHC latest and Cabal
-        uses: haskell-actions/setup@v2.8.0
-        with:
-          ghc-version: latest
-          cabal-version: latest
-          cabal-update: true
-      - name: Configure with dump-ast flag
-        run: cabal configure --enable-test --allow-newer=base --flags=dump-ast
-      - name: Build
+            ${{ runner.os }}-cabal-${{ steps.setup-ghc.outputs.ghc-version }}-
+      - name: Configure project
+        run: |
+          FLAGS=""
+          if [ "${MATRIX_GHC}" = "latest" ]; then
+            FLAGS="--allow-newer=base"
+          fi
+          cabal configure --enable-tests --flags=dump-ast $FLAGS --ghc-options="-Werror"
+      - name: Build project (GHC ${{ steps.setup-ghc.outputs.ghc-version }})
         run: cabal build
-      - name: Run tests
+      - name: Run tests (GHC ${{ steps.setup-ghc.outputs.ghc-version }})
         run: cabal test --test-show-details=direct

--- a/.github/workflows/build-and-test-windows.yaml
+++ b/.github/workflows/build-and-test-windows.yaml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build-with-stack-windows:
+    name: Build and test with Stack
     runs-on: windows-latest
     steps:
       - name: Checkout code
@@ -24,13 +25,13 @@ jobs:
             }}-${{
               hashFiles('**/package.yaml')
             }}
-          restore-keys: |
+          restore-keys: |-
             ${{ runner.os }}-stack-${{ hashFiles('**/stack.yaml.lock') }}-
             ${{ runner.os }}-stack-
       - name: Set up GHC with Stack
         run: stack setup
       - name: Build project
-        run: >
+        run: >-
           stack build --fast --hpack-force --lock-file=error-on-write
           --ghc-options="-Werror"
       - name: Run tests

--- a/.github/workflows/build-and-test-windows.yaml
+++ b/.github/workflows/build-and-test-windows.yaml
@@ -19,11 +19,13 @@ jobs:
             ~\AppData\Roaming\stack
             .stack-work
           key: >-
-            ${{ runner.os }}-stack-${{ hashFiles(
-              '**/stack.yaml.lock',
-              '**/package.yaml'
-            )}}
+            ${{ runner.os }}-stack-${{
+              hashFiles('**/stack.yaml.lock')
+            }}-${{
+              hashFiles('**/package.yaml')
+            }}
           restore-keys: |
+            ${{ runner.os }}-stack-${{ hashFiles('**/stack.yaml.lock') }}-
             ${{ runner.os }}-stack-
       - name: Set up GHC with Stack
         run: stack setup

--- a/.github/workflows/build-and-test-windows.yaml
+++ b/.github/workflows/build-and-test-windows.yaml
@@ -49,6 +49,10 @@ jobs:
           ghc-version: latest
           cabal-version: latest
           cabal-update: true
+      - name: Log GHC and Cabal outputs
+        run: |
+          echo "GHC Version: ${{ steps.setup-ghc.outputs.ghc-version }}"
+          echo "Cabal Store Path: ${{ steps.setup-ghc.outputs.cabal-store }}"
       - name: Cache GHC, Cabal store, and build artifacts
         uses: actions/cache@v4.2.3
         with:

--- a/.github/workflows/build-and-test-windows.yaml
+++ b/.github/workflows/build-and-test-windows.yaml
@@ -33,3 +33,38 @@ jobs:
           --ghc-options="-Werror"
       - name: Run tests
         run: stack test --fast
+  build-with-cabal-windows:
+    name: Build and test with Cabal (GHC latest, future-proof)
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up GHC latest and Cabal
+        id: setup-ghc
+        uses: haskell-actions/setup@v2.8.0
+        with:
+          ghc-version: latest
+          cabal-version: latest
+          cabal-update: true
+      - name: Cache GHC, Cabal store, and build artifacts
+        uses: actions/cache@v4.2.3
+        with:
+          path: |
+            dist-newstyle
+            ${{ steps.setup-ghc.outputs.cabal-store }}
+          key: >-
+            ${{ runner.os }}-cabal-${{
+               steps.setup-ghc.outputs.ghc-version
+            }}-${{
+              hashFiles('**/package.yaml')
+            }}
+          restore-keys: |
+            ${{ runner.os }}-cabal-${{ steps.setup-ghc.outputs.ghc-version }}-
+      - name: Configure project
+        shell: pwsh
+        run: |
+          cabal configure --enable-tests --flags=dump-ast --allow-newer=base --ghc-options="-Werror"
+      - name: Build project (GHC latest)
+        run: cabal build
+      - name: Run tests (GHC latest)
+        run: cabal test --test-show-details=direct

--- a/.github/workflows/lint-and-format.yaml
+++ b/.github/workflows/lint-and-format.yaml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   lint-and-format:
+    name: Lint and format
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
This PR improves CI workflows for building and testing the project across platforms and GHC versions. Key changes include:

- Improved job naming: All jobs now have clear name fields for better visibility in the Actions UI.
- Refined cache keys: Separate hashes for stack.yaml.lock and package.yaml improve cache hit accuracy.
- Unified and clarified Cabal matrix job:
- Tests with multiple GHC versions (9.4.7, 9.6.6, and latest) on Ubuntu.
- Uses --allow-newer=base with latest to catch future incompatibilities early.
- Enables the dump-ast flag to ensure internal tooling builds correctly (should we consider skipping validating this builds?) 
- Includes in-code comments explaining these decisions.
- New Windows Cabal job: Adds build-with-cabal-windows, testing with the latest GHC and Cabal on Windows to future-proof the build pipeline across OSes.
- Cosmetic improvements: YAML formatting, consistent run: >-, and removal of redundant paths in cache (e.g., ~/.ghcup).

Together, these changes strengthen cross-platform support, cache efficiency, and long-term maintainability of the Haskell CI configuration.