### PR TITLE
Laxer bounds

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -181,9 +181,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cabal-${{ matrix.ghc }}-
       - name: Build project (GHC ${{ steps.setup-ghc.outputs.ghc-version }})
-        run: cabal build --project-file cabal.project.ci all
-      - name: Build LSP test server
         run: |
-          cabal install exe:jbeam-lsp-test-server --project-file cabal.project.ci || true
+          cabal build --project-file cabal.project.ci all
+          cabal install exe:jbeam-lsp-test-server --project-file cabal.project.ci
       - name: Run tests (GHC ${{ steps.setup-ghc.outputs.ghc-version }})
         run: cabal test --project-file cabal.project.ci

--- a/jbeam-edit.cabal
+++ b/jbeam-edit.cabal
@@ -94,15 +94,15 @@ library
 
     build-depends:
         base >=4.17 && <5,
-        bytestring >=0.12,
-        containers >=0.6,
-        directory >=1.3,
-        filepath >=1.4,
-        megaparsec >=9.6,
-        mtl >=2.3,
-        scientific >=0.3,
-        text >=2.1,
-        vector >=0.13
+        bytestring,
+        containers,
+        directory,
+        filepath,
+        megaparsec,
+        mtl,
+        scientific,
+        text >=2.0,
+        vector
 
     if flag(transformation)
         cpp-options: -DENABLE_TRANSFORMATION
@@ -130,16 +130,16 @@ library jbeam-edit-transformation
 
     build-depends:
         base >=4.17 && <5,
-        bytestring >=0.12,
-        containers >=0.6,
-        directory >=1.3,
-        filepath >=1.4,
+        bytestring,
+        containers,
+        directory,
+        filepath,
         jbeam-edit,
-        megaparsec >=9.6,
-        mtl >=2.3,
-        scientific >=0.3,
-        text >=2.1,
-        vector >=0.13
+        megaparsec,
+        mtl,
+        scientific,
+        text >=2.0,
+        vector
 
     mixins:
         base hiding (Prelude),
@@ -148,7 +148,7 @@ library jbeam-edit-transformation
 
     if flag(transformation)
         build-depends:
-            relude >=1.2,
+            relude,
             yaml
 
     else
@@ -172,26 +172,26 @@ library jbeam-language-server
 
     build-depends:
         base >=4.17 && <5,
-        bytestring >=0.12,
-        containers >=0.6,
-        directory >=1.3,
-        filepath >=1.4,
+        bytestring,
+        containers,
+        directory,
+        filepath,
         jbeam-edit,
-        megaparsec >=9.6,
-        mtl >=2.3,
-        scientific >=0.3,
-        text >=2.1,
-        vector >=0.13
+        megaparsec,
+        mtl,
+        scientific,
+        text >=2.0,
+        vector
 
     mixins:
         base hiding (Prelude),
         relude (Relude as Prelude),
         relude
 
-    if (flag(lsp-server) && impl(ghc >=9.6.6))
+    if flag(lsp-server)
         build-depends:
             lsp >=2.7,
-            relude >=1.2
+            relude
 
     else
         buildable: False
@@ -214,16 +214,16 @@ executable jbeam-edit
 
     build-depends:
         base >=4.17 && <5,
-        bytestring >=0.12,
-        containers >=0.6,
-        directory >=1.3,
-        filepath >=1.4,
+        bytestring,
+        containers,
+        directory,
+        filepath,
         jbeam-edit,
-        megaparsec >=9.6,
-        mtl >=2.3,
-        scientific >=0.3,
-        text >=2.1,
-        vector >=0.13
+        megaparsec,
+        mtl,
+        scientific,
+        text >=2.0,
+        vector
 
     if flag(transformation)
         cpp-options:   -DENABLE_TRANSFORMATION
@@ -247,21 +247,21 @@ executable jbeam-edit-dump-ast
 
     build-depends:
         base >=4.17 && <5,
