### PR TITLE
Clean up unused imports and adopt Relude utilities

### DIFF
--- a/.github/workflows/future-proofing.yaml
+++ b/.github/workflows/future-proofing.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v5
       - name: Get latest supported GHC version
         id: get-ghc
-        uses: webdevred/get-supported-ghc@v0.0.7
+        uses: webdevred/get-supported-ghc@v0.0.8
       - name: Set up GHC latest and Cabal
         id: setup-ghc
         uses: haskell-actions/setup@v2.8.1

--- a/jbeam-edit.cabal
+++ b/jbeam-edit.cabal
@@ -128,6 +128,11 @@ executable jbeam-edit
         text >=2.0,
         vector
 
+    mixins:
+        base hiding (Prelude),
+        relude (Relude as Prelude),
+        relude
+
     if flag(transformation)
         cpp-options: -DENABLE_TRANSFORMATION
 
@@ -157,6 +162,11 @@ executable jbeam-edit-dump-ast
         scientific,
         text >=2.0,
         vector
+
+    mixins:
+        base hiding (Prelude),
+        relude (Relude as Prelude),
+        relude
 
     if flag(dump-ast)
 
@@ -198,3 +208,8 @@ test-suite jbeam-edit-test
         scientific,
         text >=2.0,
         vector
+
+    mixins:
+        base hiding (Prelude),
+        relude (Relude as Prelude),
+        relude

--- a/jbeam-edit.cabal
+++ b/jbeam-edit.cabal
@@ -83,9 +83,15 @@ library
         directory,
         filepath,
         megaparsec,
+        relude,
         scientific,
         text >=2.0,
         vector
+
+    mixins:
+        base hiding (Prelude),
+        relude (Relude as Prelude),
+        relude
 
     if flag(transformation)
         exposed-modules: Transformation
@@ -117,6 +123,7 @@ executable jbeam-edit
         filepath,
         jbeam-edit,
         megaparsec,
+        relude,
         scientific,
         text >=2.0,
         vector
@@ -146,6 +153,7 @@ executable jbeam-edit-dump-ast
         jbeam-edit,
         megaparsec,
         pretty-simple,
+        relude,
         scientific,
         text >=2.0,
         vector
@@ -186,6 +194,7 @@ test-suite jbeam-edit-test
         hspec-megaparsec,
         jbeam-edit,
         megaparsec,
+        relude,
         scientific,
         text >=2.0,
         vector

--- a/package.yaml
+++ b/package.yaml
@@ -18,6 +18,7 @@ tested-with: [GHC == 9.4.7, GHC == 9.6.6]
 
 dependencies:
   - base >= 4.17 && < 5
+  - relude
   - bytestring
   - vector
   - text >= 2.0
@@ -43,6 +44,11 @@ ghc-options:
 library:
   source-dirs: src
   generated-other-modules: Paths_jbeam_edit
+  verbatim:
+    mixins: |
+      base hiding (Prelude),
+      relude (Relude as Prelude),
+      relude
   when:
     - condition: flag(transformation)
       source-dirs: [src-extra/transformation]

--- a/package.yaml
+++ b/package.yaml
@@ -17,8 +17,11 @@ description: Please see the README on GitHub at <https://github.com/webdevred/jb
 tested-with: [GHC == 9.4.7, GHC == 9.6.6]
 
 dependencies:
-  - base >= 4.17 && < 5
-  - relude
+  - name: base
+    version: '>= 4.17 && < 5'
+    mixin: [hiding (Prelude)]
+  - name: relude
+    mixin: [(Relude as Prelude), '']
   - bytestring
   - vector
   - text >= 2.0
@@ -44,11 +47,6 @@ ghc-options:
 library:
   source-dirs: src
   generated-other-modules: Paths_jbeam_edit
-  verbatim:
-    mixins: |
-      base hiding (Prelude),
-      relude (Relude as Prelude),
-      relude
   when:
     - condition: flag(transformation)
       source-dirs: [src-extra/transformation]

--- a/src-extra/transformation/Types.hs
+++ b/src-extra/transformation/Types.hs
@@ -9,10 +9,7 @@ module Types (
 ) where
 
 import Core.Node
