### PR TITLE
Add Windows build-and-release workflow with Inno Setup installer

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -137,6 +137,7 @@ jobs:
         uses: softprops/action-gh-release@v2.3.2
         with:
           tag_name: ${{ github.ref_name }}
+          draft: true
           generate_release_notes: true
           files: |-
             dist/jbeam-edit-${{ github.ref_name }}.zip

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -21,7 +21,7 @@ jobs:
           windows-version: latest
           version: get-tested-for-jbeam-edit
           newest: true
-  build-release:
+  build-for-release:
     runs-on: windows-latest
     needs: get-newest-supported-ghc
     name: Build for release for ${{ matrix.ghc }}
@@ -36,8 +36,15 @@ jobs:
           ghc-version: ${{ matrix.ghc }}
           cabal-version: latest
           cabal-update: true
+      - name: Enable optimization for building on tags
+        if: startsWith(github.ref, 'refs/tags/')
+        run: cabal configure --project-file cabal.project.release -O2
+      - name: Enable tests for non-tags
+        if: "!startsWith(github.ref, 'refs/tags/')"
+        run: cabal configure --project-file cabal.project.release --enable-tests
       - name: Cache GHC, Cabal store, and build artifacts
         uses: actions/cache@v4.2.4
+        if: "!startsWith(github.ref, 'refs/tags/')"
         with:
           path: |
             dist-newstyle
@@ -52,6 +59,8 @@ jobs:
             ${{ runner.os }}-cabal-${{ matrix.ghc }}-
       - name: Build executables
         run: cabal build exe:jbeam-edit --project-file cabal.project.release
+      - name: Run tests (GHC ${{ matrix.ghc }})
+        run: cabal test --project-file cabal.project.release
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
@@ -59,7 +68,7 @@ jobs:
           path: dist-newstyle
   release:
     runs-on: windows-latest
