### PR TITLE
Improve transformation error reporting and node validation

### DIFF
--- a/jbeam-edit.cabal
+++ b/jbeam-edit.cabal
@@ -66,6 +66,7 @@ library
         Core.Node
         Core.NodeCursor
         Core.NodePath
+        Core.Result
         Formatting
         Formatting.Config
         Formatting.Rules

--- a/src/Core/Result.hs
+++ b/src/Core/Result.hs
@@ -1,0 +1,14 @@
+module Core.Result (Result (..), mapResult) where
+
+data Result bad good = Empty | Bad bad | Good good
+
+mapResult
+  :: Foldable t
+  => (b -> Result a1 a2) -> t b -> ([a1], [a2])
+mapResult f = foldr f' ([], [])
+  where
+    f' val (bad, good) =
+      case f val of
+        Empty -> (bad, good)
+        Bad newBad -> (newBad : bad, good)
+        Good newGood -> (bad, newGood : good)

--- a/src/IOUtils.hs
+++ b/src/IOUtils.hs
@@ -1,12 +1,24 @@
-module IOUtils (tryReadFile) where
+module IOUtils (tryReadFile, putErrorLine, reportInvalidNodes) where
 
 import Control.Exception (IOException, try)
+import Core.Node (Node)
+import Formatting (formatNode, newRuleSet)
 import GHC.IO.Exception (IOErrorType, IOException (IOError))
+import System.IO (hPutStrLn)
 
 import Data.ByteString.Lazy qualified as BL (
   ByteString,
  )
 import Data.Text qualified as T (append)
+
+putErrorLine :: Text -> IO ()
+putErrorLine = hPutStrLn stderr . toString
+
+reportInvalidNodes :: Text -> [Node] -> IO ()
+reportInvalidNodes msg nodes =
+  unless (null nodes) $ do
+    putErrorLine msg
+    mapM_ (putErrorLine . formatNode newRuleSet) nodes
 
 ioErrorMsg
   :: [IOErrorType]

--- a/test/TransformationSpec.hs
+++ b/test/TransformationSpec.hs
@@ -19,8 +19,11 @@ topNodeSpec rs cfName tfConfig inFilename outFilename = do
   input <- runIO $ baseReadFile inputPath
   output <- runIO $ baseReadFile outFilename
   let desc = "with " ++ cfName ++ ": should transform AST in " ++ inFilename ++ " to Jbeam in " ++ outFilename
-  describe desc . works $
-    formatNode rs <$> transform M.empty tfConfig (read input) `shouldBe` Right (toText output)
+      transformAndFormat =
+          do
+            (_, _, node) <- transform M.empty tfConfig (read input)
+            Right (formatNode rs node)
+  describe desc . works $ transformAndFormat `shouldBe` Right (toText output)
 
 spec :: Spec
 spec = do

--- a/tools/dump_ast/Main.hs
+++ b/tools/dump_ast/Main.hs
@@ -122,7 +122,7 @@ dumpTransformedJbeam cfName tfConfig rsDirPath jbeamInputAstDir outDir jbeamFile
       Left err -> do
         putTextLn $ "error occurred during transformation" <> err
         exitFailure
-      Right jbeam' -> pure jbeam'
+      Right (_, _, jbeam') -> pure jbeam'
   dump outFilename (formatNode rs transformedJbeam)
   where
     dump filename contents =


### PR DESCRIPTION
- Introduce `Core.Result` type for collecting both valid and invalid nodes
- Update transformation pipeline to return invalid vertex and beam nodes
- Add `putErrorLine` and `reportInvalidNodes` in IOUtils for stderr reporting
- Propagate bad node tracking through VertexExtraction and SupportVertex modules
- Update Transformation logic to handle (badVertexNodes, badBeamNodes, Node)
- Add Core.Result to Cabal file for build inclusion