-import Data.List.NonEmpty (NonEmpty (..))
-import Data.Map (Map)
 import Data.Scientific (Scientific)
-import Data.Text (Text)
 
 type VertexForest = Map VertexTreeType VertexTree
 

--- a/src/CommandLineOptions.hs
+++ b/src/CommandLineOptions.hs
@@ -8,7 +8,6 @@ import Formatting.Config (ConfigType (..))
 import Paths_jbeam_edit (version)
 import System.Console.GetOpt
 import System.Environment
-import System.Exit
 
 data Options = Options
   { optInPlace :: Bool
@@ -28,7 +27,7 @@ startOptions =
 parseOptions :: [String] -> IO Options
 parseOptions args = do
   let (actions, nonOptions, _) = getOpt RequireOrder options args
-  opts <- foldl (>>=) (pure startOptions) actions
+  opts <- foldl' (>>=) (pure startOptions) actions
   case (optInputFile opts, nonOptions) of
     (Nothing, filename : _) -> pure $ opts {optInputFile = Just filename}
     (_, _) -> pure opts
@@ -72,10 +71,10 @@ options =
               let header =
                     unlines
                       [ "Usage:"
-                      , "  " ++ prg ++ " [OPTIONS] [INPUT-FILE]"
+                      , "  " <> toText prg <> " [OPTIONS] [INPUT-FILE]"
                       , ""
                       ]
-              putStrLn (usageInfo header options)
+              putStrLn (usageInfo (toString header) options)
               exitSuccess
           )
       )

--- a/src/Core/Node.hs
+++ b/src/Core/Node.hs
@@ -11,7 +11,6 @@ module Core.Node (
 ) where
 
 import Data.Scientific (Scientific)
-import Data.Text (Text)
 import Data.Vector (Vector)
 
 type Object = Vector Node

