### PR TITLE
Build with stack with experimental

### DIFF
--- a/.github/scripts/extract_resolver_and_flags_for_stack.sh
+++ b/.github/scripts/extract_resolver_and_flags_for_stack.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+CABAL_FILE="${CABAL_FILE:?Environment variable CABAL_FILE is required}"
+
+readarray -t EXP_FLAGS < <(awk -f ./.github/script_helpers/extract_flags.awk "$CABAL_FILE")
+
+echo "extracting experimental flags and setting them to true."
+echo "if this fails, please verify all flags in package.yaml are set to true/false in stack.yaml"
+for flag in "${EXP_FLAGS[@]}"; do
+  pattern="^( *${flag})[[:space:]]*:[[:space:]]*(true|false)"
+  grep -qE "${pattern}" stack.yaml
+  sed -i -E "s/${pattern}/\1: true/g" stack.yaml
+done
+
+echo "contents of stack.yaml file:"
+cat stack.yaml
+
+RESOLVER=$(grep -E '^(snapshot|resolver):' stack.yaml | awk '{ print $2 }')
+
+printf "\nchose resolver %s" "$RESOLVER"
+echo "resolver=$RESOLVER" >>"$GITHUB_OUTPUT"

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -34,9 +34,9 @@ jobs:
       - name: Extract resolver
         id: extract
         shell: bash
-        run: |
-          RESOLVER=$(grep -E '^(snapshot|resolver):' stack.yaml | awk '{ print $2 }')
-          echo "resolver=$RESOLVER" >> $GITHUB_OUTPUT
+        run: bash ./.github/scripts/extract_resolver_and_flags_for_stack.sh
+        env:
+          CABAL_FILE: jbeam-edit.cabal
       - name: Cache global Stack dependencies
         uses: actions/cache@v4.3.0
         with:
@@ -45,7 +45,7 @@ jobs:
             stack-global-${{ matrix.os }}-${{
               steps.extract.outputs.resolver
             }}-${{
-              hashFiles('stack.yaml.lock')
+              hashFiles('stack.yaml', '**/stack.yaml.lock')
             }}
           restore-keys: |
             stack-global-${{ matrix.os }}-${{ steps.extract.outputs.resolver }}-
@@ -58,7 +58,7 @@ jobs:
             stack-local-${{ matrix.os }}-${{
               steps.extract.outputs.resolver
             }}-${{
-              hashFiles('**/stack.yaml.lock', '**/package.yaml')
+              hashFiles('**/stack.yaml', '**/stack.yaml.lock', '**/package.yaml')
             }}
           restore-keys: |
             stack-local-${{ matrix.os }}-${{ steps.extract.outputs.resolver }}-

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,6 +3,7 @@ packages: [.]
 
 flags:
   jbeam-edit:
+    lsp-server: false
     transformation: false
     dump-ast: false
     windows-example-paths: false


### PR DESCRIPTION
- Introduced `.github/scripts/extract_resolver_and_flags_for_stack.sh` to:
  * Extract the Stack resolver from `stack.yaml`
  * Enable all experimental flags from the `.cabal` file in `stack.yaml`
- Updated GitHub Actions workflow `build-and-test.yaml` to use this script
  * Sets `CABAL_FILE` environment variable for the script
  * Updates cache keys to include `stack.yaml` and `package.yaml` changes
- Added `lsp-server: false` flag to `stack.yaml` for `jbeam-edit` package