-    needs: build
+    needs: [build-for-release, get-newest-supported-ghc]
     if: startsWith(github.ref, 'refs/tags/')
     name: Release for Windows
     strategy:

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -1,0 +1,89 @@
+name: Build and release
+
+on:
+  push:
+    tags: [v*]
+
+jobs:
+  get-newest-supported-ghc:
+    name: Get the newest supported GHC
+    outputs:
+      matrix: ${{ steps.get-latest-version.outputs.matrix }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract the tested GHC versions
+        id: get-latest-version
+        uses: webdevred/get-tested@4671a0284723f30fa7f97989ff1f9513167180fe
+        with:
+          cabal-file: jbeam-edit.cabal
+          windows-version: latest
+          version: get-tested-for-jbeam-edit
+          newest: true
+  build-release:
+    runs-on: windows-latest
+    needs: get-newest-supported-ghc
+    name: Build and release for ${{ matrix.ghc }}
+    strategy:
+      matrix: ${{ fromJSON(needs.get-newest-supported-ghc.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up GHC latest and Cabal
+        id: setup-ghc
+        uses: haskell-actions/setup@v2.8.1
+        with:
+          ghc-version: ${{ matrix.ghc }}
+          cabal-version: latest
+          cabal-update: true
+      - name: Cache GHC, Cabal store, and build artifacts
+        uses: actions/cache@v4.2.4
+        with:
+          path: |
+            dist-newstyle
+            ${{ steps.setup-ghc.outputs.cabal-store }}
+          key: >-
+            ${{ runner.os }}-cabal-${{
+              matrix.ghc
+            }}-${{
+              hashFiles('**/package.yaml')
+            }}
+          restore-keys: |
+            ${{ runner.os }}-cabal-${{ matrix.ghc }}-
+      - name: Build executables
+        run: cabal build exe:jbeam-edit
+      - name: Prepare release folder
+        run: |
+          $releaseDir = "$env:GITHUB_WORKSPACE\dist\release"
+          Remove-Item $releaseDir -Recurse -Force -ErrorAction SilentlyContinue
+          New-Item -ItemType Directory -Path $releaseDir | Out-Null
+          $exePath = Get-ChildItem -Path "$env:GITHUB_WORKSPACE\dist-newstyle\build" -Recurse -Filter "jbeam-edit.exe" | Select-Object -First 1
+          if ($exePath) {
+            Copy-Item $exePath.FullName $releaseDir
+            Write-Host "✅ Copied $($exePath.FullName)"
+          }
+          else {
+            Write-Warning "⚠️ jbeam-edit.exe was not found in dist-newstyle, skipping."
+          }
+          $dataDir = "$releaseDir\examples\jbfl"
+          New-Item -ItemType Directory -Path $dataDir -Force | Out-Null
+          Copy-Item "examples\jbfl\*" $dataDir -Recurse -ErrorAction SilentlyContinue
+          Copy-Item README.md $releaseDir
+          Copy-Item JBFL_DOCS.md $releaseDir
+          Copy-Item LICENSE $releaseDir
+      - name: Zip release
+        run: |
+          $zipFile = "$env:GITHUB_WORKSPACE\dist\jbeam-edit-${env:GITHUB_REF_NAME}.zip"
+          Add-Type -AssemblyName System.IO.Compression.FileSystem
+          [System.IO.Compression.ZipFile]::CreateFromDirectory("$env:GITHUB_WORKSPACE\dist\release", $zipFile)
+      - name: Build Inno Setup Installer
+        uses: Minionguyjpro/Inno-Setup-Action@v1.2.2
+        with:
+          path: installer/setup.iss
+          options: /O+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2.3.2
+        with:
+          tag_name: ${{ github.ref_name }}
+          generate_release_notes: true
+          files: |-
+            dist/jbeam-edit-${{ github.ref_name }}.zip
+            dist/release/setup.exe

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -60,6 +60,7 @@ jobs:
       - name: Build executables
         run: cabal build exe:jbeam-edit --project-file cabal.project.release
       - name: Run tests (GHC ${{ matrix.ghc }})
+        if: "!startsWith(github.ref, 'refs/tags/')"
         run: cabal test --project-file cabal.project.release
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
@@ -82,34 +83,60 @@ jobs:
           path: dist-newstyle
       - name: Prepare release folder
         run: |
+          $ErrorActionPreference = 'Stop'
           $releaseDir = "$env:GITHUB_WORKSPACE\dist\release"
-          Remove-Item $releaseDir -Recurse -Force -ErrorAction SilentlyContinue
+          if (Test-Path $releaseDir) { Remove-Item $releaseDir -Recurse -Force -ErrorAction SilentlyContinue }
           New-Item -ItemType Directory -Path $releaseDir | Out-Null
-          $exePath = Get-ChildItem -Path "$env:GITHUB_WORKSPACE\dist-newstyle\build" -Recurse -Filter "jbeam-edit.exe" | Select-Object -First 1
-          if ($exePath) {
-            Copy-Item $exePath.FullName $releaseDir
+
+          $exePath = Get-ChildItem -Path "$env:GITHUB_WORKSPACE\dist-newstyle\build" -Recurse -Filter "jbeam-edit.exe" -ErrorAction SilentlyContinue | Select-Object -First 1
+          if (-not $exePath) {
+            Write-Error "jbeam-edit.exe not found in dist-newstyle build tree. Make sure build-for-release succeeded."
           }
-          $dataDir = "$releaseDir\examples\jbfl"
-          New-Item -ItemType Directory -Path $dataDir -Force | Out-Null
-          Copy-Item "examples\jbfl\*" $dataDir -Recurse -ErrorAction SilentlyContinue
-          Copy-Item README.md $releaseDir
-          Copy-Item JBFL_DOCS.md $releaseDir
-          Copy-Item LICENSE $releaseDir
-      - name: Zip release
-        run: |
-          $zipFile = "$env:GITHUB_WORKSPACE\dist\jbeam-edit-${env:GITHUB_REF_NAME}.zip"
-          Add-Type -AssemblyName System.IO.Compression.FileSystem
-          [System.IO.Compression.ZipFile]::CreateFromDirectory("$env:GITHUB_WORKSPACE\dist\release", $zipFile)
+          Copy-Item $exePath.FullName $releaseDir
+
+          $jbflDest = Join-Path $releaseDir "examples\jbfl"
+          New-Item -ItemType Directory -Path $jbflDest -Force | Out-Null
+          Copy-Item -Path "examples\jbfl\*" -Destination $jbflDest -Recurse -Force
+
+          Copy-Item README.md $releaseDir -Force
+          Copy-Item JBFL_DOCS.md $releaseDir -Force
+          Copy-Item LICENSE $releaseDir -Force
       - name: Build Inno Setup Installer
         uses: Minionguyjpro/Inno-Setup-Action@v1.2.2
         with:
           path: installer/setup.iss
           options: /O+
-      - name: Create GitHub Release
+      - name: Locate and move setup.exe into release folder
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $found = Get-ChildItem -Path "$env:GITHUB_WORKSPACE" -Recurse -Filter "setup.exe" -ErrorAction SilentlyContinue |
+                   Where-Object { $_.FullName -notmatch "\\\.git\\" } |
+                   Select-Object -First 1
+          if (-not $found) {
+            Write-Error "setup.exe not found after Inno Setup run. Check installer/output location."
+          }
+          $releaseSetupPath = Join-Path "$env:GITHUB_WORKSPACE\dist\release" "setup.exe"
+          Copy-Item $found.FullName $releaseSetupPath -Force
+          Write-Host "Copied setup.exe to $releaseSetupPath"
+      - name: Create zip containing setup.exe and docs
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $zipFile = "$env:GITHUB_WORKSPACE\dist\jbeam-edit-${env:GITHUB_REF_NAME}.zip"
+          $zipDir = "$env:GITHUB_WORKSPACE\dist\zip_temp"
+          if (Test-Path $zipDir) { Remove-Item $zipDir -Recurse -Force -ErrorAction SilentlyContinue }
+          New-Item -ItemType Directory -Path $zipDir | Out-Null
+
+          Copy-Item "$env:GITHUB_WORKSPACE\dist\release\setup.exe" $zipDir -Force
+          Copy-Item "$env:GITHUB_WORKSPACE\dist\release\README.md" $zipDir -Force
+          Copy-Item "$env:GITHUB_WORKSPACE\dist\release\JBFL_DOCS.md" $zipDir -Force
+          Copy-Item "$env:GITHUB_WORKSPACE\dist\release\LICENSE" $zipDir -Force
+          Add-Type -AssemblyName System.IO.Compression.FileSystem
+          [System.IO.Compression.ZipFile]::CreateFromDirectory($zipDir, $zipFile)
+          Write-Host "Created zip: $zipFile"
+      - name: Create GitHub Release and upload zip
         uses: softprops/action-gh-release@v2.3.2
         with:
           tag_name: ${{ github.ref_name }}
           generate_release_notes: true
           files: |-
             dist/jbeam-edit-${{ github.ref_name }}.zip
-            dist/release/setup.exe

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -1,8 +1,10 @@
-name: Build and release
+name: Build for release
 
 on:
   push:
+    branches: [master]
     tags: [v*]
+  pull_request:
 
 jobs:
   get-newest-supported-ghc:
@@ -22,7 +24,7 @@ jobs:
   build-release:
     runs-on: windows-latest
     needs: get-newest-supported-ghc
-    name: Build and release for ${{ matrix.ghc }}
+    name: Build for release for ${{ matrix.ghc }}
     strategy:
       matrix: ${{ fromJSON(needs.get-newest-supported-ghc.outputs.matrix) }}
     steps:
@@ -50,6 +52,25 @@ jobs:
             ${{ runner.os }}-cabal-${{ matrix.ghc }}-
       - name: Build executables
         run: cabal build exe:jbeam-edit --project-file cabal.project.release
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: jbeam-edit-${{ matrix.ghc }}
+          path: dist-newstyle
+  release:
+    runs-on: windows-latest
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/')
+    name: Release for Windows
+    strategy:
+      matrix: ${{ fromJSON(needs.get-newest-supported-ghc.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: jbeam-edit-${{ matrix.ghc }}
+          path: dist-newstyle
       - name: Prepare release folder
         run: |
           $releaseDir = "$env:GITHUB_WORKSPACE\dist\release"
@@ -58,10 +79,6 @@ jobs:
           $exePath = Get-ChildItem -Path "$env:GITHUB_WORKSPACE\dist-newstyle\build" -Recurse -Filter "jbeam-edit.exe" | Select-Object -First 1
           if ($exePath) {
             Copy-Item $exePath.FullName $releaseDir
-            Write-Host "✅ Copied $($exePath.FullName)"
-          }
-          else {
-            Write-Warning "⚠️ jbeam-edit.exe was not found in dist-newstyle, skipping."
           }
           $dataDir = "$releaseDir\examples\jbfl"
           New-Item -ItemType Directory -Path $dataDir -Force | Out-Null

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix: ${{ fromJSON(needs.get-newest-supported-ghc.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5.0.0
       - name: Set up GHC latest and Cabal
         id: setup-ghc
         uses: haskell-actions/setup@v2.8.1
@@ -77,7 +77,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Download build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5.0.0
         with:
           name: jbeam-edit-${{ matrix.ghc }}
           path: dist-newstyle

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -49,7 +49,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cabal-${{ matrix.ghc }}-
       - name: Build executables
-        run: cabal build exe:jbeam-edit
+        run: cabal build exe:jbeam-edit --project-file cabal.project.release
       - name: Prepare release folder
         run: |
           $releaseDir = "$env:GITHUB_WORKSPACE\dist\release"

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -69,7 +69,7 @@ jobs:
       - name: Run tests
         run: stack test --fast
   generate-matrix:
-    name: "Generate matrix from cabal"
+    name: Generate matrix from cabal
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -79,7 +79,7 @@ jobs:
         uses: kleidukos/get-tested@v0.1.7.1
         with:
           cabal-file: jbeam-edit.cabal
-          ubuntu-version: "latest"
+          ubuntu-version: latest
           version: 0.1.7.1
   build-with-cabal:
     name: Build and test with Cabal (GHC ${{ matrix.ghc }})

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ cabal.project.local~
 dist-newstyle/
 TAGS
 .stack-work/
+.ghc.environment.*
 **/*~
 **/#*#
 **/.#*

--- a/README.md
+++ b/README.md
@@ -81,28 +81,34 @@ If Windows shows a warning such as:
 
 Click **More info** → **Run anyway**.
 
-## 5. Open Command Prompt or PowerShell
+### 5. Path refresh
+The installer adds `jbeam-edit` to your **PATH**, but:
+- You must **open a new Command Prompt or PowerShell window** after installation.  
+- In some cases, you may need to **log out or restart Windows** for the PATH change to take effect.  
+- If it still doesn’t work, you can run it directly using the full path, e.g.:
 
-Press **Win + R**, type `cmd` (or `powershell`), and press **Enter**.
+```powershell
+"C:\Program Files (x86)\jbeam_edit\jbeam-edit.exe" your-file.jbeam
+```
 
-## 6. Run jbeam-edit on a file
+### 6. Open Command Prompt or PowerShell
+Press **`Win + R`**, type `cmd` or `powershell`, and hit **Enter**.
 
-Navigate to your project in CMD:
+### 7. Run jbeam-edit on a file
+Navigate to your project folder in CMD/PowerShell and run:
 
 ```powershell
 jbeam-edit your-file.jbeam
 ```
 
-Replace `your-file.jbeam` with the path to the JBeam file you want to format.
+Replace `your-file.jbeam` with the path to your JBeam file.
 
-Typical workflow:
+#### Typical workflow:
+- Parses and formats the file.  
+- Sorts and renames nodes, updating references.  
+- Writes the output back with a `.bak` backup (default).  
 
-- Parses and formats the file.
-- Sorts and renames nodes, updating references.
-- Writes output back with a `.bak` backup by default.
-
-In-place editing (no backup):
-
+#### In-place editing (no backup):
 ```powershell
 jbeam-edit -i example.jbeam
 ```

--- a/README.md
+++ b/README.md
@@ -64,14 +64,36 @@ Override per project by placing `.jbeam_edit.jbfl` in your project root.
 
 ## Usage
 
-Build and run:
+### 1. Download the latest release
+Go to the [Releases page](https://github.com/webdevred/jbeam_edit/releases) and download the most recent **`.zip`** file.
 
-```bash
-git clone https://github.com/webdevred/jbeam-tool.git
-cd jbeam-tool
-stack build
-stack exec jbeam-tool -- [options] <input-file>
+### 2. Unzip the file
+Extract the contents of the downloaded `.zip` archive to a folder of your choice.
+
+### 3. Run the setup as Administrator
+
+Inside the extracted folder, right-click on **setup.exe** and choose **Run as administrator**.
+
+## 4. Allow Windows protection if needed
+If Windows shows a warning such as:
+
+> *Windows protected your PC*
+
+Click **More info** → **Run anyway**.
+
+## 5. Open Command Prompt or PowerShell
+
+Press **Win + R**, type `cmd` (or `powershell`), and press **Enter**.
+
+## 6. Run jbeam-edit on a file
+
+Navigate to your project in CMD:
+
+```powershell
+jbeam-edit your-file.jbeam
 ```
+
+Replace `your-file.jbeam` with the path to the JBeam file you want to format.
 
 Typical workflow:
 
@@ -81,7 +103,7 @@ Typical workflow:
 
 In-place editing (no backup):
 
-```bash
+```powershell
 jbeam-edit -i example.jbeam
 ```
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ A fast, robust command-line parser, formatter, and editor for JBeam files, the J
   Uniform indentation, spacing, and layout for improved readability.
 
 - **Automatic Node Management:**
-  Renames nodes sequentially (e.g., `["bf1", ...]` → `["bf0", "bf1", "bf2"]`) and updates all references automatically.
+  Renames nodes sequentially (e.g., `["bf1", ...]` → `["bf0", "bf1", "bf2"]`) and updates all references automatically. Feature currently unstable, enabled by build flag `transformation`.
 
 - **Configurable Formatting with JBFL:**
   Customize formatting rules using JBFL, a mini-language to specify padding, decimals, indentation, and more with wildcard targeting.
@@ -107,6 +107,18 @@ In-place editing (no backup):
 jbeam-edit -i example.jbeam
 ```
 
+### From source (Linux or development)
+
+Clone and build with Cabal:
+
+```bash
+git clone https://github.com/webdevred/jbeam_edit.git
+cd jbeam_edit
+cabal update
+cabal install
+jbeam-edit your-file.jbeam
+```
+
 ## Examples
 
 For sample `.jbeam` files and JBFL rule files, see the [Examples Directory README](examples/README.org).
@@ -138,8 +150,10 @@ For an in-depth walkthrough of the implementation and design decisions, see [EXP
 
 ## Prerequisites
 
-- GHC (The Glasgow Haskell Compiler)
-- Stack build tool
+- **Windows users (BeamNG players):** none, just download the installer from [Releases](https://github.com/webdevred/jbeam_edit/releases/latest).
+- **Developers / Linux users:**
+  - [GHC](https://www.haskell.org/ghc/) (Glasgow Haskell Compiler)
+  - [Cabal](https://www.haskell.org/cabal/) build tool (comes with GHCup)
 
 ## Contributing & License
 

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,5 @@
+packages: .
+tests: True
+
+package jbeam-edit
+  flags: +dump-ast +transformation

--- a/cabal.project
+++ b/cabal.project
@@ -2,4 +2,4 @@ packages: .
 tests: True
 
 package jbeam-edit
-  flags: +dump-ast +transformation
+  flags: +dump-ast +transformation -windows-example-paths

--- a/cabal.project.ci
+++ b/cabal.project.ci
@@ -1,9 +1,5 @@
-packages: .
-tests: True
+import: cabal.project
 test-show-details: direct
 
 program-options
   ghc-options: -Werror
-
-package jbeam-edit
-  flags: +dump-ast +transformation

--- a/cabal.project.dev
+++ b/cabal.project.dev
@@ -1,4 +1,4 @@
-packages: .
+import: cabal.project
 write-ghc-environment-files: always
 
 package *
@@ -12,4 +12,3 @@ package jbeam-edit
   haddock-executables: True
   haddock-internal: True
   haddock-tests: True
-  flags: +dump-ast +transformation

--- a/cabal.project.dev
+++ b/cabal.project.dev
@@ -1,7 +1,15 @@
 packages: .
+write-ghc-environment-files: always
 
 package *
-  ghc-options: -haddock
+  optimization: 0
+  debug-info: True
+  tests: True
+  documentation: True
+  library-for-ghci: True
 
 package jbeam-edit
+  haddock-executables: True
+  haddock-internal: True
+  haddock-tests: True
   flags: +dump-ast +transformation

--- a/cabal.project.release
+++ b/cabal.project.release
@@ -1,5 +1,6 @@
 import: cabal.project
 tests: False
+executable-static: True
 
 package *
   ghc-options:

--- a/cabal.project.release
+++ b/cabal.project.release
@@ -8,4 +8,4 @@ package *
     -with-rtsopts=-N
 
 package jbeam-edit
-  flags: -dump-ast -transformation
+  flags: -dump-ast -transformation +windows-example-paths

--- a/cabal.project.release
+++ b/cabal.project.release
@@ -9,4 +9,3 @@ package *
 
 package jbeam-edit
   flags: -dump-ast -transformation
-

--- a/cabal.project.release
+++ b/cabal.project.release
@@ -1,0 +1,12 @@
+import: cabal.project
+tests: False
+
+package *
+  ghc-options:
+    -threaded
+    -rtsopts
+    -with-rtsopts=-N
+
+package jbeam-edit
+  flags: -dump-ast -transformation
+

--- a/installer/setup.iss
+++ b/installer/setup.iss
@@ -1,0 +1,23 @@
+; -- Basic Inno Setup Script for jbeam-edit --
+
+[Setup]
+AppName=jbeam-edit
+AppVersion=1.0
+DefaultDirName={pf}\jbeam-edit
+DefaultGroupName=jbeam-edit
+OutputBaseFilename=setup
+Compression=lzma
+SolidCompression=yes
+
+[Files]
+Source: "..\dist\release\jbeam-edit.exe"; DestDir: "{app}"; Flags: ignoreversion
+Source: "..\dist\release\examples\*"; DestDir: "{app}\examples"; Flags: recursesubdirs createallsubdirs
+Source: "..\dist\release\README.md"; DestDir: "{app}"; Flags: ignoreversion
+Source: "..\dist\release\JBFL_DOCS.md"; DestDir: "{app}"; Flags: ignoreversion
+Source: "..\dist\release\LICENSE"; DestDir: "{app}"; Flags: ignoreversion
+
+[Icons]
+Name: "{group}\jbeam-edit"; Filename: "{app}\jbeam-edit.exe"
+
+[Run]
+Filename: "{app}\jbeam-edit.exe"; Description: "Launch jbeam-edit"; Flags: nowait postinstall skipifsilent

--- a/installer/setup.iss
+++ b/installer/setup.iss
@@ -2,7 +2,7 @@
 
 [Setup]
 AppName=jbeam-edit
-AppVersion=1.0
+AppVersion=0.0.1.0
 DefaultDirName={pf}\jbeam-edit
 DefaultGroupName=jbeam-edit
 OutputBaseFilename=setup

--- a/installer/setup.iss
+++ b/installer/setup.iss
@@ -11,13 +11,8 @@ SolidCompression=yes
 
 [Files]
 Source: "..\dist\release\jbeam-edit.exe"; DestDir: "{app}"; Flags: ignoreversion
-Source: "..\dist\release\examples\*"; DestDir: "{app}\examples"; Flags: recursesubdirs createallsubdirs
-Source: "..\dist\release\README.md"; DestDir: "{app}"; Flags: ignoreversion
-Source: "..\dist\release\JBFL_DOCS.md"; DestDir: "{app}"; Flags: ignoreversion
-Source: "..\dist\release\LICENSE"; DestDir: "{app}"; Flags: ignoreversion
+Source: "..\dist\release\examples\jbfl\*"; DestDir: "{app}\examples\jbfl"; Flags: recursesubdirs createallsubdirs ignoreversion
 
-[Icons]
-Name: "{group}\jbeam-edit"; Filename: "{app}\jbeam-edit.exe"
-
-[Run]
-Filename: "{app}\jbeam-edit.exe"; Description: "Launch jbeam-edit"; Flags: nowait postinstall skipifsilent
+[Registry]
+  Root: HKCU; Subkey: "Environment"; ValueType: string; ValueName: "Path"; \
+    ValueData: "{olddata};{app}"; Flags: preservestringtype uninsdeletevalue

--- a/jbeam-edit.cabal
+++ b/jbeam-edit.cabal
@@ -5,7 +5,7 @@ cabal-version:      2.2
 -- see: https://github.com/sol/hpack
 
 name:               jbeam-edit
-version:            0.1.0.0
+version:            0.0.1.0
 license:            BSD-3-Clause
 license-file:       LICENSE
 copyright:          2025 webdevred

--- a/jbeam-edit.cabal
+++ b/jbeam-edit.cabal
@@ -40,6 +40,13 @@ flag transformation
     default:     False
     manual:      True
 
+flag windows-example-paths
+    description:
+        Use executable-relative example paths (for Windows release builds)
+
+    default:     False
+    manual:      True
+
 library
     exposed-modules:
         CommandLineOptions
@@ -82,7 +89,7 @@ library
         exposed-modules: Transformation
         hs-source-dirs:  src-extra/transformation
 
-    if os(windows)
+    if (os(windows) && flag(windows-example-paths))
         cpp-options: -DWINDOWS_EXAMPLE_PATHS
 
 executable jbeam-edit

--- a/jbeam-edit.cabal
+++ b/jbeam-edit.cabal
@@ -82,6 +82,9 @@ library
         exposed-modules: Transformation
         hs-source-dirs:  src-extra/transformation
 
+    if os(windows)
+        cpp-options: -DWINDOWS_EXAMPLE_PATHS
+
 executable jbeam-edit
     main-is:            Main.hs
     hs-source-dirs:     app

--- a/package.yaml
+++ b/package.yaml
@@ -42,7 +42,7 @@ library:
     - condition: flag(transformation)
       source-dirs: [src-extra/transformation]
       exposed-modules: [Transformation]
-    - condition: os(mingw32)
+    - condition: os(windows) && flag(windows-example-paths)
       cpp-options: -DWINDOWS_EXAMPLE_PATHS
 
 flags:
@@ -54,6 +54,11 @@ flags:
     description: Enable transformation (experimental)
     manual: true
     default: false
+  windows-example-paths:
+    description: Use executable-relative example paths (for Windows release builds)
+    default: false
+    manual: true
+
 
 executables:
   jbeam-edit:

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: jbeam-edit
-version: 0.1.0.0
+version: 0.0.1.0
 github: webdevred/jbeam-edit
 license: BSD-3-Clause
 author: webdevred

--- a/package.yaml
+++ b/package.yaml
@@ -39,9 +39,11 @@ library:
   source-dirs: src
   generated-other-modules: Paths_jbeam_edit
   when:
-    condition: flag(transformation)
-    source-dirs: [src-extra/transformation]
-    exposed-modules: [Transformation]
+    - condition: flag(transformation)
+      source-dirs: [src-extra/transformation]
+      exposed-modules: [Transformation]
+    - condition: os(mingw32)
+      cpp-options: -DWINDOWS_EXAMPLE_PATHS
 
 flags:
   dump-ast:

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,3 +5,4 @@ flags:
   jbeam-edit:
     transformation: false
     dump-ast: false
+    windows-example-paths: false


### PR DESCRIPTION
- Added `.github/workflows/build-and-release.yaml` to build `jbeam-edit` on Windows, cache GHC/Cabal artifacts, package release files, and upload to GitHub Releases.
- Introduced `installer/setup.iss` Inno Setup script to create a Windows installer.
- Release workflow now zips binaries and resources, including examples, documentation, and license files, for easier distribution.