-        bytestring >=0.12,
-        containers >=0.6,
-        directory >=1.3,
-        filepath >=1.4,
+        bytestring,
+        containers,
+        directory,
+        filepath,
         jbeam-edit,
-        megaparsec >=9.6,
-        mtl >=2.3,
-        scientific >=0.3,
-        text >=2.1,
-        vector >=0.13
+        megaparsec,
+        mtl,
+        scientific,
+        text >=2.0,
+        vector
 
     if (flag(dump-ast) && flag(transformation))
         build-depends:
             jbeam-edit-transformation,
-            pretty-simple >=4.1
+            pretty-simple >=2
 
     else
         buildable: False
@@ -281,18 +281,18 @@ executable jbeam-lsp-server
 
     build-depends:
         base >=4.17 && <5,
-        bytestring >=0.12,
-        containers >=0.6,
-        directory >=1.3,
-        filepath >=1.4,
+        bytestring,
+        containers,
+        directory,
+        filepath,
         jbeam-edit,
-        megaparsec >=9.6,
-        mtl >=2.3,
-        scientific >=0.3,
-        text >=2.1,
-        vector >=0.13
+        megaparsec,
+        mtl,
+        scientific,
+        text >=2.0,
+        vector
 
-    if (flag(lsp-server) && impl(ghc >=9.6.6))
+    if flag(lsp-server)
         build-depends: jbeam-language-server
 
     else
@@ -313,18 +313,18 @@ executable jbeam-lsp-test-server
 
     build-depends:
         base >=4.17 && <5,
-        bytestring >=0.12,
-        containers >=0.6,
-        directory >=1.3,
-        filepath >=1.4,
+        bytestring,
+        containers,
+        directory,
+        filepath,
         jbeam-edit,
-        megaparsec >=9.6,
-        mtl >=2.3,
-        scientific >=0.3,
-        text >=2.1,
-        vector >=0.13
+        megaparsec,
+        mtl,
+        scientific,
+        text >=2.0,
+        vector
 
-    if (flag(lsp-server) && impl(ghc >=9.6.6))
+    if flag(lsp-server)
         build-depends: jbeam-language-server
 
     else
@@ -357,20 +357,20 @@ test-suite jbeam-edit-test
 
     build-depends:
         base >=4.17 && <5,
-        bytestring >=0.12,
-        containers >=0.6,
-        directory >=1.3,
-        filepath >=1.4,
-        hspec >=2.11,
+        bytestring,
+        containers,
+        directory,
+        filepath,
+        hspec,
         jbeam-edit,
-        megaparsec >=9.6,
-        mtl >=2.3,
-        scientific >=0.3,
-        text >=2.1,
-        vector >=0.13
+        megaparsec,
+        mtl,
+        scientific,
+        text >=2.0,
+        vector
 
     if True
-        build-depends: hspec-megaparsec >=2.2
+        build-depends: hspec-megaparsec
 
 test-suite jbeam-edit-transformation-test
     type:               exitcode-stdio-1.0
@@ -388,17 +388,17 @@ test-suite jbeam-edit-transformation-test
 
     build-depends:
         base >=4.17 && <5,
-        bytestring >=0.12,
-        containers >=0.6,
-        directory >=1.3,
-        filepath >=1.4,
-        hspec >=2.11,
+        bytestring,
+        containers,
+        directory,
+        filepath,
+        hspec,
         jbeam-edit,
-        megaparsec >=9.6,
-        mtl >=2.3,
-        scientific >=0.3,
-        text >=2.1,
-        vector >=0.13
+        megaparsec,
+        mtl,
+        scientific,
+        text >=2.0,
+        vector
 
     if flag(transformation)
         build-depends: jbeam-edit-transformation
@@ -427,19 +427,19 @@ test-suite jbeam-language-server-test
 
     build-depends:
         base >=4.17 && <5,
-        bytestring >=0.12,
-        containers >=0.6,
-        directory >=1.3,
-        filepath >=1.4,
-        hspec >=2.11,
+        bytestring,
+        containers,
+        directory,
+        filepath,
+        hspec,
         jbeam-edit,
