### PR TITLE
Prefix replacement from cli arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,6 @@ For an in-depth walkthrough of the implementation and design decisions, see [EXP
 
 - Language Server Protocol (LSP) support
 - Automatic grouping of support vertices
-- Prefix replacement via CLI arguments
-- Sort a vertices using a threshold, Z values within the threshold are treated as equal; if too strict, compare the Y elements instead.
 - Update specific ranges of vertices
 - Expanded tests and example files
 - Improved documentation

--- a/README.md
+++ b/README.md
@@ -136,7 +136,6 @@ For an in-depth walkthrough of the implementation and design decisions, see [EXP
 ## Planned Features / TODO
 
 - Language Server Protocol (LSP) support
-- Automatic grouping of support vertices
 - Update specific ranges of vertices
 - Expanded tests and example files
 - Improved documentation

--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ Click **More info** → **Run anyway**.
 
 ### 5. Path refresh
 The installer adds `jbeam-edit` to your **PATH**, but:
-- You must **open a new Command Prompt or PowerShell window** after installation.  
-- In some cases, you may need to **log out or restart Windows** for the PATH change to take effect.  
+- You must **open a new Command Prompt or PowerShell window** after installation.
+- In some cases, you may need to **log out or restart Windows** for the PATH change to take effect.
 - If it still doesn’t work, you can run it directly using the full path, e.g.:
 
 ```powershell
@@ -104,9 +104,9 @@ jbeam-edit your-file.jbeam
 Replace `your-file.jbeam` with the path to your JBeam file.
 
 #### Typical workflow:
-- Parses and formats the file.  
-- Sorts and renames nodes, updating references.  
-- Writes the output back with a `.bak` backup (default).  
+- Parses and formats the file.
+- Sorts and renames nodes, updating references.
+- Writes the output back with a `.bak` backup (default).
 
 #### In-place editing (no backup):
 ```powershell

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -38,13 +38,13 @@ editFile opts = do
       outFilename <- getWritabaleFilename filename opts
       contents <- tryReadFile [] filename
       case contents >>= parseNodes . toStrict of
-        Right ns -> processNodes outFilename ns formattingConfig
+        Right ns -> processNodes opts outFilename ns formattingConfig
         Left err -> putTextLn err
     Nothing -> putTextLn "missing arg filename"
 
-processNodes :: FilePath -> Node -> RuleSet -> IO ()
-processNodes outFile nodes formattingConfig = do
-  transformedNode <- applyTransform nodes
+processNodes :: Options -> FilePath -> Node -> RuleSet -> IO ()
+processNodes opts outFile nodes formattingConfig = do
+  transformedNode <- applyTransform opts nodes
   case transformedNode of
     Right transformedNode' ->
       writeFileLBS outFile
@@ -54,11 +54,11 @@ processNodes outFile nodes formattingConfig = do
         $ transformedNode'
     Left err -> putTextLn err
 
-applyTransform :: Node -> IO (Either Text Node)
+applyTransform :: Options -> Node -> IO (Either Text Node)
 #ifdef ENABLE_TRANSFORMATION
-applyTransform node = do
+applyTransform opts node = do
   tfConfig <- loadTransformationConfig
-  pure (transform tfConfig node)
+  pure (transform (optUpdateNames opts) tfConfig node)
 #else
-applyTransform = pure . Right
+applyTransform _ = pure . Right
 #endif

--- a/src-extra/transformation/Transformation.hs
+++ b/src-extra/transformation/Transformation.hs
@@ -96,7 +96,7 @@ groupByPrefix
 groupByPrefix = NE.groupWith1 (dropIndex . vName . aVertex)
 
 addVertexTreeToForest
-  :: Map Text Text
+  :: UpdateNamesMap
   -> TransformationConfig
   -> Map Text Int
   -> Map VertexTreeType [AnnotatedVertex]
@@ -372,7 +372,7 @@ isObjectKeyEqual :: NP.NodeSelector -> Node -> Bool
 isObjectKeyEqual (NP.ObjectKey a) (ObjectKey (String b, _)) = a == b
 isObjectKeyEqual _ _ = False
 
-findAndUpdateTextInNode :: Map Text Text -> NC.NodeCursor -> Node -> Node
+findAndUpdateTextInNode :: UpdateNamesMap -> NC.NodeCursor -> Node -> Node
 findAndUpdateTextInNode m cursor node =
   case node of
     Array arr

--- a/src-extra/transformation/Transformation.hs
+++ b/src-extra/transformation/Transformation.hs
@@ -238,13 +238,12 @@ commentGroupToNodesWithPrev prevMeta (AnnotatedVertex comments vertex meta) =
 
       vertexArray :: Node
       vertexArray =
-        Array $
-          V.fromList
-            [ String (vName vertex)
-            , Number (vX vertex)
-            , Number (vY vertex)
-            , Number (vZ vertex)
-            ]
+        let name = String (vName vertex)
+            x = Number (vX vertex)
+            y = Number (vY vertex)
+            z = Number (vZ vertex)
+            possiblyMeta = maybe [] (one . Object) (vMeta vertex)
+         in Array . V.fromList $ [name, x, y, z] ++ possiblyMeta
    in ( map Comment preComments
           ++ metaNodes
           ++ one vertexArray

--- a/src-extra/transformation/Transformation.hs
+++ b/src-extra/transformation/Transformation.hs
@@ -96,16 +96,17 @@ groupByPrefix
 groupByPrefix = NE.groupWith1 (dropIndex . vName . aVertex)
 
 addVertexTreeToForest
-  :: XGroupBreakpoints
+  :: Map Text Text
+  -> XGroupBreakpoints
   -> Scientific
   -> Double
-  -> VertexConnMap
+  -> Map Text Int
   -> Map VertexTreeType [AnnotatedVertex]
   -> VertexForest
   -> VertexForest
   -> VertexTreeType
   -> Either Text VertexForest
-addVertexTreeToForest brks thr supThr conns grouped forest forestAcc t =
+addVertexTreeToForest newNames brks thr supThr conns grouped forest forestAcc t =
   case M.lookup t grouped of
     Just groupsForT ->
       let (supportVertices, tree) = buildTreeForType conns supThr forest t groupsForT
@@ -115,7 +116,9 @@ addVertexTreeToForest brks thr supThr conns grouped forest forestAcc t =
                   groupsSorted =
                     if t /= SupportTree
                       then
-                        concatMap (NE.toList . sortVertices brks thr t) (NE.toList groupsToSort)
+                        concatMap
+                          (NE.toList . sortVertices newNames brks thr t)
+                          (NE.toList groupsToSort)
                       else
                         concatMap NE.toList groupsToSort
                in case nonEmpty groupsSorted of
@@ -137,11 +140,12 @@ groupAnnotatedVertices brks g = do
   pure (treeType, [g])
 
 sortSupportVertices
-  :: XGroupBreakpoints
+  :: UpdateNamesMap
+  -> XGroupBreakpoints
   -> Scientific
   -> VertexForest
   -> VertexForest
-sortSupportVertices brks thr =
+sortSupportVertices newNames brks thr =
   M.update
     maybeNewTree
     SupportTree
@@ -149,7 +153,7 @@ sortSupportVertices brks thr =
     maybeNewTree (VertexTree topComments supportVertices) =
       let vertices =
             one
-              . sortVertices brks thr SupportTree
+              . sortVertices newNames brks thr SupportTree
               . sconcat
               $ supportVertices
        in Just
@@ -159,23 +163,24 @@ sortSupportVertices brks thr =
             )
 
 moveVerticesInVertexForest
-  :: XGroupBreakpoints
+  :: UpdateNamesMap
+  -> XGroupBreakpoints
   -> Scientific
   -> Double
   -> VertexForest
   -> VertexConnMap
   -> Either Text VertexForest
-moveVerticesInVertexForest brks thr supThr vertexTrees conns =
+moveVerticesInVertexForest newNames brks thr supThr vertexTrees conns =
   let allVertices = concatMap (NE.toList . sconcat . tAnnotatedVertices) vertexTrees
    in case mapM (groupAnnotatedVertices brks) allVertices of
         Just movableVertices' -> do
           let groupedVertices = M.fromListWith (++) movableVertices'
           newForest <-
             foldM
-              (addVertexTreeToForest brks thr supThr conns groupedVertices vertexTrees)
+              (addVertexTreeToForest newNames brks thr supThr conns groupedVertices vertexTrees)
               M.empty
               treesOrder
-          Right $ sortSupportVertices brks thr newForest
+          Right $ sortSupportVertices newNames brks thr newForest
         Nothing -> Left "invalid breakpoint"
 
 getVertexNamesInForest
@@ -287,46 +292,48 @@ renameVertexId treeType idx vertexPrefix =
    in vertexPrefix <> idx'
 
 assignNames
-  :: XGroupBreakpoints
+  :: UpdateNamesMap
+  -> XGroupBreakpoints
   -> VertexTreeType
   -> Map Text Int
   -> AnnotatedVertex
   -> (Map Text Int, AnnotatedVertex)
-assignNames brks treeType prefixMap av =
+assignNames newNames brks treeType prefixMap av =
   let v = aVertex av
+      updatedPrefix cleanPrefix' = M.findWithDefault cleanPrefix' cleanPrefix' newNames
       prefix = dropIndex (vName v)
       typeSpecific = maybe "" prefixForType (determineGroup brks v)
       (prefix', lastChar) = fromMaybe (error "unreachable") (T.unsnoc prefix)
-      prefix''
+      cleanPrefix
         | treeType /= SupportTree
             && T.length prefix >= 3
             && T.last prefix' == 's' =
-            T.init prefix' <> typeSpecific
+            updatedPrefix (T.init prefix') <> typeSpecific
         | treeType /= SupportTree
             && T.length prefix >= 3
-            && lastChar `elem` ['l', 'm', 'r']
-            || T.length prefix' >= 3 && T.last prefix' == 's' =
-            prefix' <> typeSpecific
+            && lastChar `elem` ['l', 'm', 'r'] =
+            updatedPrefix prefix' <> typeSpecific
         | treeType /= SupportTree =
-            prefix <> typeSpecific
-        | T.length prefix < 3 =
-            prefix <> one 's' <> typeSpecific
+            updatedPrefix prefix <> typeSpecific
+        | T.length prefix' >= 3
+            && T.last prefix' == 's' =
+            updatedPrefix (T.init prefix') <> one 's' <> typeSpecific
         | otherwise =
-            prefix' <> one 's' <> typeSpecific
-      curPrefix = dropIndex prefix''
-      lastIdx = M.findWithDefault 0 curPrefix prefixMap
-      newName = renameVertexId treeType lastIdx prefix''
+            updatedPrefix prefix <> one 's' <> typeSpecific
+      lastIdx = M.findWithDefault 0 cleanPrefix prefixMap
+      newName = renameVertexId treeType lastIdx cleanPrefix
       newVertex = v {vName = newName}
-      prefixMap' = M.insert curPrefix (lastIdx + 1) prefixMap
+      prefixMap' = M.insert cleanPrefix (lastIdx + 1) prefixMap
    in (prefixMap', av {aVertex = newVertex})
 
 sortVertices
-  :: XGroupBreakpoints
+  :: UpdateNamesMap
+  -> XGroupBreakpoints
   -> Scientific
   -> VertexTreeType
   -> NonEmpty AnnotatedVertex
   -> NonEmpty AnnotatedVertex
-sortVertices brks thr treeType groups =
+sortVertices newNames brks thr treeType groups =
   let groups' =
         if treeType /= SupportTree
           then
@@ -335,7 +342,7 @@ sortVertices brks thr treeType groups =
       sortedGroups = NE.sortBy (compareCG thr treeType) groups'
 
       renamedGroups =
-        snd $ mapAccumL (assignNames brks treeType) M.empty sortedGroups
+        snd $ mapAccumL (assignNames newNames brks treeType) M.empty sortedGroups
    in renamedGroups
 
 updateVerticesInNode
@@ -384,8 +391,8 @@ findAndUpdateTextInNode m cursor node =
     applyBreadcrumbAndUpdateText index =
       NC.applyCrumb (NC.ArrayIndex index) cursor (findAndUpdateTextInNode m)
 
-transform :: TransformationConfig -> Node -> Either Text Node
-transform (TransformationConfig sortThr brks supThr) topNode =
+transform :: UpdateNamesMap -> TransformationConfig -> Node -> Either Text Node
+transform newNames (TransformationConfig sortThr brks supThr) topNode =
   getVertexForest brks verticesQuery topNode
     >>= getNamesAndUpdateTree
   where
@@ -393,7 +400,7 @@ transform (TransformationConfig sortThr brks supThr) topNode =
     getNamesAndUpdateTree (globals, vertexForest) =
       let vertexNames = getVertexNamesInForest vertexForest
        in getVertexConns
-            >>= moveVerticesInVertexForest brks sortThr supThr vertexForest
+            >>= moveVerticesInVertexForest newNames brks sortThr supThr vertexForest
             >>= getUpdatedNamesAndUpdateGlobally globals vertexNames
     getUpdatedNamesAndUpdateGlobally globals oldVertexNames updatedVertexForest =
       let updatedVertexNames = getVertexNamesInForest updatedVertexForest

--- a/src-extra/transformation/Types.hs
+++ b/src-extra/transformation/Types.hs
@@ -6,6 +6,7 @@ module Types (
   AnnotatedVertex (..),
   MetaMap,
   VertexConnMap,
+  UpdateNamesMap,
 ) where
 
 import Core.Node
@@ -58,3 +59,5 @@ data AnnotatedVertex = AnnotatedVertex
 type MetaMap = Map Text Node
 
 type VertexConnMap = Map Text Int
+
+type UpdateNamesMap = Map Text Text

--- a/src-extra/transformation/VertexExtraction.hs
+++ b/src-extra/transformation/VertexExtraction.hs
@@ -101,7 +101,7 @@ isSupportVertex v =
     Nothing -> True
     Just (_, c) -> not (isDigit c)
 
-metaMapFromObject :: Node -> Map Text Node
+metaMapFromObject :: Node -> MetaMap
 metaMapFromObject (Object objKeys) =
   let toKV (ObjectKey (String k, v)) = Just (k, v)
       toKV _ = Nothing
@@ -119,7 +119,7 @@ addCommentToAn
 addCommentToAn ic (AnnotatedVertex comments vertex meta) = AnnotatedVertex (ic : comments) vertex meta
 
 nodesToCommentGroups
-  :: Map Text Node
+  :: MetaMap
   -> [Node]
   -> Either Text (NonEmpty AnnotatedVertex)
 nodesToCommentGroups initialMeta nodes = go initialMeta [] nodes []

--- a/src-extra/transformation/VertexExtraction.hs
+++ b/src-extra/transformation/VertexExtraction.hs
@@ -166,7 +166,7 @@ newVertexTree brks vertexNames vertexForest nodes =
             Right cgNe ->
               let firstCG = head cgNe
                   vertexTree = VertexTree topComments (one cgNe)
-               in case determineGroup brks (aVertex firstCG) of
+               in case determineGroup' brks (aVertex firstCG) of
                     Just treeType ->
                       let updatedForest = M.insertWith combineTrees treeType vertexTree vertexForest
                        in Right (vertexNames', treeType, vertexTree, updatedForest, rest')

--- a/src/CommandLineOptions.hs
+++ b/src/CommandLineOptions.hs
@@ -9,13 +9,14 @@ import Paths_jbeam_edit (version)
 import System.Console.GetOpt
 import System.Environment
 
+import Data.Map qualified as M
 import Data.Text qualified as T
 
 data Options = Options
   { optInPlace :: Bool
   , optCopyJbflConfig :: Maybe ConfigType
   , optInputFile :: Maybe FilePath
-  , optUpdateNames :: Maybe (Map Text Text)
+  , optUpdateNames :: Map Text Text
   }
   deriving (Show)
 
@@ -25,7 +26,7 @@ startOptions =
     { optInPlace = False
     , optInputFile = Nothing
     , optCopyJbflConfig = Nothing
-    , optUpdateNames = Nothing
+    , optUpdateNames = M.empty
     }
 
 parseOptions :: [String] -> IO Options
@@ -47,11 +48,10 @@ splitNames namePair =
     [orig, new] -> Just (orig, new)
     _ -> Nothing
 
-maybeNamesToUpdate :: String -> Maybe (Map Text Text)
-maybeNamesToUpdate names = do
+maybeNamesToUpdate :: String -> Map Text Text
+maybeNamesToUpdate names =
   let namesList = T.split (== ',') (toText names)
-  namePairs <- mapM splitNames namesList
-  pure $ fromList  namePairs
+   in maybe M.empty fromList (mapM splitNames namesList)
 
 options :: [OptDescr (Options -> IO Options)]
 options =
@@ -75,7 +75,7 @@ options =
           (\names opt -> pure opt {optUpdateNames = maybeNamesToUpdate names})
           "ORIGINAL_VERT_PREFIX:NEW_VERT_PREFIX,..."
       )
-      "Print version"
+      "Update vertex names"
   , Option
       "V"
       ["version"]

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -27,7 +27,7 @@ listFilesInDir
   :: FilePath
   -> IO [String]
 listFilesInDir dir =
-  filter (\f -> isSuffixOf ".hs" f && not (isPrefixOf ".#" f))
+  filter (\f -> isSuffixOf ".hs" f && not (".#" `isPrefixOf` f))
     <$> getDirectoryContents dir
 
 applySpecOnInput

--- a/test/TransformationSpec.hs
+++ b/test/TransformationSpec.hs
@@ -11,6 +11,7 @@ import Relude.Unsafe (read)
 import Transformation
 import Formatting
 import Config
+import Data.Map qualified as M
 
 topNodeSpec :: FilePath -> FilePath -> Spec
 topNodeSpec inFilename outFilename = do
@@ -19,7 +20,7 @@ topNodeSpec inFilename outFilename = do
   output <- runIO $ baseReadFile outFilename
   let desc = "should transform AST in " ++ inFilename ++ " to Jbeam in " ++ outFilename
   describe desc . works $
-    formatNode newRuleSet <$> transform newTransformationConfig (read input) `shouldBe` Right (toText output)
+    formatNode newRuleSet <$> transform M.empty newTransformationConfig (read input) `shouldBe` Right (toText output)
 
 spec :: Spec
 spec = do

--- a/tools/dump_ast/Main.hs
+++ b/tools/dump_ast/Main.hs
@@ -15,6 +15,7 @@ import System.FilePath (takeBaseName, (</>))
 import Text.Pretty.Simple (defaultOutputOptionsNoColor, pStringOpt)
 import Transformation
 
+import Data.Map qualified as M
 import System.IO qualified as IO (readFile)
 
 main :: IO ()
@@ -93,7 +94,7 @@ dumpTransformedJbeam jbeamInputAstDir outDir jbeamFile = do
     read <$> IO.readFile (jbeamInputAstDir </> (takeBaseName jbeamFile <> ".hs"))
   let outFilename = takeBaseName jbeamFile ++ ".jbeam"
   transformedJbeam <-
-    case transform newTransformationConfig jbeam of
+    case transform M.empty newTransformationConfig jbeam of
       Left err -> do
         putTextLn $ "error occurred during transformation" <> err
         exitFailure


### PR DESCRIPTION
Take a look at this JBeam from one of our example files:

```
        ["bfl0",0.959,-1.762,0.576],
        ["bfl1",0.855,-1.788,0.707],
        ["bfl2",0.739,-1.845,0.716],
        ["bfl3",0.948,-1.435,0.730],
```

In this example bfl is the prefix. The plan is to add support for updating all vertices with matching vertex prefixes to have a new vertex prefix provided by the user. 