### PR TITLE
Add formatting for jbfl itself

### DIFF
--- a/jbeam-edit.cabal
+++ b/jbeam-edit.cabal
@@ -74,6 +74,7 @@ library
         Core.Result
         Formatting
         Formatting.Config
+        Formatting.RuleFormatting
         Formatting.Rules
         IOUtils
         Parsing.Common

--- a/src/Formatting/RuleFormatting.hs
+++ b/src/Formatting/RuleFormatting.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Formatting.RuleFormatting (
+  formatRuleSet,
+) where
+
+import Core.NodePath qualified as NP (NodeSelector (..))
+import Data.Map qualified as M
+import Data.Text qualified as T
+import Formatting.Rules
+
+formatNodeSelector :: NP.NodeSelector -> Text
+formatNodeSelector (NP.ArrayIndex i) = "[" <> show i <> "]"
+formatNodeSelector (NP.ObjectIndex i) = "." <> show i
+formatNodeSelector (NP.ObjectKey k) = "." <> show k
+
+formatNodePatternSelector :: NodePatternSelector -> Text
+formatNodePatternSelector AnyArrayIndex = "[*]"
+formatNodePatternSelector AnyObjectKey = ".*"
+formatNodePatternSelector (Selector s) = formatNodeSelector s
+
+formatNodePattern :: NodePattern -> Text
+formatNodePattern (NodePattern ps) = foldMap formatNodePatternSelector ps
+
+formatProperty :: SomeKey -> SomeProperty -> Text
+formatProperty _ (SomeProperty key val) = "  " <> propertyName key <> " : " <> show val <> ";\n"
+
+formatRuleSet :: RuleSet -> Text
+formatRuleSet (RuleSet rs) = T.intercalate "\n\n" (M.foldMapWithKey formatPatPropPair rs) <> "\n"
+  where
+    formatPatPropPair pat props = pure $ formatNodePattern pat <> "{\n" <> formatProps props <> "}"
+    formatProps = M.foldMapWithKey formatProperty

--- a/src/Formatting/Rules.hs
+++ b/src/Formatting/Rules.hs
@@ -19,6 +19,7 @@ module Formatting.Rules (
   comparePatternAndCursor,
   noComplexNewLine,
   lookupIndentProperty,
+  propertyName,
   newRuleSet,
   findPropertiesForCursor,
 ) where


### PR DESCRIPTION
I am a big fan tooling myself and since I added jbfl, a custom DSL, it would be really cool to be able pretty print the jbfl rule files. This will require me rewrite JBFL parsing a little to preserve comments.