--- a/src/Core/NodeCursor.hs
+++ b/src/Core/NodeCursor.hs
@@ -12,7 +12,6 @@ module Core.NodeCursor (
 
 import Core.Node (Node (..))
 import Data.Sequence (Seq (..))
-import Data.Text (Text)
 
 import Core.NodePath qualified as NP
 import Data.Sequence qualified as Seq (empty, null)

--- a/src/Core/NodePath.hs
+++ b/src/Core/NodePath.hs
@@ -28,14 +28,14 @@ newtype NodePath
 instance IsList NodePath where
   type Item NodePath = NodeSelector
   fromList = NodePath . fromList
-  toList (NodePath xs) = toList xs
+  toList (NodePath xs) = Prelude.toList xs
 
 extractValInKey :: N.Node -> Maybe N.Node
 extractValInKey (N.ObjectKey (_, val)) = Just val
 extractValInKey _ = Nothing
 
 select :: NodeSelector -> N.Node -> Maybe N.Node
-select (ArrayIndex i) (N.Array ns) = getNthElem 0 (toList ns)
+select (ArrayIndex i) (N.Array ns) = getNthElem 0 (V.toList ns)
   where
     getNthElem _ [] = Nothing
     getNthElem curIndex ((N.Comment _) : rest) = getNthElem curIndex rest
@@ -46,7 +46,7 @@ select (ObjectKey k) (N.Object ns) = extractValInKey =<< V.find compareKey ns
   where
     compareKey (N.ObjectKey (N.String keyText, _)) = keyText == k
     compareKey _ = False
-select (ObjectIndex i) (N.Object a) = getNthKey 0 (toList a)
+select (ObjectIndex i) (N.Object a) = getNthKey 0 (V.toList a)
   where
     getNthKey _ [] = Nothing
     getNthKey curIndex ((N.ObjectKey (_, value)) : rest)

--- a/src/Core/NodePath.hs
+++ b/src/Core/NodePath.hs
@@ -9,7 +9,6 @@ module Core.NodePath (
 ) where
 
 import Data.Sequence (Seq (..))
-import Data.Text (Text)
 import GHC.IsList (IsList (..))
 
 import Core.Node qualified as N (Node (..))

--- a/src/Formatting.hs
+++ b/src/Formatting.hs
@@ -5,10 +5,8 @@ module Formatting (
 ) where
 
 import Core.Node (InternalComment (..), Node (..), isCommentNode, isComplexNode)
-import Data.Bool (bool)
 import Data.Char (isSpace)
 import Data.Scientific (FPFormat (Fixed), formatScientific)
-import Data.Text (Text)
 import Data.Vector (Vector)
 import Formatting.Rules (
   RuleSet (..),

--- a/src/Formatting/Config.hs
+++ b/src/Formatting/Config.hs
@@ -2,15 +2,11 @@
 
 module Formatting.Config (readFormattingConfig, copyToConfigDir, ConfigType (..)) where
 
-import Control.Monad (when)
 import Data.ByteString.Lazy as BL
-import Data.Functor (($>))
 import Formatting.Rules
 import GHC.IO.Exception (IOErrorType (NoSuchThing))
 import IOUtils
 import Parsing.DSL (parseDSL)
-import System.Directory
-import System.FilePath (takeDirectory, (</>))
 
 #if WINDOWS_EXAMPLE_PATHS
 import System.Environment (getExecutablePath)
@@ -18,7 +14,8 @@ import System.Environment (getExecutablePath)
 import Paths_jbeam_edit
 #endif
 
-import Data.Text.IO qualified as TIO (putStrLn)
+import System.Directory
+import System.FilePath (takeDirectory, (</>))
 
 data ConfigType = MinimalConfig | ComplexConfig deriving (Show)
 
@@ -74,4 +71,4 @@ readFormattingConfig = do
   contents <- tryReadFile [NoSuchThing] configPath
   case contents >>= parseDSL . BL.toStrict of
     Right rs -> pure rs
-    Left err -> TIO.putStrLn err $> newRuleSet
+    Left err -> putTextLn err $> newRuleSet

--- a/src/Formatting/Rules.hs
+++ b/src/Formatting/Rules.hs
@@ -23,23 +23,17 @@ module Formatting.Rules (
   findPropertiesForCursor,
 ) where
 
-import Text.Read qualified as TR
-import qualified Text.Show
 import Core.Node
 import Core.NodePath (NodeSelector (..))
-import Data.Function (on)
-import Data.List (find)
-import Data.Map (Map)
-import Data.Maybe (fromMaybe)
-import Data.Ord (Down (..))
 import Data.Sequence (Seq (..))
-import Data.Text (Text)
 import Data.Type.Equality ((:~:) (Refl))
 
 import Core.NodeCursor qualified as NC
 import Data.Map qualified as M
 import Data.Sequence qualified as Seq (length, null)
 import Data.Text qualified as T
+import Text.Read qualified as TR
+import Text.Show qualified
 
 data NodePatternSelector
   = AnyObjectKey
@@ -77,7 +71,7 @@ data SomeKey
     SomeKey (PropertyKey a)
 
 instance Show SomeKey where
-  show (SomeKey key) = "SomeKey " <> T.unpack (propertyName key)
+  show (SomeKey key) = "SomeKey " <> toString (propertyName key)
 
 instance Read SomeKey where
   readsPrec _ s =
@@ -110,7 +104,7 @@ data SomeProperty
     SomeProperty (PropertyKey a) a
 
 instance Show SomeProperty where
-  show (SomeProperty key val) = "SomeProperty " <> T.unpack (propertyName key) <> " " <> show val
+  show (SomeProperty key val) = "SomeProperty " <> toString (propertyName key) <> " " <> show val
 
 instance Read SomeProperty where
   readsPrec _ s =
@@ -118,7 +112,7 @@ instance Read SomeProperty where
       [("SomeProperty", rest1)] ->
         case TR.lex rest1 of
           (keyStr, rest2) : _ ->
-            case lookupKey (T.pack keyStr) allProperties of
+            case lookupKey (toText keyStr) allProperties of
               Just (SomeKey (key :: PropertyKey a)) ->
                 case reads rest2 of
                   [(val, rest3)] -> [(SomeProperty key val, rest3)]

--- a/src/Formatting/Rules.hs
+++ b/src/Formatting/Rules.hs
@@ -23,6 +23,8 @@ module Formatting.Rules (
   findPropertiesForCursor,
 ) where
 
+import Text.Read qualified as TR
+import qualified Text.Show
 import Core.Node
 import Core.NodePath (NodeSelector (..))
 import Data.Function (on)
@@ -75,17 +77,17 @@ data SomeKey
     SomeKey (PropertyKey a)
 
 instance Show SomeKey where
-  show (SomeKey key) = "SomeKey " ++ T.unpack (propertyName key)
+  show (SomeKey key) = "SomeKey " <> T.unpack (propertyName key)
 
 instance Read SomeKey where
   readsPrec _ s =
-    case lex s of
+    case TR.lex s of
       [("SomeKey", rest1)] ->
-        case lex rest1 of
+        case TR.lex rest1 of
           [(keyStr, rest2)] ->
-            case lookupKey (T.pack keyStr) allProperties of
+            case lookupKey (toText keyStr) allProperties of
               Just theKey -> [(theKey, rest2)]
-              Nothing -> error ("invalid key: " ++ keyStr)
+              Nothing -> error ("invalid key: " <> toText keyStr)
           _ -> []
       _ -> []
 
@@ -112,9 +114,9 @@ instance Show SomeProperty where
 
 instance Read SomeProperty where
   readsPrec _ s =
-    case lex s of
+    case TR.lex s of
       [("SomeProperty", rest1)] ->
-        case lex rest1 of
+        case TR.lex rest1 of
           (keyStr, rest2) : _ ->
             case lookupKey (T.pack keyStr) allProperties of
               Just (SomeKey (key :: PropertyKey a)) ->

--- a/src/IOUtils.hs
+++ b/src/IOUtils.hs
@@ -1,14 +1,12 @@
 module IOUtils (tryReadFile) where
 
 import Control.Exception (IOException, try)
-import Data.Text (Text)
 import GHC.IO.Exception (IOErrorType, IOException (IOError))
 
 import Data.ByteString.Lazy qualified as BL (
   ByteString,
-  readFile,
  )
-import Data.Text qualified as T (append, pack)
+import Data.Text qualified as T (append)
 
 ioErrorMsg
   :: [IOErrorType]
@@ -16,15 +14,15 @@ ioErrorMsg
   -> Either Text BL.ByteString
 ioErrorMsg noerrs (Left (IOError _ ioe_type _ ioe_desc _ filename)) =
   if ioe_type `notElem` noerrs
-    then Left $ maybe "" appendColon filename `T.append` T.pack ioe_desc
+    then Left $ maybe "" appendColon filename `T.append` toText ioe_desc
     else Right ""
   where
-    appendColon f = T.pack f `T.append` ": "
+    appendColon f = toText f `T.append` ": "
 ioErrorMsg _ (Right valid) = Right valid
 
 tryReadFile :: [IOErrorType] -> FilePath -> IO (Either Text BL.ByteString)
 tryReadFile noerrs fp = do
   possiblyContent <-
-    Control.Exception.try (BL.readFile fp)
+    Control.Exception.try (readFileLBS fp)
       :: IO (Either Control.Exception.IOException BL.ByteString)
   pure $ ioErrorMsg noerrs possiblyContent

--- a/src/Parsing/Common/ErrorMessage.hs
+++ b/src/Parsing/Common/ErrorMessage.hs
@@ -2,12 +2,7 @@ module Parsing.Common.ErrorMessage (
   formatErrors,
 ) where
 
-import Data.ByteString (ByteString)
-import Data.Function (on)
-import Data.Set (Set)
-import Data.Text (Text)
 import Data.Text.Encoding (decodeUtf8Lenient)
-import Data.Word (Word8)
 import Parsing.Common.Helpers (charNotEqWord8, toChar, toWord8)
 
 import Data.ByteString qualified as BS
@@ -30,8 +25,8 @@ formatTok :: MP.ErrorItem Word8 -> Text
 formatTok toks =
   case toks of
     MP.EndOfInput -> "end of input"
-    MP.Label lab -> T.pack $ NE.toList lab
-    MP.Tokens toks' -> T.pack . wrap "'" "'" . map toChar $ NE.toList toks'
+    MP.Label lab -> toText $ NE.toList lab
+    MP.Tokens toks' -> toText . wrap "'" "'" . map toChar $ NE.toList toks'
 
 errorAreaAndLineNumber :: Int -> ByteString -> (Text, Text)
 errorAreaAndLineNumber pos inputNotParsed =
@@ -41,7 +36,7 @@ errorAreaAndLineNumber pos inputNotParsed =
       lineNumber = BS.count (toWord8 '\n') begin
       errorArea =
         T.strip $ on (<>) decodeUtf8Lenient fstPartOfLine sndPartOfLine
-   in (errorArea, T.pack $ show lineNumber)
+   in (errorArea, show lineNumber)
 
 wrap :: Semigroup a => a -> a -> a -> a
 wrap l r m = l <> m <> r

--- a/src/Parsing/Common/Helpers.hs
+++ b/src/Parsing/Common/Helpers.hs
@@ -11,13 +11,7 @@ module Parsing.Common.Helpers (
   parseBool,
 ) where
 
-import Control.Applicative (Alternative (..), asum)
-import Data.ByteString (ByteString)
-import Data.Char (chr, isSpace, ord)
-import Data.Functor ((<&>))
-import Data.Text.Encoding (decodeUtf8')
-import Data.Void (Void)
-import Data.Word (Word8)
+import Data.Char (isSpace)
 
 import Data.ByteString qualified as BS
 import Data.List.NonEmpty qualified as NE (fromList)

--- a/src/Parsing/DSL.hs
+++ b/src/Parsing/DSL.hs
@@ -9,14 +9,7 @@ module Parsing.DSL (
 ) where
 
 import Core.NodePath
-import Data.Bifunctor (first)
-import Data.ByteString (ByteString)
 import Data.Char (isSpace)
-import Data.Functor (void, ($>))
-import Data.Map (Map)
-import Data.Text (Text)
-import Data.Text.Encoding (decodeUtf8')
-import Data.Word (Word8)
 import Formatting.Rules
 import Parsing.Common
 import Text.Megaparsec ((<?>))

--- a/src/Parsing/Jbeam.hs
+++ b/src/Parsing/Jbeam.hs
@@ -4,12 +4,7 @@ module Parsing.Jbeam (
   parseNodes,
 ) where
 
-import Control.Applicative (Alternative (..), optional, (<|>))
 import Core.Node (InternalComment (..), Node (..))
-import Data.Bifunctor (first)
-import Data.ByteString (ByteString)
-import Data.Functor (($>))
-import Data.Text (Text)
 import Parsing.Common
 import Text.Megaparsec ((<?>))
 

--- a/test/Parsing/DSLSpec.hs
+++ b/test/Parsing/DSLSpec.hs
@@ -1,24 +1,21 @@
+{-# OPTIONS_GHC -Wno-deprecations #-}
+
 module Parsing.DSLSpec (
   spec,
 ) where
 
-import Data.ByteString (ByteString)
 import Data.List (isSuffixOf)
-import Data.String (fromString)
-import Data.Void (Void)
 import Formatting.Rules
 import Parsing.Common.Helpers
 import Parsing.DSL
 import Parsing.ParsingTestHelpers
+import Relude.Unsafe (read)
 import SpecHelper
 import System.Directory (getDirectoryContents)
 import Test.Hspec.Megaparsec
 import Text.Megaparsec
 
 import Core.NodePath qualified as NP (NodeSelector (..))
-import Data.ByteString qualified as BS (
-  readFile,
- )
 
 patternSelectorSpecs :: [Spec]
 patternSelectorSpecs =
@@ -49,7 +46,7 @@ boolProperties =
 ruleSetSpec :: FilePath -> FilePath -> Spec
 ruleSetSpec inFilename outFilename = do
   let inputPath = "examples/jbfl/" ++ inFilename
-  input <- runIO $ BS.readFile inputPath
+  input <- runIO $ readFileBS inputPath
   output <- runIO $ readFile outFilename
   let desc = "should parse contents of " ++ inFilename ++ " to AST in " ++ outFilename
   describe desc . works $

--- a/test/Parsing/JbeamSpec.hs
+++ b/test/Parsing/JbeamSpec.hs
@@ -1,20 +1,18 @@
+{-# OPTIONS_GHC -Wno-deprecations #-}
+
 module Parsing.JbeamSpec (
   spec,
 ) where
 
 import Data.List (isSuffixOf)
-import Data.Vector (fromList)
 import Parsing.Common.Helpers
 import Parsing.Jbeam
 import Parsing.ParsingTestHelpers
+import Relude.Unsafe (read)
 import SpecHelper
 import System.Directory (getDirectoryContents)
 import Test.Hspec.Megaparsec
 import Text.Megaparsec
-
-import Data.ByteString qualified as BS (
-  readFile,
- )
 
 numberSpec :: [(String, Node)]
 numberSpec =
@@ -93,7 +91,7 @@ invalidNumberSpec =
 topNodeSpec :: FilePath -> FilePath -> Spec
 topNodeSpec inFilename outFilename = do
   let inputPath = "examples/jbeam/" ++ inFilename
-  input <- runIO $ BS.readFile inputPath
+  input <- runIO $ readFileBS inputPath
   output <- runIO $ readFile outFilename
   let desc = "should parse contents of " ++ inFilename ++ " to AST in " ++ outFilename
   describe desc . works $

--- a/test/Parsing/ParsingTestHelpers.hs
+++ b/test/Parsing/ParsingTestHelpers.hs
@@ -2,7 +2,6 @@ module Parsing.ParsingTestHelpers (
   applyParserSpec,
 ) where
 
-import Data.String (fromString)
 import Parsing.Common.Helpers
 import SpecHelper
 import Test.Hspec.Megaparsec

--- a/tools/dump_ast/Main.hs
+++ b/tools/dump_ast/Main.hs
@@ -10,10 +10,8 @@ import System.FilePath ((</>))
 import Text.Pretty.Simple (defaultOutputOptionsNoColor, pStringOpt)
 
 import Data.ByteString.Lazy qualified as BL (
-  readFile,
   toStrict,
  )
-import Data.Text.Lazy.IO qualified as TLIO (writeFile)
 
 main :: IO ()
 main =
@@ -30,17 +28,17 @@ saveDump :: Show a => String -> a -> IO ()
 saveDump outFile contents =
   let formatted = pStringOpt defaultOutputOptionsNoColor (show contents ++ "\n")
    in putStrLn ("creating " ++ outFile)
-        >> TLIO.writeFile outFile formatted
+        >> writeFileLText outFile formatted
 
 astDir :: FilePath
 astDir = "examples" </> "ast"
 
 dumpJbflAST :: String -> String -> IO ()
 dumpJbflAST dir filename = do
-  contents <- BL.readFile (dir </> filename)
+  contents <- readFileLBS (dir </> filename)
   case parseDSL (BL.toStrict contents) of
     Right rs -> dump rs
-    Left _ -> error $ "error " ++ filename
+    Left _ -> error $ "error " <> toText filename
   where
     dump contents =
       let outFile = astDir </> "jbfl" </> takeWhile (/= '.') filename ++ ".hs"
@@ -48,10 +46,10 @@ dumpJbflAST dir filename = do
 
 dumpJbeamAST :: String -> String -> IO ()
 dumpJbeamAST dir filename = do
-  contents <- BL.readFile (dir </> filename)
+  contents <- readFileLBS (dir </> filename)
   case parseNodes (BL.toStrict contents) of
     Right rs -> dump rs
-    Left _ -> error $ "error " ++ filename
+    Left _ -> error $ "error " <> toText filename
   where
     dump contents =
       let outFile = astDir </> "jbeam" </> takeWhile (/= '.') filename ++ ".hs"


### PR DESCRIPTION
- Added Relude to the project and configured it as the default Prelude.
- Removed numerous unused imports across Main, Transformation, Types, CommandLineOptions, Node*, Formatting*, Parsing*, and IOUtils.
- Simplified several helper functions by removing redundant code.
- Minor package.yaml adjustments to support Relude across library, executables, and test suite.