-        megaparsec >=9.6,
-        mtl >=2.3,
-        scientific >=0.3,
-        text >=2.1,
-        vector >=0.13
+        megaparsec,
+        mtl,
+        scientific,
+        text >=2.0,
+        vector
 
-    if (flag(lsp-server) && impl(ghc >=9.6.6))
+    if flag(lsp-server)
         build-depends:
             jbeam-language-server,
             lsp >=2.7,

--- a/package.yaml
+++ b/package.yaml
@@ -29,15 +29,15 @@ tested-with: [GHC == 9.4.7, GHC == 9.6.6]
 
 dependencies:
   - base >= 4.17 && < 5
-  - bytestring >= 0.12
-  - vector >= 0.13
-  - text >= 2.1
-  - containers >= 0.6
-  - megaparsec >= 9.6
-  - scientific >= 0.3
-  - directory >= 1.3
-  - filepath >= 1.4
-  - mtl >= 2.3
+  - bytestring
+  - vector
+  - text >= 2.0
+  - containers
+  - megaparsec
+  - scientific
+  - directory
+  - filepath
+  - mtl
 
 default-extensions: [OverloadedStrings, ImportQualifiedPost]
 
@@ -82,7 +82,7 @@ internal-libraries:
     when:
       condition: flag(transformation)
       then:
-        dependencies: [yaml, relude>=1.2]
+        dependencies: [yaml, relude]
       else:
         buildable: false
     source-dirs: src-extra/transformation
@@ -90,9 +90,9 @@ internal-libraries:
     <<: *jbeam-extra-lib
   jbeam-language-server:
     when:
-      condition: flag(lsp-server) && impl(ghc >= 9.6.6)
+      condition: flag(lsp-server)
       then:
-        dependencies: [lsp>=2.7, relude>=1.2]
+        dependencies: [lsp >= 2.7, relude]
       else:
         buildable: false
     source-dirs: src-extra/language-server
@@ -112,7 +112,7 @@ _jbeam-lsp-common: &jbeam-lsp-common
   main: Main.hs
   ghc-options: [-threaded, -rtsopts, -with-rtsopts=-N]
   when:
-    condition: flag(lsp-server) && impl(ghc >= 9.6.6)
+    condition: flag(lsp-server)
     then:
       dependencies: [jbeam-language-server]
     else:
@@ -141,7 +141,7 @@ executables:
     when:
       condition: (flag(dump-ast) && flag(transformation))
       then:
-        dependencies: [pretty-simple>=4.1, jbeam-edit-transformation]
+        dependencies: [pretty-simple>=2, jbeam-edit-transformation]
       else:
         buildable: false
     main: Main.hs
@@ -153,7 +153,7 @@ _jbeam-test-common: &jbeam-test-common
   main: Spec.hs
   ghc-options: [-threaded, -rtsopts, -with-rtsopts=-N]
   build-tools: [hspec-discover]
-  dependencies: [jbeam-edit, hspec>=2.11]
+  dependencies: [jbeam-edit, hspec]
 
 tests:
   jbeam-edit-test:
@@ -161,14 +161,14 @@ tests:
     source-dirs: test
     when:
       - condition: true
-        dependencies: [hspec-megaparsec>=2.2]
+        dependencies: [hspec-megaparsec]
   jbeam-language-server-test:
     <<: *jbeam-test-common
     source-dirs: test-extra/language-server
     when:
-      - condition: flag(lsp-server) && impl(ghc >= 9.6.6)
+      - condition: flag(lsp-server)
         then:
-          dependencies: [jbeam-language-server, lsp-test, lsp>=2.7]
+          dependencies: [jbeam-language-server, lsp-test, lsp >= 2.7]
         else:
           buildable: false
   jbeam-edit-transformation-test:


### PR DESCRIPTION
#### Summary
This PR simplifies the dependency specifications in `jbeam-edit.cabal` by removing unnecessary version constraints and adjusting some build flag conditions. This makes the build configuration more flexible and easier to maintain.