### PR TITLE
Preserve trailing commas

### DIFF
--- a/JBFL_DOCS.md
+++ b/JBFL_DOCS.md
@@ -37,27 +37,27 @@ Typical use cases include:
 
 | Pattern  | Description                                                                      |
 |----------|----------------------------------------------------------------------------------|
-| `.*`      | Matches **any key** at the current object level, regardless of name.             |
-| `[*]`     | Matches **all elements** in a list (1D array).                                   |
-| `[*][*]`  | Matches **all elements in the innermost lists** of 2D arrays (arrays of arrays). |
-| `.test`   | Matches the value with key `test` in an object.                                  |
-| `.test*`  | Matches any key that **starts with** `test` (prefix match).                      |
-| `.0`      | Matches the object child at positional index 0 (by order, ignoring key name).    |
-| `[4]`     | Matches the value at index 4 in an array.                                        |
+| `.*`     | Matches **any key** at the current object level, regardless of name.             |
+| `[*]`    | Matches **all elements** in a list (1D array).                                   |
+| `[*][*]` | Matches **all elements in the innermost lists** of 2D arrays (arrays of arrays). |
+| `.test`  | Matches the value with key `test` in an object.                                  |
+| `.test*` | Matches any key that **starts with** `test` (prefix match).                      |
+| `.0`     | Matches the object child at positional index 0 (by order, ignoring key name).    |
+| `[4]`    | Matches the value at index 4 in an array.                                        |
 
 ## Properties Overview
 
-| Setting Name          | Description                                                                                                                                                              | Applies To                      |
-|-----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------|
-| `PadDecimals`         | Adds trailing zeros only if the fractional part is shorter than `PadDecimals`, leaving existing extra decimals untouched. Guarantees a minimum number of decimal digits. | Numeric values                  |
-| `PadAmount`           | Specifies the **total length** (number of characters) the formatted value should occupy.                                                                                 | Any scalar except for comments  |
-| `AutoPad`             | Aligns values in array rows into columns by padding each cell to the maximum width in that column. Applies to the array it is set on (e.g. `nodes`, `beams`).            | Arrays of arrays                |
-| `AlignObjectKeys`     | Pads object keys so that `:` separators align vertically across all entries in the same object.                                                                          | Objects                         |
-| `AutoPadSubObjects`   | Aligns values within sibling inline objects by treating matching sub-keys as columns. Useful for `glowMap`-style structures.                                             | Objects with inline sub-objects |
-| `ComplexNewLine`      | Controls multiline formatting for complex structures. `None` disables it (inline output). `Force` always enables it. Replaces the deprecated `NoComplexNewLine` and `ForceComplexNewLine` properties. | Any complex data structure      |
-| `PreserveNumberFormat` | Outputs numbers exactly as written in the source file instead of normalizing them. Useful for preserving intentional formatting like `+1` or `0.002` vs `2.0e-3`.       | Numeric values                  |
-| `Indent`              | Controls the amount of indentation. Defaults to 4 spaces.                                                                                                                | Any complex data structure      |
-| `TrailingComma`       | Controls trailing commas. `Preserve` keeps the source value (default). `Force` always adds one. `None` always removes them. Resolved at the child level, so `.*` covers root. | Arrays and objects              |
+| Setting Name           | Description                                                                                                                                                                                           | Applies To                      |
+|------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------|
+| `PadDecimals`          | Adds trailing zeros only if the fractional part is shorter than `PadDecimals`, leaving existing extra decimals untouched. Guarantees a minimum number of decimal digits.                              | Numeric values                  |
+| `PadAmount`            | Specifies the **total length** (number of characters) the formatted value should occupy.                                                                                                              | Any scalar except for comments  |
+| `AutoPad`              | Aligns values in array rows into columns by padding each cell to the maximum width in that column. Applies to the array it is set on (e.g. `nodes`, `beams`).                                         | Arrays of arrays                |
+| `AlignObjectKeys`      | Pads object keys so that `:` separators align vertically across all entries in the same object.                                                                                                       | Objects                         |
+| `AutoPadSubObjects`    | Aligns values within sibling inline objects by treating matching sub-keys as columns. Useful for `glowMap`-style structures.                                                                          | Objects with inline sub-objects |
+| `ComplexNewLine`       | Controls multiline formatting for complex structures. `None` disables it (inline output). `Force` always enables it. Replaces the deprecated `NoComplexNewLine` and `ForceComplexNewLine` properties. | Any complex data structure      |
+| `PreserveNumberFormat` | Outputs numbers exactly as written in the source file instead of normalizing them. Useful for preserving intentional formatting like `+1` or `0.002` vs `2.0e-3`.                                     | Numeric values                  |
+| `Indent`               | Controls the amount of indentation. Defaults to 4 spaces.                                                                                                                                             | Any complex data structure      |
+| `TrailingComma`        | Controls trailing commas. `Preserve` keeps the source value (default). `Force` always adds one. `None` always removes them. Resolved at the child level, so `.*` covers root.                         | Arrays and objects              |
 
 ## How Matching Works
 

--- a/JBFL_DOCS.md
+++ b/JBFL_DOCS.md
@@ -56,7 +56,8 @@ Typical use cases include:
 | `AutoPadSubObjects`   | Aligns values within sibling inline objects by treating matching sub-keys as columns. Useful for `glowMap`-style structures.                                             | Objects with inline sub-objects |
 | `ComplexNewLine`      | Controls multiline formatting for complex structures. `None` disables it (inline output). `Force` always enables it. Replaces the deprecated `NoComplexNewLine` and `ForceComplexNewLine` properties. | Any complex data structure      |
 | `PreserveNumberFormat` | Outputs numbers exactly as written in the source file instead of normalizing them. Useful for preserving intentional formatting like `+1` or `0.002` vs `2.0e-3`.       | Numeric values                  |
-| `Indent`              | Controls the amount of indentation. Defaults to 4 spaces.                                                                                                               | Any complex data structure      |
+| `Indent`              | Controls the amount of indentation. Defaults to 4 spaces.                                                                                                                | Any complex data structure      |
+| `TrailingComma`       | Controls trailing commas. `Preserve` keeps the source value (default). `Force` always adds one. `None` always removes them. Resolved at the child level, so `.*` covers root. | Arrays and objects              |
 
 ## How Matching Works
 
@@ -70,6 +71,8 @@ Typical use cases include:
 - `ComplexNewLine: Force` ensures that matched complex structures are always output in multiline format with indentation.
 - `ComplexNewLine: None` keeps structures inline even when they contain nested arrays or objects.
 - The deprecated `NoComplexNewLine: true` and `ForceComplexNewLine: true` are still accepted for backward compatibility.
+- `TrailingComma: None` strips trailing commas. `Force` always adds them. `Preserve` (default) keeps whatever the source file had.
+- `TrailingComma` is resolved at the child level, so `.* { TrailingComma: None; }` also strips the trailing comma in the root object.
 
 ## Detailed Rules Examples
 

--- a/examples/ast/jbeam/fender.hs
+++ b/examples/ast/jbeam/fender.hs
@@ -1,3112 +1,5168 @@
 Object
     ( ObjectValue
         { ovElements =
-            [ ObjectKey
-                ( String "cot_fender"
-                , Object
-                    ( ObjectValue
-                        { ovElements =
-                            [ ObjectKey
-                                ( String "information"
-                                , Object
-                                    ( ObjectValue
-                                        { ovElements =
-                                            [ ObjectKey
-                                                ( String "authors"
-                                                , String "gittarrgy01"
-                                                )
-                                            , ObjectKey
-                                                ( String "name"
-                                                , String "Fenders"
-                                                )
-                                            ]
-                                        , ovTrailingComma = True
-                                        }
+            [
+                ( ObjectKey
+                    ( String "cot_fender"
+                    , Object
+                        ( ObjectValue
+                            { ovElements =
+                                [
+                                    ( ObjectKey
+                                        ( String "information"
+                                        , Object
+                                            ( ObjectValue
+                                                { ovElements =
+                                                    [
+                                                        ( ObjectKey
+                                                            ( String "authors"
+                                                            , String "gittarrgy01"
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( ObjectKey
+                                                            ( String "name"
+                                                            , String "Fenders"
+                                                            )
+                                                        , True
+                                                        )
+                                                    ]
+                                                }
+                                            )
+                                        )
+                                    , True
                                     )
-                                )
-                            , ObjectKey
-                                ( String "sounds"
-                                , Object
-                                    ( ObjectValue
-                                        { ovElements =
-                                            [ ObjectKey
-                                                ( String "impactMetal"
-                                                , String "event:>Destruction>Props>fender_metal"
-                                                )
-                                            , ObjectKey
-                                                ( String "impactGeneric"
-                                                , String "event:>Destruction>Props>fender_generic"
-                                                )
-                                            , ObjectKey
-                                                ( String "breakGeneric"
-                                                , String "event:>Destruction>Props>fender_break"
-                                                )
-                                            , ObjectKey
-                                                ( String "wind"
-                                                , Bool False
-                                                )
-                                            , ObjectKey
-                                                ( String "scrapeMetal"
-                                                , Bool False
-                                                )
-                                            , ObjectKey
-                                                ( String "scrapePlastic"
-                                                , Bool False
-                                                )
-                                            ]
-                                        , ovTrailingComma = False
-                                        }
-                                    )
-                                )
-                            , ObjectKey
-                                ( String "slotType"
-                                , String "cot_fender"
-                                )
-                            , ObjectKey
-                                ( String "nodes"
-                                , Array
-                                    ( ArrayValue
-                                        { avElements =
-                                            [ Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "id"
-                                                        , String "posX"
-                                                        , String "posY"
-                                                        , String "posZ"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "nodeWeight"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "0.65"
-                                                                    , nvValue = 0.65
-                                                                    }
-                                                                )
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "frictionCoef"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "0.7"
-                                                                    , nvValue = 0.7
-                                                                    }
-                                                                )
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "nodeMaterial"
-                                                            , String "|NM_METAL"
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "collision"
-                                                            , Bool True
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "selfCollision"
-                                                            , Bool True
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "Left side"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = True
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "group"
-                                                            , String "cot_fender_l"
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl0"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.959"
-                                                                , nvValue = 0.959
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-1.762"
-                                                                , nvValue = -1.762
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.576"
-                                                                , nvValue = 0.576
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl1"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.855"
-                                                                , nvValue = 0.855
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-1.788"
-                                                                , nvValue = -1.788
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.707"
-                                                                , nvValue = 0.707
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl2"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.739"
-                                                                , nvValue = 0.739
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-1.845"
-                                                                , nvValue = -1.845
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.716"
-                                                                , nvValue = 0.716
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl3"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.948"
-                                                                , nvValue = 0.948
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-1.435"
-                                                                , nvValue = -1.435
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.730"
-                                                                , nvValue = 0.73
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl4"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.756"
-                                                                , nvValue = 0.756
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-1.413"
-                                                                , nvValue = -1.413
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.843"
-                                                                , nvValue = 0.843
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl5"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.963"
-                                                                , nvValue = 0.963
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-1.024"
-                                                                , nvValue = -1.024
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.112"
-                                                                , nvValue = 0.112
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl6"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.964"
-                                                                , nvValue = 0.964
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-1.072"
-                                                                , nvValue = -1.072
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.507"
-                                                                , nvValue = 0.507
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl7"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.778"
-                                                                , nvValue = 0.778
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-1.008"
-                                                                , nvValue = -1.008
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.873"
-                                                                , nvValue = 0.873
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl8"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.987"
-                                                                , nvValue = 0.987
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.743"
-                                                                , nvValue = -0.743
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.109"
-                                                                , nvValue = 0.109
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl9"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.987"
-                                                                , nvValue = 0.987
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.744"
-                                                                , nvValue = -0.744
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.494"
-                                                                , nvValue = 0.494
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl10"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.812"
-                                                                , nvValue = 0.812
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.759"
-                                                                , nvValue = -0.759
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.896"
-                                                                , nvValue = 0.896
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "Right side"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = True
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "group"
-                                                            , String "cot_fender_r"
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr0"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.906"
-                                                                , nvValue = -0.906
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-1.737"
-                                                                , nvValue = -1.737
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.578"
-                                                                , nvValue = 0.578
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr1"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.807"
-                                                                , nvValue = -0.807
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-1.769"
-                                                                , nvValue = -1.769
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.707"
-                                                                , nvValue = 0.707
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr2"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.691"
-                                                                , nvValue = -0.691
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-1.829"
-                                                                , nvValue = -1.829
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.716"
-                                                                , nvValue = 0.716
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr3"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.890"
-                                                                , nvValue = -0.89
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-1.409"
-                                                                , nvValue = -1.409
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.729"
-                                                                , nvValue = 0.729
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr4"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.700"
-                                                                , nvValue = -0.7
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-1.397"
-                                                                , nvValue = -1.397
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.843"
-                                                                , nvValue = 0.843
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr5"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.899"
-                                                                , nvValue = -0.899
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-1.005"
-                                                                , nvValue = -1.005
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.112"
-                                                                , nvValue = 0.112
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr6"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.900"
-                                                                , nvValue = -0.9
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-1.053"
-                                                                , nvValue = -1.053
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.508"
-                                                                , nvValue = 0.508
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr7"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.715"
-                                                                , nvValue = -0.715
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.991"
-                                                                , nvValue = -0.991
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.873"
-                                                                , nvValue = 0.873
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr8"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.916"
-                                                                , nvValue = -0.916
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.742"
-                                                                , nvValue = -0.742
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.112"
-                                                                , nvValue = 0.112
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr9"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.917"
-                                                                , nvValue = -0.917
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.746"
-                                                                , nvValue = -0.746
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.494"
-                                                                , nvValue = 0.494
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr10"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.734"
-                                                                , nvValue = -0.734
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.746"
-                                                                , nvValue = -0.746
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.888"
-                                                                , nvValue = 0.888
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "Support nodes"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = True
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "collision"
+                                ,
+                                    ( ObjectKey
+                                        ( String "sounds"
+                                        , Object
+                                            ( ObjectValue
+                                                { ovElements =
+                                                    [
+                                                        ( ObjectKey
+                                                            ( String "impactMetal"
+                                                            , String "event:>Destruction>Props>fender_metal"
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( ObjectKey
+                                                            ( String "impactGeneric"
+                                                            , String "event:>Destruction>Props>fender_generic"
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( ObjectKey
+                                                            ( String "breakGeneric"
+                                                            , String "event:>Destruction>Props>fender_break"
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( ObjectKey
+                                                            ( String "wind"
                                                             , Bool False
                                                             )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "selfCollision"
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( ObjectKey
+                                                            ( String "scrapeMetal"
                                                             , Bool False
                                                             )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "nodeWeight"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "1.2"
-                                                                    , nvValue = 1.2
-                                                                    }
-                                                                )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( ObjectKey
+                                                            ( String "scrapePlastic"
+                                                            , Bool False
                                                             )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "group"
-                                                            , String ""
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfsl"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.684"
-                                                                , nvValue = 0.684
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-1.079"
-                                                                , nvValue = -1.079
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.507"
-                                                                , nvValue = 0.507
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfsr"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.623"
-                                                                , nvValue = -0.623
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-1.064"
-                                                                , nvValue = -1.064
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.507"
-                                                                , nvValue = 0.507
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            ]
-                                        , avTrailingComma = True
-                                        }
+                                                        , False
+                                                        )
+                                                    ]
+                                                }
+                                            )
+                                        )
+                                    , True
                                     )
-                                )
-                            , ObjectKey
-                                ( String "beams"
-                                , Array
-                                    ( ArrayValue
-                                        { avElements =
-                                            [ Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "id1:"
-                                                        , String "id2:"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "Structural beams"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "beamSpring: 451000, beamDamp: 50"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "beamStrength: FLT_MAX"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = False
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "beamType"
-                                                            , String "|NORMAL"
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "beamSpring"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "451000"
-                                                                    , nvValue = 451000.0
-                                                                    }
-                                                                )
-                                                            )
-                                                        , ObjectKey
-                                                            ( String "beamDamp"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "50"
-                                                                    , nvValue = 50.0
-                                                                    }
-                                                                )
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "beamStrength"
-                                                            , String "FLT_MAX"
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "deformLimitExpansion"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "1.1"
-                                                                    , nvValue = 1.1
-                                                                    }
-                                                                )
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "beamDeform"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "6000"
-                                                                    , nvValue = 6000.0
-                                                                    }
-                                                                )
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "Front"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = True
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr2"
-                                                        , String "bfr4"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr2"
-                                                        , String "bfr1"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr1"
-                                                        , String "bfr4"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl4"
-                                                        , String "bfl2"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl2"
-                                                        , String "bfl1"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl0"
-                                                        , String "bfl1"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl4"
-                                                        , String "bfl3"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl0"
-                                                        , String "bfl3"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr1"
-                                                        , String "bfr0"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr4"
-                                                        , String "bfr3"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr0"
-                                                        , String "bfr3"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl4"
-                                                        , String "bfl1"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "Middle"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = True
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "beamDeform"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "12000"
-                                                                    , nvValue = 12000.0
-                                                                    }
-                                                                )
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl6"
-                                                        , String "bfl3"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr6"
-                                                        , String "bfr3"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl4"
-                                                        , String "bfl7"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr4"
-                                                        , String "bfr7"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "Rear"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = True
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl7"
-                                                        , String "bfl10"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl5"
-                                                        , String "bfl6"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl7"
-                                                        , String "bfl6"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl5"
-                                                        , String "bfl8"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl6"
-                                                        , String "bfl9"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl8"
-                                                        , String "bfl9"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl10"
-                                                        , String "bfl9"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr7"
-                                                        , String "bfr10"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr6"
-                                                        , String "bfr5"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr6"
-                                                        , String "bfr7"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr5"
-                                                        , String "bfr8"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr6"
-                                                        , String "bfr9"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr8"
-                                                        , String "bfr9"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr10"
-                                                        , String "bfr9"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "Crossing beams"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = True
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "deformLimitExpansion"
-                                                            , String ""
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "Front"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl0"
-                                                        , String "bfl4"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl4"
-                                                        , String "bfl6"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl7"
-                                                        , String "bfl3"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr4"
-                                                        , String "bfr6"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr7"
-                                                        , String "bfr3"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl1"
-                                                        , String "bfl3"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr3"
-                                                        , String "bfr1"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr4"
-                                                        , String "bfr0"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "Rear"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = True
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl6"
-                                                        , String "bfl10"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl7"
-                                                        , String "bfl9"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl5"
-                                                        , String "bfl9"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl6"
-                                                        , String "bfl8"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr6"
-                                                        , String "bfr10"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr7"
-                                                        , String "bfr9"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr5"
-                                                        , String "bfr9"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr6"
-                                                        , String "bfr8"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "Support beams"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = True
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl2"
-                                                        , String "bfsl"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl6"
-                                                        , String "bfsl"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl5"
-                                                        , String "bfsl"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl3"
-                                                        , String "bfsl"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl0"
-                                                        , String "bfsl"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl1"
-                                                        , String "bfsl"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl4"
-                                                        , String "bfsl"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl7"
-                                                        , String "bfsl"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl8"
-                                                        , String "bfsl"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl9"
-                                                        , String "bfsl"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl10"
-                                                        , String "bfsl"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr2"
-                                                        , String "bfsr"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr6"
-                                                        , String "bfsr"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr5"
-                                                        , String "bfsr"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr3"
-                                                        , String "bfsr"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr0"
-                                                        , String "bfsr"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr1"
-                                                        , String "bfsr"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr4"
-                                                        , String "bfsr"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr7"
-                                                        , String "bfsr"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr8"
-                                                        , String "bfsr"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr9"
-                                                        , String "bfsr"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr10"
-                                                        , String "bfsr"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "Front rigid"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = True
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "beamSpring"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "350000"
-                                                                    , nvValue = 350000.0
-                                                                    }
-                                                                )
-                                                            )
-                                                        , ObjectKey
-                                                            ( String "beamDamp"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "115"
-                                                                    , nvValue = 115.0
-                                                                    }
-                                                                )
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "beamDeform"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "900"
-                                                                    , nvValue = 900.0
-                                                                    }
-                                                                )
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "Left side"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = True
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl3"
-                                                        , String "bfl9"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl4"
-                                                        , String "bfl10"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "Right side"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = True
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr3"
-                                                        , String "bfr9"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr4"
-                                                        , String "bfr10"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "Attachment beams"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = True
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "beamType"
-                                                            , String "|NORMAL"
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "beamSpring"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "501000"
-                                                                    , nvValue = 501000.0
-                                                                    }
-                                                                )
-                                                            )
-                                                        , ObjectKey
-                                                            ( String "beamDamp"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "75"
-                                                                    , nvValue = 75.0
-                                                                    }
-                                                                )
-                                                            )
-                                                        , ObjectKey
-                                                            ( String "beamStrength"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "20000"
-                                                                    , nvValue = 20000.0
-                                                                    }
-                                                                )
-                                                            )
-                                                        , ObjectKey
-                                                            ( String "beamDeform"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "1000"
-                                                                    , nvValue = 1000.0
-                                                                    }
-                                                                )
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "deformLimitExpansion"
-                                                            , String ""
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "Frame"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = True
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "Left side"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = True
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "Front"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = True
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "breakGroup"
-                                                            , String "fender_l"
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "breakGroupType"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "1"
-                                                                    , nvValue = 1.0
-                                                                    }
-                                                                )
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl0"
-                                                        , String "fr17"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl0"
-                                                        , String "fr9"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl1"
-                                                        , String "fr17"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl1"
-                                                        , String "fr9"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl2"
-                                                        , String "fr17"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl2"
-                                                        , String "fr9"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "Middle"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = True
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "beamDeform"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "18000"
-                                                                    , nvValue = 18000.0
-                                                                    }
-                                                                )
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "beamStrength"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "4000"
-                                                                    , nvValue = 4000.0
-                                                                    }
-                                                                )
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "breakGroupType"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "1"
-                                                                    , nvValue = 1.0
-                                                                    }
-                                                                )
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl3"
-                                                        , String "fr17"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl4"
-                                                        , String "fr17"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl4"
-                                                        , String "fr9"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "breakGroupType"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "0"
-                                                                    , nvValue = 0.0
-                                                                    }
-                                                                )
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "Rear"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = True
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "beamStrength"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "16000"
-                                                                    , nvValue = 16000.0
-                                                                    }
-                                                                )
-                                                            )
-                                                        , ObjectKey
-                                                            ( String "beamDeform"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "12000"
-                                                                    , nvValue = 12000.0
-                                                                    }
-                                                                )
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl5"
-                                                        , String "fr18"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl5"
-                                                        , String "fr27"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl6"
-                                                        , String "fr17"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl6"
-                                                        , String "fr21"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl7"
-                                                        , String "fr17"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl7"
-                                                        , String "fr29"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl8"
-                                                        , String "fr18"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl8"
-                                                        , String "fr27"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl9"
-                                                        , String "fr28"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl9"
-                                                        , String "fr21"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl10"
-                                                        , String "fr17"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl10"
-                                                        , String "fr29"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "Right side"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = True
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "Front"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = True
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "beamStrength"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "20000"
-                                                                    , nvValue = 20000.0
-                                                                    }
-                                                                )
-                                                            )
-                                                        , ObjectKey
-                                                            ( String "beamDeform"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "1000"
-                                                                    , nvValue = 1000.0
-                                                                    }
-                                                                )
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "breakGroup"
-                                                            , String "fender_r"
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "breakGroupType"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "1"
-                                                                    , nvValue = 1.0
-                                                                    }
-                                                                )
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl0"
-                                                        , String "rl_f8"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl0"
-                                                        , String "rl_f6"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl1"
-                                                        , String "rl_f6"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl2"
-                                                        , String "rl_f6"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr0"
-                                                        , String "rl_f9"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr0"
-                                                        , String "rl_f7"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr1"
-                                                        , String "rl_f7"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr2"
-                                                        , String "rl_f7"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "Middle"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = True
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "beamDeform"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "18000"
-                                                                    , nvValue = 18000.0
-                                                                    }
-                                                                )
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "beamStrength"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "4000"
-                                                                    , nvValue = 4000.0
-                                                                    }
-                                                                )
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "breakGroupType"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "1"
-                                                                    , nvValue = 1.0
-                                                                    }
-                                                                )
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl3"
-                                                        , String "rl_f10"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl3"
-                                                        , String "rl_f11"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl4"
-                                                        , String "rl_f11"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr3"
-                                                        , String "rl_f12"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr3"
-                                                        , String "rl_f13"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr4"
-                                                        , String "rl_f13"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "breakGroupType"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "0"
-                                                                    , nvValue = 0.0
-                                                                    }
-                                                                )
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "Rear"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = True
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "beamStrength"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "16000"
-                                                                    , nvValue = 16000.0
-                                                                    }
-                                                                )
-                                                            )
-                                                        , ObjectKey
-                                                            ( String "beamDeform"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "12000"
-                                                                    , nvValue = 12000.0
-                                                                    }
-                                                                )
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl5"
-                                                        , String "rl_f15"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl5"
-                                                        , String "rl_f16"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl6"
-                                                        , String "rl_f15"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl6"
-                                                        , String "rl_f16"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl8"
-                                                        , String "rl_f15"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl8"
-                                                        , String "rl_f16"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl9"
-                                                        , String "rl_f15"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl9"
-                                                        , String "rl_f16"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl7"
-                                                        , String "rl_f16"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl10"
-                                                        , String "rl_f16"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr5"
-                                                        , String "rl_f17"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr5"
-                                                        , String "rl_f18"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr6"
-                                                        , String "rl_f17"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr6"
-                                                        , String "rl_f18"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr8"
-                                                        , String "rl_f17"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr8"
-                                                        , String "rl_f18"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr9"
-                                                        , String "rl_f17"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr9"
-                                                        , String "rl_f18"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr7"
-                                                        , String "rl_f18"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr10"
-                                                        , String "rl_f18"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "beamStrength"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "16000"
-                                                                    , nvValue = 16000.0
-                                                                    }
-                                                                )
-                                                            )
-                                                        , ObjectKey
-                                                            ( String "beamDeform"
-                                                            , String "FLT_MAX"
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "Body"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "Left side"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = True
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "breakGroup"
-                                                            , String "fender_l"
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl8"
-                                                        , String "mbl0"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl9"
-                                                        , String "mbl1"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl10"
-                                                        , String "mbl2"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "Right side"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = True
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "breakGroup"
-                                                            , String "fender_r"
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr8"
-                                                        , String "mbr0"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr9"
-                                                        , String "mbr1"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr10"
-                                                        , String "mbr2"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "breakGroup"
-                                                            , String ""
-                                                            )
-                                                        , ObjectKey
-                                                            ( String "breakGroupType"
-                                                            , String ""
-                                                            )
-                                                        , ObjectKey
-                                                            ( String "beamType"
-                                                            , String "|NORMAL"
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            ]
-                                        , avTrailingComma = True
-                                        }
+                                ,
+                                    ( ObjectKey
+                                        ( String "slotType"
+                                        , String "cot_fender"
+                                        )
+                                    , True
                                     )
-                                )
-                            , ObjectKey
-                                ( String "triangles"
-                                , Array
-                                    ( ArrayValue
-                                        { avElements =
-                                            [ Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "id1:"
-                                                        , String "id2:"
-                                                        , String "id3:"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl3"
-                                                        , String "bfl4"
-                                                        , String "bfl1"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl0"
-                                                        , String "bfl3"
-                                                        , String "bfl1"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl4"
-                                                        , String "bfl2"
-                                                        , String "bfl1"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl4"
-                                                        , String "bfl3"
-                                                        , String "bfl7"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl6"
-                                                        , String "bfl7"
-                                                        , String "bfl3"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl10"
-                                                        , String "bfl7"
-                                                        , String "bfl6"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl9"
-                                                        , String "bfl10"
-                                                        , String "bfl6"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl5"
-                                                        , String "bfl8"
-                                                        , String "bfl6"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfl9"
-                                                        , String "bfl6"
-                                                        , String "bfl8"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr4"
-                                                        , String "bfr1"
-                                                        , String "bfr2"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr3"
-                                                        , String "bfr1"
-                                                        , String "bfr4"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr0"
-                                                        , String "bfr1"
-                                                        , String "bfr3"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr6"
-                                                        , String "bfr3"
-                                                        , String "bfr7"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr4"
-                                                        , String "bfr7"
-                                                        , String "bfr3"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr10"
-                                                        , String "bfr6"
-                                                        , String "bfr7"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr9"
-                                                        , String "bfr6"
-                                                        , String "bfr10"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr9"
-                                                        , String "bfr8"
-                                                        , String "bfr6"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "bfr5"
-                                                        , String "bfr6"
-                                                        , String "bfr8"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            ]
-                                        , avTrailingComma = True
-                                        }
-                                    )
-                                )
-                            , ObjectKey
-                                ( String "flexbodies"
-                                , Array
-                                    ( ArrayValue
-                                        { avElements =
-                                            [ Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "mesh"
-                                                        , String "[group]:"
-                                                        , String "nonFlexMaterials"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "impala_fender_l"
-                                                        , Array
+                                ,
+                                    ( ObjectKey
+                                        ( String "nodes"
+                                        , Array
+                                            ( ArrayValue
+                                                { avElements =
+                                                    [
+                                                        ( Array
                                                             ( ArrayValue
                                                                 { avElements =
-                                                                    [ String "cot_fender_l" ]
-                                                                , avTrailingComma = False
+                                                                    [
+                                                                        ( String "id"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "posX"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "posY"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "posZ"
+                                                                        , False
+                                                                        )
+                                                                    ]
                                                                 }
                                                             )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "impala_fender_inter_l"
-                                                        , Array
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "nodeWeight"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "0.65"
+                                                                                    , nvValue = 0.65
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "frictionCoef"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "0.7"
+                                                                                    , nvValue = 0.7
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "nodeMaterial"
+                                                                            , String "|NM_METAL"
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "collision"
+                                                                            , Bool True
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "selfCollision"
+                                                                            , Bool True
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "Left side"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = True
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "group"
+                                                                            , String "cot_fender_l"
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
                                                             ( ArrayValue
                                                                 { avElements =
-                                                                    [ String "cot_fender_l" ]
-                                                                , avTrailingComma = False
+                                                                    [
+                                                                        ( String "bfl0"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.959"
+                                                                                , nvValue = 0.959
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-1.762"
+                                                                                , nvValue = -1.762
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.576"
+                                                                                , nvValue = 0.576
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
                                                                 }
                                                             )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "impala_fender_r"
-                                                        , Array
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
                                                             ( ArrayValue
                                                                 { avElements =
-                                                                    [ String "cot_fender_r" ]
-                                                                , avTrailingComma = False
+                                                                    [
+                                                                        ( String "bfl1"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.855"
+                                                                                , nvValue = 0.855
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-1.788"
+                                                                                , nvValue = -1.788
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.707"
+                                                                                , nvValue = 0.707
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
                                                                 }
                                                             )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "impala_fender_inter_r"
-                                                        , Array
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
                                                             ( ArrayValue
                                                                 { avElements =
-                                                                    [ String "cot_fender_r" ]
-                                                                , avTrailingComma = False
+                                                                    [
+                                                                        ( String "bfl2"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.739"
+                                                                                , nvValue = 0.739
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-1.845"
+                                                                                , nvValue = -1.845
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.716"
+                                                                                , nvValue = 0.716
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
                                                                 }
                                                             )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            ]
-                                        , avTrailingComma = True
-                                        }
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl3"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.948"
+                                                                                , nvValue = 0.948
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-1.435"
+                                                                                , nvValue = -1.435
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.730"
+                                                                                , nvValue = 0.73
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl4"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.756"
+                                                                                , nvValue = 0.756
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-1.413"
+                                                                                , nvValue = -1.413
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.843"
+                                                                                , nvValue = 0.843
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl5"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.963"
+                                                                                , nvValue = 0.963
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-1.024"
+                                                                                , nvValue = -1.024
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.112"
+                                                                                , nvValue = 0.112
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl6"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.964"
+                                                                                , nvValue = 0.964
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-1.072"
+                                                                                , nvValue = -1.072
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.507"
+                                                                                , nvValue = 0.507
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl7"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.778"
+                                                                                , nvValue = 0.778
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-1.008"
+                                                                                , nvValue = -1.008
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.873"
+                                                                                , nvValue = 0.873
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl8"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.987"
+                                                                                , nvValue = 0.987
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.743"
+                                                                                , nvValue = -0.743
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.109"
+                                                                                , nvValue = 0.109
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl9"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.987"
+                                                                                , nvValue = 0.987
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.744"
+                                                                                , nvValue = -0.744
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.494"
+                                                                                , nvValue = 0.494
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl10"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.812"
+                                                                                , nvValue = 0.812
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.759"
+                                                                                , nvValue = -0.759
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.896"
+                                                                                , nvValue = 0.896
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "Right side"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = True
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "group"
+                                                                            , String "cot_fender_r"
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr0"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.906"
+                                                                                , nvValue = -0.906
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-1.737"
+                                                                                , nvValue = -1.737
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.578"
+                                                                                , nvValue = 0.578
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr1"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.807"
+                                                                                , nvValue = -0.807
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-1.769"
+                                                                                , nvValue = -1.769
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.707"
+                                                                                , nvValue = 0.707
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr2"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.691"
+                                                                                , nvValue = -0.691
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-1.829"
+                                                                                , nvValue = -1.829
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.716"
+                                                                                , nvValue = 0.716
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr3"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.890"
+                                                                                , nvValue = -0.89
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-1.409"
+                                                                                , nvValue = -1.409
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.729"
+                                                                                , nvValue = 0.729
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr4"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.700"
+                                                                                , nvValue = -0.7
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-1.397"
+                                                                                , nvValue = -1.397
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.843"
+                                                                                , nvValue = 0.843
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr5"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.899"
+                                                                                , nvValue = -0.899
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-1.005"
+                                                                                , nvValue = -1.005
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.112"
+                                                                                , nvValue = 0.112
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr6"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.900"
+                                                                                , nvValue = -0.9
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-1.053"
+                                                                                , nvValue = -1.053
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.508"
+                                                                                , nvValue = 0.508
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr7"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.715"
+                                                                                , nvValue = -0.715
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.991"
+                                                                                , nvValue = -0.991
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.873"
+                                                                                , nvValue = 0.873
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr8"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.916"
+                                                                                , nvValue = -0.916
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.742"
+                                                                                , nvValue = -0.742
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.112"
+                                                                                , nvValue = 0.112
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr9"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.917"
+                                                                                , nvValue = -0.917
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.746"
+                                                                                , nvValue = -0.746
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.494"
+                                                                                , nvValue = 0.494
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr10"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.734"
+                                                                                , nvValue = -0.734
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.746"
+                                                                                , nvValue = -0.746
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.888"
+                                                                                , nvValue = 0.888
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "Support nodes"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = True
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "collision"
+                                                                            , Bool False
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "selfCollision"
+                                                                            , Bool False
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "nodeWeight"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "1.2"
+                                                                                    , nvValue = 1.2
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "group"
+                                                                            , String ""
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfsl"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.684"
+                                                                                , nvValue = 0.684
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-1.079"
+                                                                                , nvValue = -1.079
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.507"
+                                                                                , nvValue = 0.507
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfsr"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.623"
+                                                                                , nvValue = -0.623
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-1.064"
+                                                                                , nvValue = -1.064
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.507"
+                                                                                , nvValue = 0.507
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ]
+                                                }
+                                            )
+                                        )
+                                    , True
                                     )
-                                )
-                            ]
-                        , ovTrailingComma = True
-                        }
+                                ,
+                                    ( ObjectKey
+                                        ( String "beams"
+                                        , Array
+                                            ( ArrayValue
+                                                { avElements =
+                                                    [
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "id1:"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "id2:"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "Structural beams"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = False
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "beamSpring: 451000, beamDamp: 50"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = False
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "beamStrength: FLT_MAX"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = False
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "beamType"
+                                                                            , String "|NORMAL"
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "beamSpring"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "451000"
+                                                                                    , nvValue = 451000.0
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( ObjectKey
+                                                                            ( String "beamDamp"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "50"
+                                                                                    , nvValue = 50.0
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "beamStrength"
+                                                                            , String "FLT_MAX"
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "deformLimitExpansion"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "1.1"
+                                                                                    , nvValue = 1.1
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "beamDeform"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "6000"
+                                                                                    , nvValue = 6000.0
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "Front"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = True
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr2"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfr4"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr2"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfr1"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr1"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfr4"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl4"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfl2"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl2"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfl1"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl0"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfl1"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl4"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfl3"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl0"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfl3"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr1"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfr0"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr4"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfr3"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr0"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfr3"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl4"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfl1"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "Middle"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = True
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "beamDeform"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "12000"
+                                                                                    , nvValue = 12000.0
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl6"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfl3"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr6"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfr3"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl4"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfl7"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr4"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfr7"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "Rear"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = True
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl7"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfl10"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl5"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfl6"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl7"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfl6"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl5"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfl8"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl6"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfl9"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl8"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfl9"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl10"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfl9"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr7"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfr10"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr6"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfr5"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr6"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfr7"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr5"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfr8"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr6"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfr9"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr8"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfr9"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr10"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfr9"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "Crossing beams"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = True
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "deformLimitExpansion"
+                                                                            , String ""
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "Front"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = False
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl0"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfl4"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl4"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfl6"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl7"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfl3"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr4"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfr6"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr7"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfr3"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl1"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfl3"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr3"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfr1"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr4"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfr0"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "Rear"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = True
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl6"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfl10"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl7"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfl9"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl5"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfl9"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl6"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfl8"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr6"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfr10"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr7"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfr9"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr5"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfr9"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr6"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfr8"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "Support beams"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = True
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl2"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfsl"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl6"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfsl"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl5"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfsl"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl3"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfsl"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl0"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfsl"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl1"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfsl"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl4"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfsl"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl7"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfsl"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl8"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfsl"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl9"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfsl"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl10"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfsl"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr2"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfsr"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr6"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfsr"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr5"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfsr"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr3"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfsr"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr0"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfsr"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr1"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfsr"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr4"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfsr"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr7"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfsr"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr8"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfsr"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr9"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfsr"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr10"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfsr"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "Front rigid"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = True
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "beamSpring"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "350000"
+                                                                                    , nvValue = 350000.0
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( ObjectKey
+                                                                            ( String "beamDamp"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "115"
+                                                                                    , nvValue = 115.0
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "beamDeform"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "900"
+                                                                                    , nvValue = 900.0
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "Left side"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = True
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl3"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfl9"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl4"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfl10"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "Right side"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = True
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr3"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfr9"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr4"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfr10"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "Attachment beams"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = True
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "beamType"
+                                                                            , String "|NORMAL"
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "beamSpring"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "501000"
+                                                                                    , nvValue = 501000.0
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( ObjectKey
+                                                                            ( String "beamDamp"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "75"
+                                                                                    , nvValue = 75.0
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( ObjectKey
+                                                                            ( String "beamStrength"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "20000"
+                                                                                    , nvValue = 20000.0
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( ObjectKey
+                                                                            ( String "beamDeform"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "1000"
+                                                                                    , nvValue = 1000.0
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "deformLimitExpansion"
+                                                                            , String ""
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "Frame"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = True
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "Left side"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = True
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "Front"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = True
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "breakGroup"
+                                                                            , String "fender_l"
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "breakGroupType"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "1"
+                                                                                    , nvValue = 1.0
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl0"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "fr17"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl0"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "fr9"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl1"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "fr17"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl1"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "fr9"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl2"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "fr17"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl2"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "fr9"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "Middle"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = True
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "beamDeform"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "18000"
+                                                                                    , nvValue = 18000.0
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "beamStrength"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "4000"
+                                                                                    , nvValue = 4000.0
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "breakGroupType"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "1"
+                                                                                    , nvValue = 1.0
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl3"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "fr17"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl4"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "fr17"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl4"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "fr9"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "breakGroupType"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "0"
+                                                                                    , nvValue = 0.0
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "Rear"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = True
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "beamStrength"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "16000"
+                                                                                    , nvValue = 16000.0
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( ObjectKey
+                                                                            ( String "beamDeform"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "12000"
+                                                                                    , nvValue = 12000.0
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl5"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "fr18"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl5"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "fr27"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl6"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "fr17"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl6"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "fr21"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl7"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "fr17"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl7"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "fr29"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl8"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "fr18"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl8"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "fr27"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl9"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "fr28"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl9"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "fr21"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl10"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "fr17"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl10"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "fr29"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "Right side"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = True
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "Front"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = True
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "beamStrength"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "20000"
+                                                                                    , nvValue = 20000.0
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( ObjectKey
+                                                                            ( String "beamDeform"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "1000"
+                                                                                    , nvValue = 1000.0
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "breakGroup"
+                                                                            , String "fender_r"
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "breakGroupType"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "1"
+                                                                                    , nvValue = 1.0
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl0"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f8"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl0"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f6"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl1"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f6"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl2"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f6"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr0"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f9"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr0"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f7"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr1"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f7"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr2"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f7"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "Middle"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = True
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "beamDeform"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "18000"
+                                                                                    , nvValue = 18000.0
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "beamStrength"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "4000"
+                                                                                    , nvValue = 4000.0
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "breakGroupType"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "1"
+                                                                                    , nvValue = 1.0
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl3"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f10"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl3"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f11"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl4"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f11"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr3"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f12"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr3"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f13"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr4"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f13"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "breakGroupType"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "0"
+                                                                                    , nvValue = 0.0
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "Rear"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = True
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "beamStrength"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "16000"
+                                                                                    , nvValue = 16000.0
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( ObjectKey
+                                                                            ( String "beamDeform"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "12000"
+                                                                                    , nvValue = 12000.0
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl5"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f15"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl5"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f16"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl6"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f15"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl6"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f16"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl8"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f15"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl8"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f16"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl9"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f15"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl9"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f16"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl7"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f16"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl10"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f16"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr5"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f17"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr5"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f18"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr6"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f17"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr6"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f18"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr8"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f17"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr8"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f18"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr9"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f17"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr9"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f18"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr7"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f18"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr10"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f18"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "beamStrength"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "16000"
+                                                                                    , nvValue = 16000.0
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( ObjectKey
+                                                                            ( String "beamDeform"
+                                                                            , String "FLT_MAX"
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "Body"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = False
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "Left side"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = True
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "breakGroup"
+                                                                            , String "fender_l"
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl8"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "mbl0"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl9"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "mbl1"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl10"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "mbl2"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "Right side"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = True
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "breakGroup"
+                                                                            , String "fender_r"
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr8"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "mbr0"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr9"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "mbr1"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr10"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "mbr2"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "breakGroup"
+                                                                            , String ""
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( ObjectKey
+                                                                            ( String "breakGroupType"
+                                                                            , String ""
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( ObjectKey
+                                                                            ( String "beamType"
+                                                                            , String "|NORMAL"
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ]
+                                                }
+                                            )
+                                        )
+                                    , True
+                                    )
+                                ,
+                                    ( ObjectKey
+                                        ( String "triangles"
+                                        , Array
+                                            ( ArrayValue
+                                                { avElements =
+                                                    [
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "id1:"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "id2:"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "id3:"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl3"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfl4"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfl1"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl0"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfl3"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfl1"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl4"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfl2"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfl1"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl4"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfl3"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfl7"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl6"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfl7"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfl3"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl10"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfl7"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfl6"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl9"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfl10"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfl6"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl5"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfl8"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfl6"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfl9"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfl6"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfl8"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr4"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfr1"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfr2"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr3"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfr1"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfr4"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr0"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfr1"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfr3"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr6"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfr3"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfr7"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr4"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfr7"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfr3"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr10"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfr6"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfr7"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr9"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfr6"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfr10"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr9"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfr8"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfr6"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "bfr5"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfr6"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "bfr8"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ]
+                                                }
+                                            )
+                                        )
+                                    , True
+                                    )
+                                ,
+                                    ( ObjectKey
+                                        ( String "flexbodies"
+                                        , Array
+                                            ( ArrayValue
+                                                { avElements =
+                                                    [
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "mesh"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "[group]:"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "nonFlexMaterials"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "impala_fender_l"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Array
+                                                                            ( ArrayValue
+                                                                                { avElements =
+                                                                                    [
+                                                                                        ( String "cot_fender_l"
+                                                                                        , False
+                                                                                        )
+                                                                                    ]
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "impala_fender_inter_l"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Array
+                                                                            ( ArrayValue
+                                                                                { avElements =
+                                                                                    [
+                                                                                        ( String "cot_fender_l"
+                                                                                        , False
+                                                                                        )
+                                                                                    ]
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "impala_fender_r"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Array
+                                                                            ( ArrayValue
+                                                                                { avElements =
+                                                                                    [
+                                                                                        ( String "cot_fender_r"
+                                                                                        , False
+                                                                                        )
+                                                                                    ]
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "impala_fender_inter_r"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Array
+                                                                            ( ArrayValue
+                                                                                { avElements =
+                                                                                    [
+                                                                                        ( String "cot_fender_r"
+                                                                                        , False
+                                                                                        )
+                                                                                    ]
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ]
+                                                }
+                                            )
+                                        )
+                                    , True
+                                    )
+                                ]
+                            }
+                        )
                     )
+                , True
                 )
             ]
-        , ovTrailingComma = True
         }
     )

--- a/examples/ast/jbeam/fender.hs
+++ b/examples/ast/jbeam/fender.hs
@@ -1,1927 +1,3112 @@
 Object
-    [ ObjectKey
-        ( String "cot_fender"
-        , Object
+    ( ObjectValue
+        { ovElements =
             [ ObjectKey
-                ( String "information"
+                ( String "cot_fender"
                 , Object
-                    [ ObjectKey
-                        ( String "authors"
-                        , String "gittarrgy01"
-                        )
-                    , ObjectKey
-                        ( String "name"
-                        , String "Fenders"
-                        )
-                    ]
-                )
-            , ObjectKey
-                ( String "sounds"
-                , Object
-                    [ ObjectKey
-                        ( String "impactMetal"
-                        , String "event:>Destruction>Props>fender_metal"
-                        )
-                    , ObjectKey
-                        ( String "impactGeneric"
-                        , String "event:>Destruction>Props>fender_generic"
-                        )
-                    , ObjectKey
-                        ( String "breakGeneric"
-                        , String "event:>Destruction>Props>fender_break"
-                        )
-                    , ObjectKey
-                        ( String "wind"
-                        , Bool False
-                        )
-                    , ObjectKey
-                        ( String "scrapeMetal"
-                        , Bool False
-                        )
-                    , ObjectKey
-                        ( String "scrapePlastic"
-                        , Bool False
-                        )
-                    ]
-                )
-            , ObjectKey
-                ( String "slotType"
-                , String "cot_fender"
-                )
-            , ObjectKey
-                ( String "nodes"
-                , Array
-                    [ Array
-                        [ String "id"
-                        , String "posX"
-                        , String "posY"
-                        , String "posZ"
-                        ]
-                    , Object
-                        [ ObjectKey
-                            ( String "nodeWeight"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "0.65"
-                                    , nvValue = 0.65
-                                    }
+                    ( ObjectValue
+                        { ovElements =
+                            [ ObjectKey
+                                ( String "information"
+                                , Object
+                                    ( ObjectValue
+                                        { ovElements =
+                                            [ ObjectKey
+                                                ( String "authors"
+                                                , String "gittarrgy01"
+                                                )
+                                            , ObjectKey
+                                                ( String "name"
+                                                , String "Fenders"
+                                                )
+                                            ]
+                                        , ovTrailingComma = True
+                                        }
+                                    )
                                 )
-                            )
-                        ]
-                    , Object
-                        [ ObjectKey
-                            ( String "frictionCoef"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "0.7"
-                                    , nvValue = 0.7
-                                    }
+                            , ObjectKey
+                                ( String "sounds"
+                                , Object
+                                    ( ObjectValue
+                                        { ovElements =
+                                            [ ObjectKey
+                                                ( String "impactMetal"
+                                                , String "event:>Destruction>Props>fender_metal"
+                                                )
+                                            , ObjectKey
+                                                ( String "impactGeneric"
+                                                , String "event:>Destruction>Props>fender_generic"
+                                                )
+                                            , ObjectKey
+                                                ( String "breakGeneric"
+                                                , String "event:>Destruction>Props>fender_break"
+                                                )
+                                            , ObjectKey
+                                                ( String "wind"
+                                                , Bool False
+                                                )
+                                            , ObjectKey
+                                                ( String "scrapeMetal"
+                                                , Bool False
+                                                )
+                                            , ObjectKey
+                                                ( String "scrapePlastic"
+                                                , Bool False
+                                                )
+                                            ]
+                                        , ovTrailingComma = False
+                                        }
+                                    )
                                 )
-                            )
-                        ]
-                    , Object
-                        [ ObjectKey
-                            ( String "nodeMaterial"
-                            , String "|NM_METAL"
-                            )
-                        ]
-                    , Object
-                        [ ObjectKey
-                            ( String "collision"
-                            , Bool True
-                            )
-                        ]
-                    , Object
-                        [ ObjectKey
-                            ( String "selfCollision"
-                            , Bool True
-                            )
-                        ]
-                    , Comment
-                        ( InternalComment
-                            { cText = "Left side"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = True
-                            }
-                        )
-                    , Object
-                        [ ObjectKey
-                            ( String "group"
-                            , String "cot_fender_l"
-                            )
-                        ]
-                    , Array
-                        [ String "bfl0"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.959"
-                                , nvValue = 0.959
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-1.762"
-                                , nvValue = -1.762
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.576"
-                                , nvValue = 0.576
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "bfl1"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.855"
-                                , nvValue = 0.855
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-1.788"
-                                , nvValue = -1.788
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.707"
-                                , nvValue = 0.707
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "bfl2"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.739"
-                                , nvValue = 0.739
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-1.845"
-                                , nvValue = -1.845
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.716"
-                                , nvValue = 0.716
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "bfl3"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.948"
-                                , nvValue = 0.948
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-1.435"
-                                , nvValue = -1.435
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.730"
-                                , nvValue = 0.73
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "bfl4"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.756"
-                                , nvValue = 0.756
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-1.413"
-                                , nvValue = -1.413
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.843"
-                                , nvValue = 0.843
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "bfl5"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.963"
-                                , nvValue = 0.963
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-1.024"
-                                , nvValue = -1.024
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.112"
-                                , nvValue = 0.112
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "bfl6"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.964"
-                                , nvValue = 0.964
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-1.072"
-                                , nvValue = -1.072
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.507"
-                                , nvValue = 0.507
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "bfl7"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.778"
-                                , nvValue = 0.778
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-1.008"
-                                , nvValue = -1.008
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.873"
-                                , nvValue = 0.873
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "bfl8"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.987"
-                                , nvValue = 0.987
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.743"
-                                , nvValue = -0.743
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.109"
-                                , nvValue = 0.109
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "bfl9"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.987"
-                                , nvValue = 0.987
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.744"
-                                , nvValue = -0.744
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.494"
-                                , nvValue = 0.494
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "bfl10"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.812"
-                                , nvValue = 0.812
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.759"
-                                , nvValue = -0.759
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.896"
-                                , nvValue = 0.896
-                                }
-                            )
-                        ]
-                    , Comment
-                        ( InternalComment
-                            { cText = "Right side"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = True
-                            }
-                        )
-                    , Object
-                        [ ObjectKey
-                            ( String "group"
-                            , String "cot_fender_r"
-                            )
-                        ]
-                    , Array
-                        [ String "bfr0"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.906"
-                                , nvValue = -0.906
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-1.737"
-                                , nvValue = -1.737
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.578"
-                                , nvValue = 0.578
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "bfr1"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.807"
-                                , nvValue = -0.807
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-1.769"
-                                , nvValue = -1.769
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.707"
-                                , nvValue = 0.707
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "bfr2"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.691"
-                                , nvValue = -0.691
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-1.829"
-                                , nvValue = -1.829
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.716"
-                                , nvValue = 0.716
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "bfr3"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.890"
-                                , nvValue = -0.89
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-1.409"
-                                , nvValue = -1.409
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.729"
-                                , nvValue = 0.729
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "bfr4"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.700"
-                                , nvValue = -0.7
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-1.397"
-                                , nvValue = -1.397
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.843"
-                                , nvValue = 0.843
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "bfr5"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.899"
-                                , nvValue = -0.899
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-1.005"
-                                , nvValue = -1.005
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.112"
-                                , nvValue = 0.112
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "bfr6"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.900"
-                                , nvValue = -0.9
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-1.053"
-                                , nvValue = -1.053
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.508"
-                                , nvValue = 0.508
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "bfr7"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.715"
-                                , nvValue = -0.715
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.991"
-                                , nvValue = -0.991
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.873"
-                                , nvValue = 0.873
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "bfr8"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.916"
-                                , nvValue = -0.916
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.742"
-                                , nvValue = -0.742
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.112"
-                                , nvValue = 0.112
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "bfr9"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.917"
-                                , nvValue = -0.917
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.746"
-                                , nvValue = -0.746
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.494"
-                                , nvValue = 0.494
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "bfr10"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.734"
-                                , nvValue = -0.734
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.746"
-                                , nvValue = -0.746
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.888"
-                                , nvValue = 0.888
-                                }
-                            )
-                        ]
-                    , Comment
-                        ( InternalComment
-                            { cText = "Support nodes"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = True
-                            }
-                        )
-                    , Object
-                        [ ObjectKey
-                            ( String "collision"
-                            , Bool False
-                            )
-                        ]
-                    , Object
-                        [ ObjectKey
-                            ( String "selfCollision"
-                            , Bool False
-                            )
-                        ]
-                    , Object
-                        [ ObjectKey
-                            ( String "nodeWeight"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "1.2"
-                                    , nvValue = 1.2
-                                    }
+                            , ObjectKey
+                                ( String "slotType"
+                                , String "cot_fender"
                                 )
-                            )
-                        ]
-                    , Object
-                        [ ObjectKey
-                            ( String "group"
-                            , String ""
-                            )
-                        ]
-                    , Array
-                        [ String "bfsl"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.684"
-                                , nvValue = 0.684
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-1.079"
-                                , nvValue = -1.079
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.507"
-                                , nvValue = 0.507
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "bfsr"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.623"
-                                , nvValue = -0.623
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-1.064"
-                                , nvValue = -1.064
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.507"
-                                , nvValue = 0.507
-                                }
-                            )
-                        ]
-                    ]
-                )
-            , ObjectKey
-                ( String "beams"
-                , Array
-                    [ Array
-                        [ String "id1:"
-                        , String "id2:"
-                        ]
-                    , Comment
-                        ( InternalComment
-                            { cText = "Structural beams"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = False
-                            }
-                        )
-                    , Comment
-                        ( InternalComment
-                            { cText = "beamSpring: 451000, beamDamp: 50"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = False
-                            }
-                        )
-                    , Comment
-                        ( InternalComment
-                            { cText = "beamStrength: FLT_MAX"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = False
-                            }
-                        )
-                    , Object
-                        [ ObjectKey
-                            ( String "beamType"
-                            , String "|NORMAL"
-                            )
-                        ]
-                    , Object
-                        [ ObjectKey
-                            ( String "beamSpring"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "451000"
-                                    , nvValue = 451000.0
-                                    }
+                            , ObjectKey
+                                ( String "nodes"
+                                , Array
+                                    ( ArrayValue
+                                        { avElements =
+                                            [ Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "id"
+                                                        , String "posX"
+                                                        , String "posY"
+                                                        , String "posZ"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "nodeWeight"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "0.65"
+                                                                    , nvValue = 0.65
+                                                                    }
+                                                                )
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "frictionCoef"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "0.7"
+                                                                    , nvValue = 0.7
+                                                                    }
+                                                                )
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "nodeMaterial"
+                                                            , String "|NM_METAL"
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "collision"
+                                                            , Bool True
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "selfCollision"
+                                                            , Bool True
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "Left side"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = True
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "group"
+                                                            , String "cot_fender_l"
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl0"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.959"
+                                                                , nvValue = 0.959
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-1.762"
+                                                                , nvValue = -1.762
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.576"
+                                                                , nvValue = 0.576
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl1"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.855"
+                                                                , nvValue = 0.855
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-1.788"
+                                                                , nvValue = -1.788
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.707"
+                                                                , nvValue = 0.707
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl2"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.739"
+                                                                , nvValue = 0.739
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-1.845"
+                                                                , nvValue = -1.845
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.716"
+                                                                , nvValue = 0.716
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl3"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.948"
+                                                                , nvValue = 0.948
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-1.435"
+                                                                , nvValue = -1.435
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.730"
+                                                                , nvValue = 0.73
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl4"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.756"
+                                                                , nvValue = 0.756
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-1.413"
+                                                                , nvValue = -1.413
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.843"
+                                                                , nvValue = 0.843
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl5"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.963"
+                                                                , nvValue = 0.963
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-1.024"
+                                                                , nvValue = -1.024
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.112"
+                                                                , nvValue = 0.112
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl6"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.964"
+                                                                , nvValue = 0.964
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-1.072"
+                                                                , nvValue = -1.072
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.507"
+                                                                , nvValue = 0.507
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl7"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.778"
+                                                                , nvValue = 0.778
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-1.008"
+                                                                , nvValue = -1.008
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.873"
+                                                                , nvValue = 0.873
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl8"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.987"
+                                                                , nvValue = 0.987
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.743"
+                                                                , nvValue = -0.743
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.109"
+                                                                , nvValue = 0.109
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl9"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.987"
+                                                                , nvValue = 0.987
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.744"
+                                                                , nvValue = -0.744
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.494"
+                                                                , nvValue = 0.494
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl10"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.812"
+                                                                , nvValue = 0.812
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.759"
+                                                                , nvValue = -0.759
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.896"
+                                                                , nvValue = 0.896
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "Right side"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = True
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "group"
+                                                            , String "cot_fender_r"
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr0"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.906"
+                                                                , nvValue = -0.906
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-1.737"
+                                                                , nvValue = -1.737
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.578"
+                                                                , nvValue = 0.578
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr1"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.807"
+                                                                , nvValue = -0.807
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-1.769"
+                                                                , nvValue = -1.769
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.707"
+                                                                , nvValue = 0.707
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr2"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.691"
+                                                                , nvValue = -0.691
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-1.829"
+                                                                , nvValue = -1.829
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.716"
+                                                                , nvValue = 0.716
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr3"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.890"
+                                                                , nvValue = -0.89
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-1.409"
+                                                                , nvValue = -1.409
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.729"
+                                                                , nvValue = 0.729
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr4"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.700"
+                                                                , nvValue = -0.7
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-1.397"
+                                                                , nvValue = -1.397
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.843"
+                                                                , nvValue = 0.843
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr5"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.899"
+                                                                , nvValue = -0.899
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-1.005"
+                                                                , nvValue = -1.005
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.112"
+                                                                , nvValue = 0.112
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr6"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.900"
+                                                                , nvValue = -0.9
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-1.053"
+                                                                , nvValue = -1.053
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.508"
+                                                                , nvValue = 0.508
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr7"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.715"
+                                                                , nvValue = -0.715
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.991"
+                                                                , nvValue = -0.991
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.873"
+                                                                , nvValue = 0.873
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr8"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.916"
+                                                                , nvValue = -0.916
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.742"
+                                                                , nvValue = -0.742
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.112"
+                                                                , nvValue = 0.112
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr9"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.917"
+                                                                , nvValue = -0.917
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.746"
+                                                                , nvValue = -0.746
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.494"
+                                                                , nvValue = 0.494
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr10"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.734"
+                                                                , nvValue = -0.734
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.746"
+                                                                , nvValue = -0.746
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.888"
+                                                                , nvValue = 0.888
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "Support nodes"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = True
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "collision"
+                                                            , Bool False
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "selfCollision"
+                                                            , Bool False
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "nodeWeight"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "1.2"
+                                                                    , nvValue = 1.2
+                                                                    }
+                                                                )
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "group"
+                                                            , String ""
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfsl"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.684"
+                                                                , nvValue = 0.684
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-1.079"
+                                                                , nvValue = -1.079
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.507"
+                                                                , nvValue = 0.507
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfsr"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.623"
+                                                                , nvValue = -0.623
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-1.064"
+                                                                , nvValue = -1.064
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.507"
+                                                                , nvValue = 0.507
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            ]
+                                        , avTrailingComma = True
+                                        }
+                                    )
                                 )
-                            )
-                        , ObjectKey
-                            ( String "beamDamp"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "50"
-                                    , nvValue = 50.0
-                                    }
+                            , ObjectKey
+                                ( String "beams"
+                                , Array
+                                    ( ArrayValue
+                                        { avElements =
+                                            [ Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "id1:"
+                                                        , String "id2:"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "Structural beams"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "beamSpring: 451000, beamDamp: 50"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "beamStrength: FLT_MAX"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = False
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "beamType"
+                                                            , String "|NORMAL"
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "beamSpring"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "451000"
+                                                                    , nvValue = 451000.0
+                                                                    }
+                                                                )
+                                                            )
+                                                        , ObjectKey
+                                                            ( String "beamDamp"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "50"
+                                                                    , nvValue = 50.0
+                                                                    }
+                                                                )
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "beamStrength"
+                                                            , String "FLT_MAX"
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "deformLimitExpansion"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "1.1"
+                                                                    , nvValue = 1.1
+                                                                    }
+                                                                )
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "beamDeform"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "6000"
+                                                                    , nvValue = 6000.0
+                                                                    }
+                                                                )
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "Front"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = True
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr2"
+                                                        , String "bfr4"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr2"
+                                                        , String "bfr1"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr1"
+                                                        , String "bfr4"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl4"
+                                                        , String "bfl2"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl2"
+                                                        , String "bfl1"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl0"
+                                                        , String "bfl1"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl4"
+                                                        , String "bfl3"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl0"
+                                                        , String "bfl3"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr1"
+                                                        , String "bfr0"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr4"
+                                                        , String "bfr3"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr0"
+                                                        , String "bfr3"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl4"
+                                                        , String "bfl1"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "Middle"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = True
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "beamDeform"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "12000"
+                                                                    , nvValue = 12000.0
+                                                                    }
+                                                                )
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl6"
+                                                        , String "bfl3"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr6"
+                                                        , String "bfr3"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl4"
+                                                        , String "bfl7"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr4"
+                                                        , String "bfr7"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "Rear"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = True
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl7"
+                                                        , String "bfl10"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl5"
+                                                        , String "bfl6"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl7"
+                                                        , String "bfl6"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl5"
+                                                        , String "bfl8"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl6"
+                                                        , String "bfl9"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl8"
+                                                        , String "bfl9"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl10"
+                                                        , String "bfl9"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr7"
+                                                        , String "bfr10"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr6"
+                                                        , String "bfr5"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr6"
+                                                        , String "bfr7"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr5"
+                                                        , String "bfr8"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr6"
+                                                        , String "bfr9"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr8"
+                                                        , String "bfr9"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr10"
+                                                        , String "bfr9"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "Crossing beams"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = True
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "deformLimitExpansion"
+                                                            , String ""
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "Front"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl0"
+                                                        , String "bfl4"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl4"
+                                                        , String "bfl6"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl7"
+                                                        , String "bfl3"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr4"
+                                                        , String "bfr6"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr7"
+                                                        , String "bfr3"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl1"
+                                                        , String "bfl3"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr3"
+                                                        , String "bfr1"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr4"
+                                                        , String "bfr0"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "Rear"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = True
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl6"
+                                                        , String "bfl10"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl7"
+                                                        , String "bfl9"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl5"
+                                                        , String "bfl9"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl6"
+                                                        , String "bfl8"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr6"
+                                                        , String "bfr10"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr7"
+                                                        , String "bfr9"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr5"
+                                                        , String "bfr9"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr6"
+                                                        , String "bfr8"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "Support beams"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = True
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl2"
+                                                        , String "bfsl"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl6"
+                                                        , String "bfsl"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl5"
+                                                        , String "bfsl"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl3"
+                                                        , String "bfsl"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl0"
+                                                        , String "bfsl"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl1"
+                                                        , String "bfsl"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl4"
+                                                        , String "bfsl"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl7"
+                                                        , String "bfsl"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl8"
+                                                        , String "bfsl"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl9"
+                                                        , String "bfsl"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl10"
+                                                        , String "bfsl"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr2"
+                                                        , String "bfsr"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr6"
+                                                        , String "bfsr"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr5"
+                                                        , String "bfsr"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr3"
+                                                        , String "bfsr"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr0"
+                                                        , String "bfsr"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr1"
+                                                        , String "bfsr"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr4"
+                                                        , String "bfsr"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr7"
+                                                        , String "bfsr"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr8"
+                                                        , String "bfsr"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr9"
+                                                        , String "bfsr"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr10"
+                                                        , String "bfsr"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "Front rigid"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = True
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "beamSpring"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "350000"
+                                                                    , nvValue = 350000.0
+                                                                    }
+                                                                )
+                                                            )
+                                                        , ObjectKey
+                                                            ( String "beamDamp"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "115"
+                                                                    , nvValue = 115.0
+                                                                    }
+                                                                )
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "beamDeform"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "900"
+                                                                    , nvValue = 900.0
+                                                                    }
+                                                                )
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "Left side"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = True
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl3"
+                                                        , String "bfl9"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl4"
+                                                        , String "bfl10"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "Right side"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = True
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr3"
+                                                        , String "bfr9"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr4"
+                                                        , String "bfr10"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "Attachment beams"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = True
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "beamType"
+                                                            , String "|NORMAL"
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "beamSpring"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "501000"
+                                                                    , nvValue = 501000.0
+                                                                    }
+                                                                )
+                                                            )
+                                                        , ObjectKey
+                                                            ( String "beamDamp"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "75"
+                                                                    , nvValue = 75.0
+                                                                    }
+                                                                )
+                                                            )
+                                                        , ObjectKey
+                                                            ( String "beamStrength"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "20000"
+                                                                    , nvValue = 20000.0
+                                                                    }
+                                                                )
+                                                            )
+                                                        , ObjectKey
+                                                            ( String "beamDeform"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "1000"
+                                                                    , nvValue = 1000.0
+                                                                    }
+                                                                )
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "deformLimitExpansion"
+                                                            , String ""
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "Frame"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = True
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "Left side"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = True
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "Front"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = True
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "breakGroup"
+                                                            , String "fender_l"
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "breakGroupType"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "1"
+                                                                    , nvValue = 1.0
+                                                                    }
+                                                                )
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl0"
+                                                        , String "fr17"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl0"
+                                                        , String "fr9"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl1"
+                                                        , String "fr17"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl1"
+                                                        , String "fr9"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl2"
+                                                        , String "fr17"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl2"
+                                                        , String "fr9"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "Middle"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = True
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "beamDeform"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "18000"
+                                                                    , nvValue = 18000.0
+                                                                    }
+                                                                )
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "beamStrength"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "4000"
+                                                                    , nvValue = 4000.0
+                                                                    }
+                                                                )
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "breakGroupType"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "1"
+                                                                    , nvValue = 1.0
+                                                                    }
+                                                                )
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl3"
+                                                        , String "fr17"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl4"
+                                                        , String "fr17"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl4"
+                                                        , String "fr9"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "breakGroupType"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "0"
+                                                                    , nvValue = 0.0
+                                                                    }
+                                                                )
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "Rear"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = True
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "beamStrength"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "16000"
+                                                                    , nvValue = 16000.0
+                                                                    }
+                                                                )
+                                                            )
+                                                        , ObjectKey
+                                                            ( String "beamDeform"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "12000"
+                                                                    , nvValue = 12000.0
+                                                                    }
+                                                                )
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl5"
+                                                        , String "fr18"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl5"
+                                                        , String "fr27"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl6"
+                                                        , String "fr17"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl6"
+                                                        , String "fr21"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl7"
+                                                        , String "fr17"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl7"
+                                                        , String "fr29"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl8"
+                                                        , String "fr18"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl8"
+                                                        , String "fr27"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl9"
+                                                        , String "fr28"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl9"
+                                                        , String "fr21"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl10"
+                                                        , String "fr17"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl10"
+                                                        , String "fr29"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "Right side"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = True
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "Front"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = True
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "beamStrength"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "20000"
+                                                                    , nvValue = 20000.0
+                                                                    }
+                                                                )
+                                                            )
+                                                        , ObjectKey
+                                                            ( String "beamDeform"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "1000"
+                                                                    , nvValue = 1000.0
+                                                                    }
+                                                                )
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "breakGroup"
+                                                            , String "fender_r"
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "breakGroupType"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "1"
+                                                                    , nvValue = 1.0
+                                                                    }
+                                                                )
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl0"
+                                                        , String "rl_f8"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl0"
+                                                        , String "rl_f6"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl1"
+                                                        , String "rl_f6"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl2"
+                                                        , String "rl_f6"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr0"
+                                                        , String "rl_f9"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr0"
+                                                        , String "rl_f7"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr1"
+                                                        , String "rl_f7"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr2"
+                                                        , String "rl_f7"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "Middle"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = True
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "beamDeform"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "18000"
+                                                                    , nvValue = 18000.0
+                                                                    }
+                                                                )
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "beamStrength"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "4000"
+                                                                    , nvValue = 4000.0
+                                                                    }
+                                                                )
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "breakGroupType"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "1"
+                                                                    , nvValue = 1.0
+                                                                    }
+                                                                )
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl3"
+                                                        , String "rl_f10"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl3"
+                                                        , String "rl_f11"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl4"
+                                                        , String "rl_f11"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr3"
+                                                        , String "rl_f12"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr3"
+                                                        , String "rl_f13"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr4"
+                                                        , String "rl_f13"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "breakGroupType"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "0"
+                                                                    , nvValue = 0.0
+                                                                    }
+                                                                )
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "Rear"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = True
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "beamStrength"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "16000"
+                                                                    , nvValue = 16000.0
+                                                                    }
+                                                                )
+                                                            )
+                                                        , ObjectKey
+                                                            ( String "beamDeform"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "12000"
+                                                                    , nvValue = 12000.0
+                                                                    }
+                                                                )
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl5"
+                                                        , String "rl_f15"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl5"
+                                                        , String "rl_f16"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl6"
+                                                        , String "rl_f15"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl6"
+                                                        , String "rl_f16"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl8"
+                                                        , String "rl_f15"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl8"
+                                                        , String "rl_f16"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl9"
+                                                        , String "rl_f15"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl9"
+                                                        , String "rl_f16"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl7"
+                                                        , String "rl_f16"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl10"
+                                                        , String "rl_f16"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr5"
+                                                        , String "rl_f17"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr5"
+                                                        , String "rl_f18"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr6"
+                                                        , String "rl_f17"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr6"
+                                                        , String "rl_f18"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr8"
+                                                        , String "rl_f17"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr8"
+                                                        , String "rl_f18"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr9"
+                                                        , String "rl_f17"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr9"
+                                                        , String "rl_f18"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr7"
+                                                        , String "rl_f18"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr10"
+                                                        , String "rl_f18"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "beamStrength"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "16000"
+                                                                    , nvValue = 16000.0
+                                                                    }
+                                                                )
+                                                            )
+                                                        , ObjectKey
+                                                            ( String "beamDeform"
+                                                            , String "FLT_MAX"
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "Body"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "Left side"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = True
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "breakGroup"
+                                                            , String "fender_l"
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl8"
+                                                        , String "mbl0"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl9"
+                                                        , String "mbl1"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl10"
+                                                        , String "mbl2"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "Right side"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = True
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "breakGroup"
+                                                            , String "fender_r"
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr8"
+                                                        , String "mbr0"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr9"
+                                                        , String "mbr1"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr10"
+                                                        , String "mbr2"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "breakGroup"
+                                                            , String ""
+                                                            )
+                                                        , ObjectKey
+                                                            ( String "breakGroupType"
+                                                            , String ""
+                                                            )
+                                                        , ObjectKey
+                                                            ( String "beamType"
+                                                            , String "|NORMAL"
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            ]
+                                        , avTrailingComma = True
+                                        }
+                                    )
                                 )
-                            )
-                        ]
-                    , Object
-                        [ ObjectKey
-                            ( String "beamStrength"
-                            , String "FLT_MAX"
-                            )
-                        ]
-                    , Object
-                        [ ObjectKey
-                            ( String "deformLimitExpansion"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "1.1"
-                                    , nvValue = 1.1
-                                    }
+                            , ObjectKey
+                                ( String "triangles"
+                                , Array
+                                    ( ArrayValue
+                                        { avElements =
+                                            [ Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "id1:"
+                                                        , String "id2:"
+                                                        , String "id3:"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl3"
+                                                        , String "bfl4"
+                                                        , String "bfl1"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl0"
+                                                        , String "bfl3"
+                                                        , String "bfl1"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl4"
+                                                        , String "bfl2"
+                                                        , String "bfl1"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl4"
+                                                        , String "bfl3"
+                                                        , String "bfl7"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl6"
+                                                        , String "bfl7"
+                                                        , String "bfl3"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl10"
+                                                        , String "bfl7"
+                                                        , String "bfl6"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl9"
+                                                        , String "bfl10"
+                                                        , String "bfl6"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl5"
+                                                        , String "bfl8"
+                                                        , String "bfl6"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfl9"
+                                                        , String "bfl6"
+                                                        , String "bfl8"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr4"
+                                                        , String "bfr1"
+                                                        , String "bfr2"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr3"
+                                                        , String "bfr1"
+                                                        , String "bfr4"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr0"
+                                                        , String "bfr1"
+                                                        , String "bfr3"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr6"
+                                                        , String "bfr3"
+                                                        , String "bfr7"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr4"
+                                                        , String "bfr7"
+                                                        , String "bfr3"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr10"
+                                                        , String "bfr6"
+                                                        , String "bfr7"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr9"
+                                                        , String "bfr6"
+                                                        , String "bfr10"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr9"
+                                                        , String "bfr8"
+                                                        , String "bfr6"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "bfr5"
+                                                        , String "bfr6"
+                                                        , String "bfr8"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            ]
+                                        , avTrailingComma = True
+                                        }
+                                    )
                                 )
-                            )
-                        ]
-                    , Object
-                        [ ObjectKey
-                            ( String "beamDeform"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "6000"
-                                    , nvValue = 6000.0
-                                    }
+                            , ObjectKey
+                                ( String "flexbodies"
+                                , Array
+                                    ( ArrayValue
+                                        { avElements =
+                                            [ Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "mesh"
+                                                        , String "[group]:"
+                                                        , String "nonFlexMaterials"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "impala_fender_l"
+                                                        , Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [ String "cot_fender_l" ]
+                                                                , avTrailingComma = False
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "impala_fender_inter_l"
+                                                        , Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [ String "cot_fender_l" ]
+                                                                , avTrailingComma = False
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "impala_fender_r"
+                                                        , Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [ String "cot_fender_r" ]
+                                                                , avTrailingComma = False
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "impala_fender_inter_r"
+                                                        , Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [ String "cot_fender_r" ]
+                                                                , avTrailingComma = False
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            ]
+                                        , avTrailingComma = True
+                                        }
+                                    )
                                 )
-                            )
-                        ]
-                    , Comment
-                        ( InternalComment
-                            { cText = "Front"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = True
-                            }
-                        )
-                    , Array
-                        [ String "bfr2"
-                        , String "bfr4"
-                        ]
-                    , Array
-                        [ String "bfr2"
-                        , String "bfr1"
-                        ]
-                    , Array
-                        [ String "bfr1"
-                        , String "bfr4"
-                        ]
-                    , Array
-                        [ String "bfl4"
-                        , String "bfl2"
-                        ]
-                    , Array
-                        [ String "bfl2"
-                        , String "bfl1"
-                        ]
-                    , Array
-                        [ String "bfl0"
-                        , String "bfl1"
-                        ]
-                    , Array
-                        [ String "bfl4"
-                        , String "bfl3"
-                        ]
-                    , Array
-                        [ String "bfl0"
-                        , String "bfl3"
-                        ]
-                    , Array
-                        [ String "bfr1"
-                        , String "bfr0"
-                        ]
-                    , Array
-                        [ String "bfr4"
-                        , String "bfr3"
-                        ]
-                    , Array
-                        [ String "bfr0"
-                        , String "bfr3"
-                        ]
-                    , Array
-                        [ String "bfl4"
-                        , String "bfl1"
-                        ]
-                    , Comment
-                        ( InternalComment
-                            { cText = "Middle"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = True
-                            }
-                        )
-                    , Object
-                        [ ObjectKey
-                            ( String "beamDeform"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "12000"
-                                    , nvValue = 12000.0
-                                    }
-                                )
-                            )
-                        ]
-                    , Array
-                        [ String "bfl6"
-                        , String "bfl3"
-                        ]
-                    , Array
-                        [ String "bfr6"
-                        , String "bfr3"
-                        ]
-                    , Array
-                        [ String "bfl4"
-                        , String "bfl7"
-                        ]
-                    , Array
-                        [ String "bfr4"
-                        , String "bfr7"
-                        ]
-                    , Comment
-                        ( InternalComment
-                            { cText = "Rear"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = True
-                            }
-                        )
-                    , Array
-                        [ String "bfl7"
-                        , String "bfl10"
-                        ]
-                    , Array
-                        [ String "bfl5"
-                        , String "bfl6"
-                        ]
-                    , Array
-                        [ String "bfl7"
-                        , String "bfl6"
-                        ]
-                    , Array
-                        [ String "bfl5"
-                        , String "bfl8"
-                        ]
-                    , Array
-                        [ String "bfl6"
-                        , String "bfl9"
-                        ]
-                    , Array
-                        [ String "bfl8"
-                        , String "bfl9"
-                        ]
-                    , Array
-                        [ String "bfl10"
-                        , String "bfl9"
-                        ]
-                    , Array
-                        [ String "bfr7"
-                        , String "bfr10"
-                        ]
-                    , Array
-                        [ String "bfr6"
-                        , String "bfr5"
-                        ]
-                    , Array
-                        [ String "bfr6"
-                        , String "bfr7"
-                        ]
-                    , Array
-                        [ String "bfr5"
-                        , String "bfr8"
-                        ]
-                    , Array
-                        [ String "bfr6"
-                        , String "bfr9"
-                        ]
-                    , Array
-                        [ String "bfr8"
-                        , String "bfr9"
-                        ]
-                    , Array
-                        [ String "bfr10"
-                        , String "bfr9"
-                        ]
-                    , Comment
-                        ( InternalComment
-                            { cText = "Crossing beams"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = True
-                            }
-                        )
-                    , Object
-                        [ ObjectKey
-                            ( String "deformLimitExpansion"
-                            , String ""
-                            )
-                        ]
-                    , Comment
-                        ( InternalComment
-                            { cText = "Front"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = False
-                            }
-                        )
-                    , Array
-                        [ String "bfl0"
-                        , String "bfl4"
-                        ]
-                    , Array
-                        [ String "bfl4"
-                        , String "bfl6"
-                        ]
-                    , Array
-                        [ String "bfl7"
-                        , String "bfl3"
-                        ]
-                    , Array
-                        [ String "bfr4"
-                        , String "bfr6"
-                        ]
-                    , Array
-                        [ String "bfr7"
-                        , String "bfr3"
-                        ]
-                    , Array
-                        [ String "bfl1"
-                        , String "bfl3"
-                        ]
-                    , Array
-                        [ String "bfr3"
-                        , String "bfr1"
-                        ]
-                    , Array
-                        [ String "bfr4"
-                        , String "bfr0"
-                        ]
-                    , Comment
-                        ( InternalComment
-                            { cText = "Rear"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = True
-                            }
-                        )
-                    , Array
-                        [ String "bfl6"
-                        , String "bfl10"
-                        ]
-                    , Array
-                        [ String "bfl7"
-                        , String "bfl9"
-                        ]
-                    , Array
-                        [ String "bfl5"
-                        , String "bfl9"
-                        ]
-                    , Array
-                        [ String "bfl6"
-                        , String "bfl8"
-                        ]
-                    , Array
-                        [ String "bfr6"
-                        , String "bfr10"
-                        ]
-                    , Array
-                        [ String "bfr7"
-                        , String "bfr9"
-                        ]
-                    , Array
-                        [ String "bfr5"
-                        , String "bfr9"
-                        ]
-                    , Array
-                        [ String "bfr6"
-                        , String "bfr8"
-                        ]
-                    , Comment
-                        ( InternalComment
-                            { cText = "Support beams"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = True
-                            }
-                        )
-                    , Array
-                        [ String "bfl2"
-                        , String "bfsl"
-                        ]
-                    , Array
-                        [ String "bfl6"
-                        , String "bfsl"
-                        ]
-                    , Array
-                        [ String "bfl5"
-                        , String "bfsl"
-                        ]
-                    , Array
-                        [ String "bfl3"
-                        , String "bfsl"
-                        ]
-                    , Array
-                        [ String "bfl0"
-                        , String "bfsl"
-                        ]
-                    , Array
-                        [ String "bfl1"
-                        , String "bfsl"
-                        ]
-                    , Array
-                        [ String "bfl4"
-                        , String "bfsl"
-                        ]
-                    , Array
-                        [ String "bfl7"
-                        , String "bfsl"
-                        ]
-                    , Array
-                        [ String "bfl8"
-                        , String "bfsl"
-                        ]
-                    , Array
-                        [ String "bfl9"
-                        , String "bfsl"
-                        ]
-                    , Array
-                        [ String "bfl10"
-                        , String "bfsl"
-                        ]
-                    , Array
-                        [ String "bfr2"
-                        , String "bfsr"
-                        ]
-                    , Array
-                        [ String "bfr6"
-                        , String "bfsr"
-                        ]
-                    , Array
-                        [ String "bfr5"
-                        , String "bfsr"
-                        ]
-                    , Array
-                        [ String "bfr3"
-                        , String "bfsr"
-                        ]
-                    , Array
-                        [ String "bfr0"
-                        , String "bfsr"
-                        ]
-                    , Array
-                        [ String "bfr1"
-                        , String "bfsr"
-                        ]
-                    , Array
-                        [ String "bfr4"
-                        , String "bfsr"
-                        ]
-                    , Array
-                        [ String "bfr7"
-                        , String "bfsr"
-                        ]
-                    , Array
-                        [ String "bfr8"
-                        , String "bfsr"
-                        ]
-                    , Array
-                        [ String "bfr9"
-                        , String "bfsr"
-                        ]
-                    , Array
-                        [ String "bfr10"
-                        , String "bfsr"
-                        ]
-                    , Comment
-                        ( InternalComment
-                            { cText = "Front rigid"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = True
-                            }
-                        )
-                    , Object
-                        [ ObjectKey
-                            ( String "beamSpring"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "350000"
-                                    , nvValue = 350000.0
-                                    }
-                                )
-                            )
-                        , ObjectKey
-                            ( String "beamDamp"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "115"
-                                    , nvValue = 115.0
-                                    }
-                                )
-                            )
-                        ]
-                    , Object
-                        [ ObjectKey
-                            ( String "beamDeform"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "900"
-                                    , nvValue = 900.0
-                                    }
-                                )
-                            )
-                        ]
-                    , Comment
-                        ( InternalComment
-                            { cText = "Left side"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = True
-                            }
-                        )
-                    , Array
-                        [ String "bfl3"
-                        , String "bfl9"
-                        ]
-                    , Array
-                        [ String "bfl4"
-                        , String "bfl10"
-                        ]
-                    , Comment
-                        ( InternalComment
-                            { cText = "Right side"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = True
-                            }
-                        )
-                    , Array
-                        [ String "bfr3"
-                        , String "bfr9"
-                        ]
-                    , Array
-                        [ String "bfr4"
-                        , String "bfr10"
-                        ]
-                    , Comment
-                        ( InternalComment
-                            { cText = "Attachment beams"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = True
-                            }
-                        )
-                    , Object
-                        [ ObjectKey
-                            ( String "beamType"
-                            , String "|NORMAL"
-                            )
-                        ]
-                    , Object
-                        [ ObjectKey
-                            ( String "beamSpring"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "501000"
-                                    , nvValue = 501000.0
-                                    }
-                                )
-                            )
-                        , ObjectKey
-                            ( String "beamDamp"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "75"
-                                    , nvValue = 75.0
-                                    }
-                                )
-                            )
-                        , ObjectKey
-                            ( String "beamStrength"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "20000"
-                                    , nvValue = 20000.0
-                                    }
-                                )
-                            )
-                        , ObjectKey
-                            ( String "beamDeform"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "1000"
-                                    , nvValue = 1000.0
-                                    }
-                                )
-                            )
-                        ]
-                    , Object
-                        [ ObjectKey
-                            ( String "deformLimitExpansion"
-                            , String ""
-                            )
-                        ]
-                    , Comment
-                        ( InternalComment
-                            { cText = "Frame"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = True
-                            }
-                        )
-                    , Comment
-                        ( InternalComment
-                            { cText = "Left side"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = True
-                            }
-                        )
-                    , Comment
-                        ( InternalComment
-                            { cText = "Front"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = True
-                            }
-                        )
-                    , Object
-                        [ ObjectKey
-                            ( String "breakGroup"
-                            , String "fender_l"
-                            )
-                        ]
-                    , Object
-                        [ ObjectKey
-                            ( String "breakGroupType"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "1"
-                                    , nvValue = 1.0
-                                    }
-                                )
-                            )
-                        ]
-                    , Array
-                        [ String "bfl0"
-                        , String "fr17"
-                        ]
-                    , Array
-                        [ String "bfl0"
-                        , String "fr9"
-                        ]
-                    , Array
-                        [ String "bfl1"
-                        , String "fr17"
-                        ]
-                    , Array
-                        [ String "bfl1"
-                        , String "fr9"
-                        ]
-                    , Array
-                        [ String "bfl2"
-                        , String "fr17"
-                        ]
-                    , Array
-                        [ String "bfl2"
-                        , String "fr9"
-                        ]
-                    , Comment
-                        ( InternalComment
-                            { cText = "Middle"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = True
-                            }
-                        )
-                    , Object
-                        [ ObjectKey
-                            ( String "beamDeform"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "18000"
-                                    , nvValue = 18000.0
-                                    }
-                                )
-                            )
-                        ]
-                    , Object
-                        [ ObjectKey
-                            ( String "beamStrength"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "4000"
-                                    , nvValue = 4000.0
-                                    }
-                                )
-                            )
-                        ]
-                    , Object
-                        [ ObjectKey
-                            ( String "breakGroupType"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "1"
-                                    , nvValue = 1.0
-                                    }
-                                )
-                            )
-                        ]
-                    , Array
-                        [ String "bfl3"
-                        , String "fr17"
-                        ]
-                    , Array
-                        [ String "bfl4"
-                        , String "fr17"
-                        ]
-                    , Array
-                        [ String "bfl4"
-                        , String "fr9"
-                        ]
-                    , Object
-                        [ ObjectKey
-                            ( String "breakGroupType"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "0"
-                                    , nvValue = 0.0
-                                    }
-                                )
-                            )
-                        ]
-                    , Comment
-                        ( InternalComment
-                            { cText = "Rear"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = True
-                            }
-                        )
-                    , Object
-                        [ ObjectKey
-                            ( String "beamStrength"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "16000"
-                                    , nvValue = 16000.0
-                                    }
-                                )
-                            )
-                        , ObjectKey
-                            ( String "beamDeform"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "12000"
-                                    , nvValue = 12000.0
-                                    }
-                                )
-                            )
-                        ]
-                    , Array
-                        [ String "bfl5"
-                        , String "fr18"
-                        ]
-                    , Array
-                        [ String "bfl5"
-                        , String "fr27"
-                        ]
-                    , Array
-                        [ String "bfl6"
-                        , String "fr17"
-                        ]
-                    , Array
-                        [ String "bfl6"
-                        , String "fr21"
-                        ]
-                    , Array
-                        [ String "bfl7"
-                        , String "fr17"
-                        ]
-                    , Array
-                        [ String "bfl7"
-                        , String "fr29"
-                        ]
-                    , Array
-                        [ String "bfl8"
-                        , String "fr18"
-                        ]
-                    , Array
-                        [ String "bfl8"
-                        , String "fr27"
-                        ]
-                    , Array
-                        [ String "bfl9"
-                        , String "fr28"
-                        ]
-                    , Array
-                        [ String "bfl9"
-                        , String "fr21"
-                        ]
-                    , Array
-                        [ String "bfl10"
-                        , String "fr17"
-                        ]
-                    , Array
-                        [ String "bfl10"
-                        , String "fr29"
-                        ]
-                    , Comment
-                        ( InternalComment
-                            { cText = "Right side"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = True
-                            }
-                        )
-                    , Comment
-                        ( InternalComment
-                            { cText = "Front"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = True
-                            }
-                        )
-                    , Object
-                        [ ObjectKey
-                            ( String "beamStrength"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "20000"
-                                    , nvValue = 20000.0
-                                    }
-                                )
-                            )
-                        , ObjectKey
-                            ( String "beamDeform"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "1000"
-                                    , nvValue = 1000.0
-                                    }
-                                )
-                            )
-                        ]
-                    , Object
-                        [ ObjectKey
-                            ( String "breakGroup"
-                            , String "fender_r"
-                            )
-                        ]
-                    , Object
-                        [ ObjectKey
-                            ( String "breakGroupType"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "1"
-                                    , nvValue = 1.0
-                                    }
-                                )
-                            )
-                        ]
-                    , Array
-                        [ String "bfl0"
-                        , String "rl_f8"
-                        ]
-                    , Array
-                        [ String "bfl0"
-                        , String "rl_f6"
-                        ]
-                    , Array
-                        [ String "bfl1"
-                        , String "rl_f6"
-                        ]
-                    , Array
-                        [ String "bfl2"
-                        , String "rl_f6"
-                        ]
-                    , Array
-                        [ String "bfr0"
-                        , String "rl_f9"
-                        ]
-                    , Array
-                        [ String "bfr0"
-                        , String "rl_f7"
-                        ]
-                    , Array
-                        [ String "bfr1"
-                        , String "rl_f7"
-                        ]
-                    , Array
-                        [ String "bfr2"
-                        , String "rl_f7"
-                        ]
-                    , Comment
-                        ( InternalComment
-                            { cText = "Middle"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = True
-                            }
-                        )
-                    , Object
-                        [ ObjectKey
-                            ( String "beamDeform"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "18000"
-                                    , nvValue = 18000.0
-                                    }
-                                )
-                            )
-                        ]
-                    , Object
-                        [ ObjectKey
-                            ( String "beamStrength"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "4000"
-                                    , nvValue = 4000.0
-                                    }
-                                )
-                            )
-                        ]
-                    , Object
-                        [ ObjectKey
-                            ( String "breakGroupType"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "1"
-                                    , nvValue = 1.0
-                                    }
-                                )
-                            )
-                        ]
-                    , Array
-                        [ String "bfl3"
-                        , String "rl_f10"
-                        ]
-                    , Array
-                        [ String "bfl3"
-                        , String "rl_f11"
-                        ]
-                    , Array
-                        [ String "bfl4"
-                        , String "rl_f11"
-                        ]
-                    , Array
-                        [ String "bfr3"
-                        , String "rl_f12"
-                        ]
-                    , Array
-                        [ String "bfr3"
-                        , String "rl_f13"
-                        ]
-                    , Array
-                        [ String "bfr4"
-                        , String "rl_f13"
-                        ]
-                    , Object
-                        [ ObjectKey
-                            ( String "breakGroupType"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "0"
-                                    , nvValue = 0.0
-                                    }
-                                )
-                            )
-                        ]
-                    , Comment
-                        ( InternalComment
-                            { cText = "Rear"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = True
-                            }
-                        )
-                    , Object
-                        [ ObjectKey
-                            ( String "beamStrength"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "16000"
-                                    , nvValue = 16000.0
-                                    }
-                                )
-                            )
-                        , ObjectKey
-                            ( String "beamDeform"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "12000"
-                                    , nvValue = 12000.0
-                                    }
-                                )
-                            )
-                        ]
-                    , Array
-                        [ String "bfl5"
-                        , String "rl_f15"
-                        ]
-                    , Array
-                        [ String "bfl5"
-                        , String "rl_f16"
-                        ]
-                    , Array
-                        [ String "bfl6"
-                        , String "rl_f15"
-                        ]
-                    , Array
-                        [ String "bfl6"
-                        , String "rl_f16"
-                        ]
-                    , Array
-                        [ String "bfl8"
-                        , String "rl_f15"
-                        ]
-                    , Array
-                        [ String "bfl8"
-                        , String "rl_f16"
-                        ]
-                    , Array
-                        [ String "bfl9"
-                        , String "rl_f15"
-                        ]
-                    , Array
-                        [ String "bfl9"
-                        , String "rl_f16"
-                        ]
-                    , Array
-                        [ String "bfl7"
-                        , String "rl_f16"
-                        ]
-                    , Array
-                        [ String "bfl10"
-                        , String "rl_f16"
-                        ]
-                    , Array
-                        [ String "bfr5"
-                        , String "rl_f17"
-                        ]
-                    , Array
-                        [ String "bfr5"
-                        , String "rl_f18"
-                        ]
-                    , Array
-                        [ String "bfr6"
-                        , String "rl_f17"
-                        ]
-                    , Array
-                        [ String "bfr6"
-                        , String "rl_f18"
-                        ]
-                    , Array
-                        [ String "bfr8"
-                        , String "rl_f17"
-                        ]
-                    , Array
-                        [ String "bfr8"
-                        , String "rl_f18"
-                        ]
-                    , Array
-                        [ String "bfr9"
-                        , String "rl_f17"
-                        ]
-                    , Array
-                        [ String "bfr9"
-                        , String "rl_f18"
-                        ]
-                    , Array
-                        [ String "bfr7"
-                        , String "rl_f18"
-                        ]
-                    , Array
-                        [ String "bfr10"
-                        , String "rl_f18"
-                        ]
-                    , Object
-                        [ ObjectKey
-                            ( String "beamStrength"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "16000"
-                                    , nvValue = 16000.0
-                                    }
-                                )
-                            )
-                        , ObjectKey
-                            ( String "beamDeform"
-                            , String "FLT_MAX"
-                            )
-                        ]
-                    , Comment
-                        ( InternalComment
-                            { cText = "Body"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = False
-                            }
-                        )
-                    , Comment
-                        ( InternalComment
-                            { cText = "Left side"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = True
-                            }
-                        )
-                    , Object
-                        [ ObjectKey
-                            ( String "breakGroup"
-                            , String "fender_l"
-                            )
-                        ]
-                    , Array
-                        [ String "bfl8"
-                        , String "mbl0"
-                        ]
-                    , Array
-                        [ String "bfl9"
-                        , String "mbl1"
-                        ]
-                    , Array
-                        [ String "bfl10"
-                        , String "mbl2"
-                        ]
-                    , Comment
-                        ( InternalComment
-                            { cText = "Right side"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = True
-                            }
-                        )
-                    , Object
-                        [ ObjectKey
-                            ( String "breakGroup"
-                            , String "fender_r"
-                            )
-                        ]
-                    , Array
-                        [ String "bfr8"
-                        , String "mbr0"
-                        ]
-                    , Array
-                        [ String "bfr9"
-                        , String "mbr1"
-                        ]
-                    , Array
-                        [ String "bfr10"
-                        , String "mbr2"
-                        ]
-                    , Object
-                        [ ObjectKey
-                            ( String "breakGroup"
-                            , String ""
-                            )
-                        , ObjectKey
-                            ( String "breakGroupType"
-                            , String ""
-                            )
-                        , ObjectKey
-                            ( String "beamType"
-                            , String "|NORMAL"
-                            )
-                        ]
-                    ]
-                )
-            , ObjectKey
-                ( String "triangles"
-                , Array
-                    [ Array
-                        [ String "id1:"
-                        , String "id2:"
-                        , String "id3:"
-                        ]
-                    , Array
-                        [ String "bfl3"
-                        , String "bfl4"
-                        , String "bfl1"
-                        ]
-                    , Array
-                        [ String "bfl0"
-                        , String "bfl3"
-                        , String "bfl1"
-                        ]
-                    , Array
-                        [ String "bfl4"
-                        , String "bfl2"
-                        , String "bfl1"
-                        ]
-                    , Array
-                        [ String "bfl4"
-                        , String "bfl3"
-                        , String "bfl7"
-                        ]
-                    , Array
-                        [ String "bfl6"
-                        , String "bfl7"
-                        , String "bfl3"
-                        ]
-                    , Array
-                        [ String "bfl10"
-                        , String "bfl7"
-                        , String "bfl6"
-                        ]
-                    , Array
-                        [ String "bfl9"
-                        , String "bfl10"
-                        , String "bfl6"
-                        ]
-                    , Array
-                        [ String "bfl5"
-                        , String "bfl8"
-                        , String "bfl6"
-                        ]
-                    , Array
-                        [ String "bfl9"
-                        , String "bfl6"
-                        , String "bfl8"
-                        ]
-                    , Array
-                        [ String "bfr4"
-                        , String "bfr1"
-                        , String "bfr2"
-                        ]
-                    , Array
-                        [ String "bfr3"
-                        , String "bfr1"
-                        , String "bfr4"
-                        ]
-                    , Array
-                        [ String "bfr0"
-                        , String "bfr1"
-                        , String "bfr3"
-                        ]
-                    , Array
-                        [ String "bfr6"
-                        , String "bfr3"
-                        , String "bfr7"
-                        ]
-                    , Array
-                        [ String "bfr4"
-                        , String "bfr7"
-                        , String "bfr3"
-                        ]
-                    , Array
-                        [ String "bfr10"
-                        , String "bfr6"
-                        , String "bfr7"
-                        ]
-                    , Array
-                        [ String "bfr9"
-                        , String "bfr6"
-                        , String "bfr10"
-                        ]
-                    , Array
-                        [ String "bfr9"
-                        , String "bfr8"
-                        , String "bfr6"
-                        ]
-                    , Array
-                        [ String "bfr5"
-                        , String "bfr6"
-                        , String "bfr8"
-                        ]
-                    ]
-                )
-            , ObjectKey
-                ( String "flexbodies"
-                , Array
-                    [ Array
-                        [ String "mesh"
-                        , String "[group]:"
-                        , String "nonFlexMaterials"
-                        ]
-                    , Array
-                        [ String "impala_fender_l"
-                        , Array
-                            [ String "cot_fender_l" ]
-                        ]
-                    , Array
-                        [ String "impala_fender_inter_l"
-                        , Array
-                            [ String "cot_fender_l" ]
-                        ]
-                    , Array
-                        [ String "impala_fender_r"
-                        , Array
-                            [ String "cot_fender_r" ]
-                        ]
-                    , Array
-                        [ String "impala_fender_inter_r"
-                        , Array
-                            [ String "cot_fender_r" ]
-                        ]
-                    ]
+                            ]
+                        , ovTrailingComma = True
+                        }
+                    )
                 )
             ]
-        )
-    ]
+        , ovTrailingComma = True
+        }
+    )

--- a/examples/ast/jbeam/frame.hs
+++ b/examples/ast/jbeam/frame.hs
@@ -1,3065 +1,4925 @@
 Object
-    [ ObjectKey
-        ( String "chassis_rails"
-        , Object
+    ( ObjectValue
+        { ovElements =
             [ ObjectKey
-                ( String "information"
+                ( String "chassis_rails"
                 , Object
-                    [ ObjectKey
-                        ( String "authors"
-                        , String "gittarrgy01"
-                        )
-                    , ObjectKey
-                        ( String "name"
-                        , String ""
-                        )
-                    ]
-                )
-            , ObjectKey
-                ( String "slotType"
-                , String "main"
-                )
-            , Comment
-                ( InternalComment
-                    { cText = "\nThe purpose of this file is prove that moving metadata\nalong with vertices when moving vertices works as intended.\nSee issue for #69 explanation on the transformation part of the codebase.\n"
-                    , cMultiline = True
-                    , cAssociationDirection = NextNode
-                    , cHadNewlineBefore = False
-                    }
-                )
-            , Comment
-                ( InternalComment
-                    { cText = "--Nodes--"
-                    , cMultiline = False
-                    , cAssociationDirection = NextNode
-                    , cHadNewlineBefore = False
-                    }
-                )
-            , ObjectKey
-                ( String "nodes"
-                , Array
-                    [ Array
-                        [ String "id"
-                        , String "posX"
-                        , String "posY"
-                        , String "posZ"
-                        ]
-                    , Object
-                        [ ObjectKey
-                            ( String "group"
-                            , String "chassis_rails"
-                            )
-                        ]
-                    , Array
-                        [ String "rl_f0"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.523"
-                                , nvValue = 0.523
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-2.098"
-                                , nvValue = -2.098
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.319"
-                                , nvValue = 0.319
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl_f1"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.417"
-                                , nvValue = -0.417
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-2.098"
-                                , nvValue = -2.098
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.319"
-                                , nvValue = 0.319
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl_f2"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.053"
-                                , nvValue = 5.3e-2
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-2.095"
-                                , nvValue = -2.095
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.319"
-                                , nvValue = 0.319
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl_f3"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.523"
-                                , nvValue = 0.523
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-2.093"
-                                , nvValue = -2.093
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.268"
-                                , nvValue = 0.268
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl_f4"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.417"
-                                , nvValue = -0.417
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-2.093"
-                                , nvValue = -2.093
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.268"
-                                , nvValue = 0.268
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl_f5"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.053"
-                                , nvValue = 5.3e-2
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-2.090"
-                                , nvValue = -2.09
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.269"
-                                , nvValue = 0.269
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl_f6"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.531"
-                                , nvValue = 0.531
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-1.724"
-                                , nvValue = -1.724
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.341"
-                                , nvValue = 0.341
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl_f7"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.424"
-                                , nvValue = -0.424
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-1.724"
-                                , nvValue = -1.724
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.341"
-                                , nvValue = 0.341
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl_f8"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.531"
-                                , nvValue = 0.531
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-1.721"
-                                , nvValue = -1.721
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.289"
-                                , nvValue = 0.289
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl_f9"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.424"
-                                , nvValue = -0.424
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-1.721"
-                                , nvValue = -1.721
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.289"
-                                , nvValue = 0.289
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl_f10"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.547"
-                                , nvValue = 0.547
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-1.350"
-                                , nvValue = -1.35
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.310"
-                                , nvValue = 0.31
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl_f11"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.547"
-                                , nvValue = 0.547
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-1.350"
-                                , nvValue = -1.35
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.364"
-                                , nvValue = 0.364
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl_f12"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.440"
-                                , nvValue = -0.44
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-1.350"
-                                , nvValue = -1.35
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.310"
-                                , nvValue = 0.31
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl_f13"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.440"
-                                , nvValue = -0.44
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-1.350"
-                                , nvValue = -1.35
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.364"
-                                , nvValue = 0.364
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl_f14"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.053"
-                                , nvValue = 5.3e-2
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-1.314"
-                                , nvValue = -1.314
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.382"
-                                , nvValue = 0.382
-                                }
-                            )
-                        ]
-                    , Comment
-                        ( InternalComment
-                            { cText = "support for front"
-                            , cMultiline = False
-                            , cAssociationDirection = PreviousNode
-                            , cHadNewlineBefore = False
-                            }
-                        )
-                    , Array
-                        [ String "rl15"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.790"
-                                , nvValue = 0.79
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.919"
-                                , nvValue = -0.919
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.182"
-                                , nvValue = 0.182
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl16"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.790"
-                                , nvValue = 0.79
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.919"
-                                , nvValue = -0.919
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.233"
-                                , nvValue = 0.233
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl17"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.683"
-                                , nvValue = -0.683
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.919"
-                                , nvValue = -0.919
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.182"
-                                , nvValue = 0.182
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl18"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.683"
-                                , nvValue = -0.683
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.919"
-                                , nvValue = -0.919
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.233"
-                                , nvValue = 0.233
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl19"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.053"
-                                , nvValue = 5.3e-2
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.024"
-                                , nvValue = -2.4e-2
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.578"
-                                , nvValue = 0.578
-                                }
-                            )
-                        ]
-                    , Comment
-                        ( InternalComment
-                            { cText = "support"
-                            , cMultiline = False
-                            , cAssociationDirection = PreviousNode
-                            , cHadNewlineBefore = False
-                            }
-                        )
-                    , Array
-                        [ String "rl20"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.837"
-                                , nvValue = 0.837
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.002"
-                                , nvValue = 2.0e-3
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.182"
-                                , nvValue = 0.182
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl21"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.837"
-                                , nvValue = 0.837
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.002"
-                                , nvValue = 2.0e-3
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.233"
-                                , nvValue = 0.233
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl22"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.415"
-                                , nvValue = 0.415
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.002"
-                                , nvValue = 2.0e-3
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.182"
-                                , nvValue = 0.182
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl23"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.415"
-                                , nvValue = 0.415
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.002"
-                                , nvValue = 2.0e-3
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.233"
-                                , nvValue = 0.233
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl24"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.053"
-                                , nvValue = 5.3e-2
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.002"
-                                , nvValue = 2.0e-3
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.182"
-                                , nvValue = 0.182
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl25"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.053"
-                                , nvValue = 5.3e-2
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.002"
-                                , nvValue = 2.0e-3
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.233"
-                                , nvValue = 0.233
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl26"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.308"
-                                , nvValue = -0.308
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.002"
-                                , nvValue = 2.0e-3
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.182"
-                                , nvValue = 0.182
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl27"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.308"
-                                , nvValue = -0.308
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.002"
-                                , nvValue = 2.0e-3
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.233"
-                                , nvValue = 0.233
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl28"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.730"
-                                , nvValue = -0.73
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.002"
-                                , nvValue = 2.0e-3
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.182"
-                                , nvValue = 0.182
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl29"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.730"
-                                , nvValue = -0.73
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.002"
-                                , nvValue = 2.0e-3
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.233"
-                                , nvValue = 0.233
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl30"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.822"
-                                , nvValue = 0.822
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.791"
-                                , nvValue = 0.791
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.182"
-                                , nvValue = 0.182
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl31"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.822"
-                                , nvValue = 0.822
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.791"
-                                , nvValue = 0.791
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.233"
-                                , nvValue = 0.233
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl32"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.715"
-                                , nvValue = -0.715
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.791"
-                                , nvValue = 0.791
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.182"
-                                , nvValue = 0.182
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl33"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.715"
-                                , nvValue = -0.715
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.791"
-                                , nvValue = 0.791
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.233"
-                                , nvValue = 0.233
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl_r34"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.651"
-                                , nvValue = 0.651
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "1.121"
-                                , nvValue = 1.121
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.628"
-                                , nvValue = 0.628
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl_r35"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.053"
-                                , nvValue = 5.3e-2
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "1.121"
-                                , nvValue = 1.121
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.628"
-                                , nvValue = 0.628
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl_r36"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.544"
-                                , nvValue = -0.544
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "1.121"
-                                , nvValue = 1.121
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.628"
-                                , nvValue = 0.628
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl_r37"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.651"
-                                , nvValue = 0.651
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "1.152"
-                                , nvValue = 1.152
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.565"
-                                , nvValue = 0.565
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl_r38"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.053"
-                                , nvValue = 5.3e-2
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "1.152"
-                                , nvValue = 1.152
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.565"
-                                , nvValue = 0.565
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl_r39"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.544"
-                                , nvValue = -0.544
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "1.152"
-                                , nvValue = 1.152
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.565"
-                                , nvValue = 0.565
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl_r40"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.602"
-                                , nvValue = 0.602
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "1.514"
-                                , nvValue = 1.514
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.566"
-                                , nvValue = 0.566
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl_r41"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.495"
-                                , nvValue = -0.495
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "1.514"
-                                , nvValue = 1.514
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.566"
-                                , nvValue = 0.566
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl_r42"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.602"
-                                , nvValue = 0.602
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "1.532"
-                                , nvValue = 1.532
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.623"
-                                , nvValue = 0.623
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl_r43"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.495"
-                                , nvValue = -0.495
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "1.532"
-                                , nvValue = 1.532
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.623"
-                                , nvValue = 0.623
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl_r44"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.553"
-                                , nvValue = 0.553
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "1.654"
-                                , nvValue = 1.654
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.359"
-                                , nvValue = 0.359
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl_r45"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.446"
-                                , nvValue = -0.446
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "1.654"
-                                , nvValue = 1.654
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.359"
-                                , nvValue = 0.359
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl_r46"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.553"
-                                , nvValue = 0.553
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "1.679"
-                                , nvValue = 1.679
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.448"
-                                , nvValue = 0.448
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl_r47"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.446"
-                                , nvValue = -0.446
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "1.679"
-                                , nvValue = 1.679
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.448"
-                                , nvValue = 0.448
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl_r48"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.053"
-                                , nvValue = 5.3e-2
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "1.710"
-                                , nvValue = 1.71
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.565"
-                                , nvValue = 0.565
-                                }
-                            )
-                        ]
-                    , Comment
-                        ( InternalComment
-                            { cText = "support for rear"
-                            , cMultiline = False
-                            , cAssociationDirection = PreviousNode
-                            , cHadNewlineBefore = False
-                            }
-                        )
-                    , Array
-                        [ String "rl_r49"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.558"
-                                , nvValue = 0.558
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "2.284"
-                                , nvValue = 2.284
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.364"
-                                , nvValue = 0.364
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl_r50"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.558"
-                                , nvValue = 0.558
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "2.284"
-                                , nvValue = 2.284
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.447"
-                                , nvValue = 0.447
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl_r51"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.053"
-                                , nvValue = 5.3e-2
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "2.284"
-                                , nvValue = 2.284
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.370"
-                                , nvValue = 0.37
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl_r52"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.053"
-                                , nvValue = 5.3e-2
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "2.284"
-                                , nvValue = 2.284
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.441"
-                                , nvValue = 0.441
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl_r53"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.451"
-                                , nvValue = -0.451
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "2.284"
-                                , nvValue = 2.284
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.364"
-                                , nvValue = 0.364
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl_r54"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.451"
-                                , nvValue = -0.451
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "2.284"
-                                , nvValue = 2.284
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.447"
-                                , nvValue = 0.447
-                                }
-                            )
-                        ]
-                    , Object
-                        [ ObjectKey
-                            ( String "group"
-                            , String ""
-                            )
-                        ]
-                    ]
-                )
-            , Comment
-                ( InternalComment
-                    { cText = "--Beams--"
-                    , cMultiline = False
-                    , cAssociationDirection = NextNode
-                    , cHadNewlineBefore = False
-                    }
-                )
-            , ObjectKey
-                ( String "beams"
-                , Array
-                    [ Array
-                        [ String "id1:"
-                        , String "id2:"
-                        ]
-                    , Comment
-                        ( InternalComment
-                            { cText = "Structural beams"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = True
-                            }
-                        )
-                    , Object
-                        [ ObjectKey
-                            ( String "beamStrength"
-                            , String "FLT_MAX"
-                            )
-                        , ObjectKey
-                            ( String "beamSpring"
-                            , String "3800000"
-                            )
-                        ]
-                    , Object
-                        [ ObjectKey
-                            ( String "beamDamp"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "130"
-                                    , nvValue = 130.0
-                                    }
-                                )
-                            )
-                        , ObjectKey
-                            ( String "deformLimit"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "1.1"
-                                    , nvValue = 1.1
-                                    }
-                                )
-                            )
-                        ]
-                    , Comment
-                        ( InternalComment
-                            { cText = "Front end"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = True
-                            }
-                        )
-                    , Object
-                        [ ObjectKey
-                            ( String "beamDeform"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "20600"
-                                    , nvValue = 20600.0
-                                    }
-                                )
-                            )
-                        , ObjectKey
-                            ( String "deformLimit"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "1.1"
-                                    , nvValue = 1.1
-                                    }
-                                )
-                            )
-                        ]
-                    , Array
-                        [ String "rl_f3"
-                        , String "rl_f5"
-                        ]
-                    , Array
-                        [ String "rl_f0"
-                        , String "rl_f3"
-                        ]
-                    , Array
-                        [ String "rl_f8"
-                        , String "rl_f3"
-                        ]
-                    , Array
-                        [ String "rl15"
-                        , String "rl_f10"
-                        ]
-                    , Array
-                        [ String "rl_f8"
-                        , String "rl_f6"
-                        ]
-                    , Array
-                        [ String "rl_f11"
-                        , String "rl_f10"
-                        ]
-                    , Array
-                        [ String "rl_f10"
-                        , String "rl_f8"
-                        ]
-                    , Array
-                        [ String "rl_f9"
-                        , String "rl_f7"
-                        ]
-                    , Array
-                        [ String "rl17"
-                        , String "rl_f12"
-                        ]
-                    , Array
-                        [ String "rl_f6"
-                        , String "rl_f11"
-                        ]
-                    , Array
-                        [ String "rl_f11"
-                        , String "rl16"
-                        ]
-                    , Array
-                        [ String "rl_f13"
-                        , String "rl18"
-                        ]
-                    , Array
-                        [ String "rl_f13"
-                        , String "rl_f12"
-                        ]
-                    , Array
-                        [ String "rl_f1"
-                        , String "rl_f4"
-                        ]
-                    , Array
-                        [ String "rl_f2"
-                        , String "rl_f1"
-                        ]
-                    , Array
-                        [ String "rl_f2"
-                        , String "rl_f5"
-                        ]
-                    , Array
-                        [ String "rl_f12"
-                        , String "rl_f9"
-                        ]
-                    , Array
-                        [ String "rl_f7"
-                        , String "rl_f13"
-                        ]
-                    , Array
-                        [ String "rl_f0"
-                        , String "rl_f6"
-                        ]
-                    , Array
-                        [ String "rl_f9"
-                        , String "rl_f4"
-                        ]
-                    , Array
-                        [ String "rl_f2"
-                        , String "rl_f0"
-                        ]
-                    , Array
-                        [ String "rl_f4"
-                        , String "rl_f5"
-                        ]
-                    , Array
-                        [ String "rl_f1"
-                        , String "rl_f7"
-                        ]
-                    , Comment
-                        ( InternalComment
-                            { cText = "Middle"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = True
-                            }
-                        )
-                    , Object
-                        [ ObjectKey
-                            ( String "beamDeform"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "27000"
-                                    , nvValue = 27000.0
-                                    }
-                                )
-                            )
-                        ]
-                    , Array
-                        [ String "rl16"
-                        , String "rl15"
-                        ]
-                    , Array
-                        [ String "rl20"
-                        , String "rl30"
-                        ]
-                    , Array
-                        [ String "rl16"
-                        , String "rl23"
-                        ]
-                    , Array
-                        [ String "rl18"
-                        , String "rl17"
-                        ]
-                    , Array
-                        [ String "rl17"
-                        , String "rl28"
-                        ]
-                    , Array
-                        [ String "rl26"
-                        , String "rl17"
-                        ]
-                    , Array
-                        [ String "rl18"
-                        , String "rl27"
-                        ]
-                    , Array
-                        [ String "rl26"
-                        , String "rl24"
-                        ]
-                    , Array
-                        [ String "rl25"
-                        , String "rl24"
-                        ]
-                    , Array
-                        [ String "rl25"
-                        , String "rl27"
-                        ]
-                    , Array
-                        [ String "rl21"
-                        , String "rl16"
-                        ]
-                    , Array
-                        [ String "rl22"
-                        , String "rl15"
-                        ]
-                    , Array
-                        [ String "rl15"
-                        , String "rl20"
-                        ]
-                    , Array
-                        [ String "rl29"
-                        , String "rl27"
-                        ]
-                    , Array
-                        [ String "rl28"
-                        , String "rl32"
-                        ]
-                    , Array
-                        [ String "rl29"
-                        , String "rl18"
-                        ]
-                    , Array
-                        [ String "rl22"
-                        , String "rl24"
-                        ]
-                    , Array
-                        [ String "rl31"
-                        , String "rl21"
-                        ]
-                    , Array
-                        [ String "rl28"
-                        , String "rl29"
-                        ]
-                    , Array
-                        [ String "rl32"
-                        , String "rl33"
-                        ]
-                    , Array
-                        [ String "rl30"
-                        , String "rl31"
-                        ]
-                    , Array
-                        [ String "rl33"
-                        , String "rl29"
-                        ]
-                    , Array
-                        [ String "rl30"
-                        , String "rl22"
-                        ]
-                    , Array
-                        [ String "rl25"
-                        , String "rl23"
-                        ]
-                    , Array
-                        [ String "rl32"
-                        , String "rl26"
-                        ]
-                    , Array
-                        [ String "rl20"
-                        , String "rl21"
-                        ]
-                    , Array
-                        [ String "rl31"
-                        , String "rl23"
-                        ]
-                    , Array
-                        [ String "rl20"
-                        , String "rl22"
-                        ]
-                    , Array
-                        [ String "rl21"
-                        , String "rl23"
-                        ]
-                    , Array
-                        [ String "rl33"
-                        , String "rl27"
-                        ]
-                    , Array
-                        [ String "rl23"
-                        , String "rl22"
-                        ]
-                    , Array
-                        [ String "rl28"
-                        , String "rl26"
-                        ]
-                    , Array
-                        [ String "rl27"
-                        , String "rl26"
-                        ]
-                    , Comment
-                        ( InternalComment
-                            { cText = "Rear end"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = True
-                            }
-                        )
-                    , Object
-                        [ ObjectKey
-                            ( String "beamDeform"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "22000"
-                                    , nvValue = 22000.0
-                                    }
-                                )
-                            )
-                        ]
-                    , Array
-                        [ String "rl_r37"
-                        , String "rl_r34"
-                        ]
-                    , Array
-                        [ String "rl_r39"
-                        , String "rl_r41"
-                        ]
-                    , Array
-                        [ String "rl_r44"
-                        , String "rl_r46"
-                        ]
-                    , Array
-                        [ String "rl33"
-                        , String "rl_r36"
-                        ]
-                    , Array
-                        [ String "rl_r46"
-                        , String "rl_r42"
-                        ]
-                    , Array
-                        [ String "rl31"
-                        , String "rl_r34"
-                        ]
-                    , Array
-                        [ String "rl_r37"
-                        , String "rl30"
-                        ]
-                    , Array
-                        [ String "rl_r49"
-                        , String "rl_r51"
-                        ]
-                    , Array
-                        [ String "rl_r52"
-                        , String "rl_r50"
-                        ]
-                    , Array
-                        [ String "rl_r50"
-                        , String "rl_r46"
-                        ]
-                    , Array
-                        [ String "rl_r49"
-                        , String "rl_r50"
-                        ]
-                    , Array
-                        [ String "rl_r42"
-                        , String "rl_r34"
-                        ]
-                    , Array
-                        [ String "rl_r40"
-                        , String "rl_r44"
-                        ]
-                    , Array
-                        [ String "rl_r40"
-                        , String "rl_r42"
-                        ]
-                    , Array
-                        [ String "rl_r41"
-                        , String "rl_r45"
-                        ]
-                    , Array
-                        [ String "rl_r39"
-                        , String "rl_r36"
-                        ]
-                    , Array
-                        [ String "rl_r36"
-                        , String "rl_r35"
-                        ]
-                    , Array
-                        [ String "rl_r38"
-                        , String "rl_r35"
-                        ]
-                    , Array
-                        [ String "rl_r53"
-                        , String "rl_r54"
-                        ]
-                    , Array
-                        [ String "rl_r52"
-                        , String "rl_r54"
-                        ]
-                    , Array
-                        [ String "rl_r51"
-                        , String "rl_r52"
-                        ]
-                    , Array
-                        [ String "rl_r45"
-                        , String "rl_r53"
-                        ]
-                    , Array
-                        [ String "rl_r54"
-                        , String "rl_r47"
-                        ]
-                    , Array
-                        [ String "rl_r43"
-                        , String "rl_r36"
-                        ]
-                    , Array
-                        [ String "rl_r53"
-                        , String "rl_r51"
-                        ]
-                    , Array
-                        [ String "rl_r34"
-                        , String "rl_r35"
-                        ]
-                    , Array
-                        [ String "rl_r38"
-                        , String "rl_r37"
-                        ]
-                    , Array
-                        [ String "rl_r45"
-                        , String "rl_r47"
-                        ]
-                    , Array
-                        [ String "rl_r41"
-                        , String "rl_r43"
-                        ]
-                    , Array
-                        [ String "rl_r38"
-                        , String "rl_r39"
-                        ]
-                    , Array
-                        [ String "rl_r39"
-                        , String "rl32"
-                        ]
-                    , Array
-                        [ String "rl_r47"
-                        , String "rl_r43"
-                        ]
-                    , Array
-                        [ String "rl_r44"
-                        , String "rl_r49"
-                        ]
-                    , Array
-                        [ String "rl_r37"
-                        , String "rl_r40"
-                        ]
-                    , Comment
-                        ( InternalComment
-                            { cText = "Crossing beams"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = True
-                            }
-                        )
-                    , Comment
-                        ( InternalComment
-                            { cText = "Front end"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = True
-                            }
-                        )
-                    , Object
-                        [ ObjectKey
-                            ( String "beamDeform"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "16000"
-                                    , nvValue = 16000.0
-                                    }
-                                )
-                            )
-                        ]
-                    , Array
-                        [ String "rl_f4"
-                        , String "rl_f2"
-                        ]
-                    , Array
-                        [ String "rl_f0"
-                        , String "rl_f8"
-                        ]
-                    , Array
-                        [ String "rl16"
-                        , String "rl_f10"
-                        ]
-                    , Array
-                        [ String "rl15"
-                        , String "rl_f11"
-                        ]
-                    , Array
-                        [ String "rl_f10"
-                        , String "rl_f6"
-                        ]
-                    , Array
-                        [ String "rl_f11"
-                        , String "rl_f8"
-                        ]
-                    , Array
-                        [ String "rl_f1"
-                        , String "rl_f5"
-                        ]
-                    , Array
-                        [ String "rl_f4"
-                        , String "rl_f7"
-                        ]
-                    , Array
-                        [ String "rl_f1"
-                        , String "rl_f9"
-                        ]
-                    , Array
-                        [ String "rl_f12"
-                        , String "rl_f7"
-                        ]
-                    , Array
-                        [ String "rl_f3"
-                        , String "rl_f6"
-                        ]
-                    , Array
-                        [ String "rl_f0"
-                        , String "rl_f5"
-                        ]
-                    , Array
-                        [ String "rl_f3"
-                        , String "rl_f2"
-                        ]
-                    , Array
-                        [ String "rl_f13"
-                        , String "rl_f9"
-                        ]
-                    , Array
-                        [ String "rl17"
-                        , String "rl_f13"
-                        ]
-                    , Array
-                        [ String "rl18"
-                        , String "rl_f12"
-                        ]
-                    , Comment
-                        ( InternalComment
-                            { cText = "Middle"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = True
-                            }
-                        )
-                    , Object
-                        [ ObjectKey
-                            ( String "beamDeform"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "6500"
-                                    , nvValue = 6500.0
-                                    }
-                                )
-                            )
-                        ]
-                    , Array
-                        [ String "rl16"
-                        , String "rl20"
-                        ]
-                    , Array
-                        [ String "rl15"
-                        , String "rl23"
-                        ]
-                    , Array
-                        [ String "rl18"
-                        , String "rl28"
-                        ]
-                    , Array
-                        [ String "rl18"
-                        , String "rl26"
-                        ]
-                    , Array
-                        [ String "rl17"
-                        , String "rl27"
-                        ]
-                    , Array
-                        [ String "rl27"
-                        , String "rl24"
-                        ]
-                    , Array
-                        [ String "rl26"
-                        , String "rl25"
-                        ]
-                    , Array
-                        [ String "rl31"
-                        , String "rl20"
-                        ]
-                    , Array
-                        [ String "rl15"
-                        , String "rl21"
-                        ]
-                    , Array
-                        [ String "rl16"
-                        , String "rl22"
-                        ]
-                    , Array
-                        [ String "rl32"
-                        , String "rl29"
-                        ]
-                    , Array
-                        [ String "rl30"
-                        , String "rl21"
-                        ]
-                    , Array
-                        [ String "rl23"
-                        , String "rl24"
-                        ]
-                    , Array
-                        [ String "rl32"
-                        , String "rl27"
-                        ]
-                    , Array
-                        [ String "rl17"
-                        , String "rl29"
-                        ]
-                    , Array
-                        [ String "rl33"
-                        , String "rl28"
-                        ]
-                    , Array
-                        [ String "rl29"
-                        , String "rl26"
-                        ]
-                    , Array
-                        [ String "rl30"
-                        , String "rl23"
-                        ]
-                    , Array
-                        [ String "rl33"
-                        , String "rl26"
-                        ]
-                    , Array
-                        [ String "rl22"
-                        , String "rl25"
-                        ]
-                    , Array
-                        [ String "rl20"
-                        , String "rl23"
-                        ]
-                    , Array
-                        [ String "rl28"
-                        , String "rl27"
-                        ]
-                    , Array
-                        [ String "rl31"
-                        , String "rl22"
-                        ]
-                    , Array
-                        [ String "rl21"
-                        , String "rl22"
-                        ]
-                    , Comment
-                        ( InternalComment
-                            { cText = "Rear end"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = True
-                            }
-                        )
-                    , Object
-                        [ ObjectKey
-                            ( String "beamDeform"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "16000"
-                                    , nvValue = 16000.0
-                                    }
-                                )
-                            )
-                        ]
-                    , Array
-                        [ String "rl_r54"
-                        , String "rl_r45"
-                        ]
-                    , Array
-                        [ String "rl32"
-                        , String "rl_r36"
-                        ]
-                    , Array
-                        [ String "rl_r36"
-                        , String "rl_r41"
-                        ]
-                    , Array
-                        [ String "rl_r50"
-                        , String "rl_r51"
-                        ]
-                    , Array
-                        [ String "rl31"
-                        , String "rl_r37"
-                        ]
-                    , Array
-                        [ String "rl30"
-                        , String "rl_r34"
-                        ]
-                    , Array
-                        [ String "rl_r46"
-                        , String "rl_r40"
-                        ]
-                    , Array
-                        [ String "rl_r53"
-                        , String "rl_r47"
-                        ]
-                    , Array
-                        [ String "rl_r50"
-                        , String "rl_r44"
-                        ]
-                    , Array
-                        [ String "rl_r49"
-                        , String "rl_r46"
-                        ]
-                    , Array
-                        [ String "rl_r37"
-                        , String "rl_r42"
-                        ]
-                    , Array
-                        [ String "rl_r34"
-                        , String "rl_r40"
-                        ]
-                    , Array
-                        [ String "rl_r34"
-                        , String "rl_r38"
-                        ]
-                    , Array
-                        [ String "rl33"
-                        , String "rl_r39"
-                        ]
-                    , Array
-                        [ String "rl_r39"
-                        , String "rl_r35"
-                        ]
-                    , Array
-                        [ String "rl_r36"
-                        , String "rl_r38"
-                        ]
-                    , Array
-                        [ String "rl_r53"
-                        , String "rl_r52"
-                        ]
-                    , Array
-                        [ String "rl_r54"
-                        , String "rl_r51"
-                        ]
-                    , Array
-                        [ String "rl_r45"
-                        , String "rl_r43"
-                        ]
-                    , Array
-                        [ String "rl_r47"
-                        , String "rl_r41"
-                        ]
-                    , Array
-                        [ String "rl_r39"
-                        , String "rl_r43"
-                        ]
-                    , Array
-                        [ String "rl_r37"
-                        , String "rl_r35"
-                        ]
-                    , Array
-                        [ String "rl_r49"
-                        , String "rl_r52"
-                        ]
-                    , Array
-                        [ String "rl_r44"
-                        , String "rl_r42"
-                        ]
-                    , Comment
-                        ( InternalComment
-                            { cText = "Support beams"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = True
-                            }
-                        )
-                    , Comment
-                        ( InternalComment
-                            { cText = "Front end"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = True
-                            }
-                        )
-                    , Object
-                        [ ObjectKey
-                            ( String "beamDeform"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "19000"
-                                    , nvValue = 19000.0
-                                    }
-                                )
-                            )
-                        ]
-                    , Array
-                        [ String "rl_f8"
-                        , String "rl_f14"
-                        ]
-                    , Array
-                        [ String "rl_f9"
-                        , String "rl_f14"
-                        ]
-                    , Array
-                        [ String "rl_f"
-                        , String "rl_f3"
-                        ]
-                    , Array
-                        [ String "rl_f10"
-                        , String "rl_f14"
-                        ]
-                    , Array
-                        [ String "rl_f14"
-                        , String "rl_f13"
-                        ]
-                    , Array
-                        [ String "rl_f1"
-                        , String "rl_f14"
-                        ]
-                    , Array
-                        [ String "rl_f0"
-                        , String "rl_f14"
-                        ]
-                    , Array
-                        [ String "rl_f12"
-                        , String "rl_f14"
-                        ]
-                    , Array
-                        [ String "rl_f5"
-                        , String "rl_f14"
-                        ]
-                    , Array
-                        [ String "rl_f14"
-                        , String "rl_f4"
-                        ]
-                    , Array
-                        [ String "rl_f14"
-                        , String "rl_f6"
-                        ]
-                    , Array
-                        [ String "rl_f14"
-                        , String "rl_f7"
-                        ]
-                    , Array
-                        [ String "rl_f14"
-                        , String "rl_f2"
-                        ]
-                    , Array
-                        [ String "rl_f14"
-                        , String "rl_f11"
-                        ]
-                    , Comment
-                        ( InternalComment
-                            { cText = "Middle"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = True
-                            }
-                        )
-                    , Object
-                        [ ObjectKey
-                            ( String "beamDeform"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "11000"
-                                    , nvValue = 11000.0
-                                    }
-                                )
-                            )
-                        ]
-                    , Array
-                        [ String "rl27"
-                        , String "rl19"
-                        ]
-                    , Array
-                        [ String "rl26"
-                        , String "rl19"
-                        ]
-                    , Array
-                        [ String "rl24"
-                        , String "rl19"
-                        ]
-                    , Array
-                        [ String "rl23"
-                        , String "rl19"
-                        ]
-                    , Array
-                        [ String "rl20"
-                        , String "rl19"
-                        ]
-                    , Array
-                        [ String "rl19"
-                        , String "rl16"
-                        ]
-                    , Array
-                        [ String "rl19"
-                        , String "rl15"
-                        ]
-                    , Array
-                        [ String "rl31"
-                        , String "rl19"
-                        ]
-                    , Array
-                        [ String "rl33"
-                        , String "rl19"
-                        ]
-                    , Array
-                        [ String "rl28"
-                        , String "rl19"
-                        ]
-                    , Array
-                        [ String "rl19"
-                        , String "rl25"
-                        ]
-                    , Array
-                        [ String "rl21"
-                        , String "rl19"
-                        ]
-                    , Array
-                        [ String "rl22"
-                        , String "rl19"
-                        ]
-                    , Array
-                        [ String "rl19"
-                        , String "rl32"
-                        ]
-                    , Array
-                        [ String "rl29"
-                        , String "rl19"
-                        ]
-                    , Array
-                        [ String "rl19"
-                        , String "rl18"
-                        ]
-                    , Array
-                        [ String "rl19"
-                        , String "rl17"
-                        ]
-                    , Array
-                        [ String "rl19"
-                        , String "rl30"
-                        ]
-                    , Comment
-                        ( InternalComment
-                            { cText = "Rear end"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = True
-                            }
-                        )
-                    , Object
-                        [ ObjectKey
-                            ( String "beamDeform"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "19000"
-                                    , nvValue = 19000.0
-                                    }
-                                )
-                            )
-                        ]
-                    , Array
-                        [ String "rl_r48"
-                        , String "rl_r51"
-                        ]
-                    , Array
-                        [ String "rl_r48"
-                        , String "rl_r54"
-                        ]
-                    , Array
-                        [ String "rl_r45"
-                        , String "rl_r48"
-                        ]
-                    , Array
-                        [ String "rl_r48"
-                        , String "rl_r50"
-                        ]
-                    , Array
-                        [ String "rl_r48"
-                        , String "rl_r42"
-                        ]
-                    , Array
-                        [ String "rl_r48"
-                        , String "rl_r47"
-                        ]
-                    , Array
-                        [ String "rl_r49"
-                        , String "rl_r48"
-                        ]
-                    , Array
-                        [ String "rl_r35"
-                        , String "rl_r48"
-                        ]
-                    , Array
-                        [ String "rl_r48"
-                        , String "rl_r43"
-                        ]
-                    , Array
-                        [ String "rl_r44"
-                        , String "rl_r48"
-                        ]
-                    , Array
-                        [ String "rl_r53"
-                        , String "rl_r48"
-                        ]
-                    , Array
-                        [ String "rl_r52"
-                        , String "rl_r48"
-                        ]
-                    , Array
-                        [ String "rl_r40"
-                        , String "rl_r48"
-                        ]
-                    , Array
-                        [ String "rl_r48"
-                        , String "rl_r38"
-                        ]
-                    , Array
-                        [ String "rl_r41"
-                        , String "rl_r48"
-                        ]
-                    , Array
-                        [ String "rl_r4"
-                        , String "rl_r46"
-                        ]
-                    , Comment
-                        ( InternalComment
-                            { cText = "Front crush"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = True
-                            }
-                        )
-                    , Object
-                        [ ObjectKey
-                            ( String "beamDeform"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "8500"
-                                    , nvValue = 8500.0
-                                    }
-                                )
-                            )
-                        ]
-                    , Array
-                        [ String "rl17"
-                        , String "rl_f9"
-                        ]
-                    , Array
-                        [ String "rl15"
-                        , String "rl_f8"
-                        ]
-                    ]
-                )
-            , Comment
-                ( InternalComment
-                    { cText = "--Collision Triangles--"
-                    , cMultiline = False
-                    , cAssociationDirection = NextNode
-                    , cHadNewlineBefore = False
-                    }
-                )
-            , ObjectKey
-                ( String "triangles"
-                , Array
-                    [ Array
-                        [ String "id1:"
-                        , String "id2:"
-                        , String "id3:"
-                        ]
-                    , Array
-                        [ String "rl_f5"
-                        , String "rl_f3"
-                        , String "rl_f2"
-                        ]
-                    , Array
-                        [ String "rl_f0"
-                        , String "rl_f2"
-                        , String "rl_f3"
-                        ]
-                    , Array
-                        [ String "rl_f5"
-                        , String "rl_f2"
-                        , String "rl_f4"
-                        ]
-                    , Array
-                        [ String "rl_f1"
-                        , String "rl_f4"
-                        , String "rl_f2"
-                        ]
-                    , Array
-                        [ String "rl_f4"
-                        , String "rl_f1"
-                        , String "rl_f7"
-                        ]
-                    , Array
-                        [ String "rl_f4"
-                        , String "rl_f7"
-                        , String "rl_f9"
-                        ]
-                    , Array
-                        [ String "rl_f7"
-                        , String "rl_f13"
-                        , String "rl_f9"
-                        ]
-                    , Array
-                        [ String "rl_f12"
-                        , String "rl_f9"
-                        , String "rl_f13"
-                        ]
-                    , Array
-                        [ String "rl_f12"
-                        , String "rl_f13"
-                        , String "rl18"
-                        ]
-                    , Array
-                        [ String "rl18"
-                        , String "rl17"
-                        , String "rl_f12"
-                        ]
-                    , Array
-                        [ String "rl_f3"
-                        , String "rl_f6"
-                        , String "rl_f0"
-                        ]
-                    , Array
-                        [ String "rl_f3"
-                        , String "rl_f8"
-                        , String "rl_f6"
-                        ]
-                    , Array
-                        [ String "rl_f10"
-                        , String "rl_f11"
-                        , String "rl_f8"
-                        ]
-                    , Array
-                        [ String "rl_f6"
-                        , String "rl_f8"
-                        , String "rl_f11"
-                        ]
-                    , Array
-                        [ String "rl_f10"
-                        , String "rl16"
-                        , String "rl_f11"
-                        ]
-                    , Array
-                        [ String "rl16"
-                        , String "rl_f10"
-                        , String "rl15"
-                        ]
-                    , Array
-                        [ String "rl15"
-                        , String "rl20"
-                        , String "rl16"
-                        ]
-                    , Array
-                        [ String "rl21"
-                        , String "rl16"
-                        , String "rl20"
-                        ]
-                    , Array
-                        [ String "rl30"
-                        , String "rl21"
-                        , String "rl20"
-                        ]
-                    , Array
-                        [ String "rl31"
-                        , String "rl21"
-                        , String "rl30"
-                        ]
-                    , Array
-                        [ String "rl17"
-                        , String "rl18"
-                        , String "rl28"
-                        ]
-                    , Array
-                        [ String "rl29"
-                        , String "rl28"
-                        , String "rl18"
-                        ]
-                    , Array
-                        [ String "rl32"
-                        , String "rl28"
-                        , String "rl29"
-                        ]
-                    , Array
-                        [ String "rl33"
-                        , String "rl32"
-                        , String "rl29"
-                        ]
-                    , Array
-                        [ String "rl32"
-                        , String "rl33"
-                        , String "rl_r39"
-                        ]
-                    , Array
-                        [ String "rl_r39"
-                        , String "rl33"
-                        , String "rl_r36"
-                        ]
-                    , Array
-                        [ String "rl_r36"
-                        , String "rl_r41"
-                        , String "rl_r39"
-                        ]
-                    , Array
-                        [ String "rl_r43"
-                        , String "rl_r41"
-                        , String "rl_r36"
-                        ]
-                    , Array
-                        [ String "rl_r45"
-                        , String "rl_r41"
-                        , String "rl_r43"
-                        ]
-                    , Array
-                        [ String "rl_r47"
-                        , String "rl_r45"
-                        , String "rl_r43"
-                        ]
-                    , Array
-                        [ String "rl_r53"
-                        , String "rl_r45"
-                        , String "rl_r47"
-                        ]
-                    , Array
-                        [ String "rl_r54"
-                        , String "rl_r53"
-                        , String "rl_r47"
-                        ]
-                    , Array
-                        [ String "rl_r54"
-                        , String "rl_r51"
-                        , String "rl_r53"
-                        ]
-                    , Array
-                        [ String "rl_r51"
-                        , String "rl_r54"
-                        , String "rl_r52"
-                        ]
-                    , Array
-                        [ String "rl_r52"
-                        , String "rl_r50"
-                        , String "rl_r51"
-                        ]
-                    , Array
-                        [ String "rl_r50"
-                        , String "rl_r49"
-                        , String "rl_r51"
-                        ]
-                    , Array
-                        [ String "rl_r46"
-                        , String "rl_r44"
-                        , String "rl_r49"
-                        ]
-                    , Array
-                        [ String "rl_r50"
-                        , String "rl_r46"
-                        , String "rl_r49"
-                        ]
-                    , Array
-                        [ String "rl_r46"
-                        , String "rl_r42"
-                        , String "rl_r44"
-                        ]
-                    , Array
-                        [ String "rl_r44"
-                        , String "rl_r42"
-                        , String "rl_r40"
-                        ]
-                    , Array
-                        [ String "rl_r34"
-                        , String "rl_r37"
-                        , String "rl_r40"
-                        ]
-                    , Array
-                        [ String "rl_r42"
-                        , String "rl_r34"
-                        , String "rl_r40"
-                        ]
-                    , Array
-                        [ String "rl_r34"
-                        , String "rl_r35"
-                        , String "rl_r37"
-                        ]
-                    , Array
-                        [ String "rl_r35"
-                        , String "rl_r38"
-                        , String "rl_r37"
-                        ]
-                    , Array
-                        [ String "rl_r35"
-                        , String "rl_r39"
-                        , String "rl_r38"
-                        ]
-                    , Array
-                        [ String "rl_r39"
-                        , String "rl_r35"
-                        , String "rl_r36"
-                        ]
-                    , Array
-                        [ String "rl30"
-                        , String "rl_r37"
-                        , String "rl31"
-                        ]
-                    , Array
-                        [ String "rl_r37"
-                        , String "rl_r34"
-                        , String "rl31"
-                        ]
-                    , Array
-                        [ String "rl16"
-                        , String "rl15"
-                        , String "rl22"
-                        ]
-                    , Array
-                        [ String "rl16"
-                        , String "rl22"
-                        , String "rl23"
-                        ]
-                    , Array
-                        [ String "rl23"
-                        , String "rl22"
-                        , String "rl21"
-                        ]
-                    , Array
-                        [ String "rl21"
-                        , String "rl22"
-                        , String "rl20"
-                        ]
-                    , Array
-                        [ String "rl27"
-                        , String "rl29"
-                        , String "rl26"
-                        ]
-                    , Array
-                        [ String "rl29"
-                        , String "rl28"
-                        , String "rl26"
-                        ]
-                    , Array
-                        [ String "rl18"
-                        , String "rl26"
-                        , String "rl17"
-                        ]
-                    , Array
-                        [ String "rl27"
-                        , String "rl26"
-                        , String "rl18"
-                        ]
-                    , Array
-                        [ String "rl24"
-                        , String "rl22"
-                        , String "rl23"
-                        ]
-                    , Array
-                        [ String "rl27"
-                        , String "rl26"
-                        , String "rl24"
-                        ]
-                    , Array
-                        [ String "rl24"
-                        , String "rl25"
-                        , String "rl27"
-                        ]
-                    , Array
-                        [ String "rl24"
-                        , String "rl23"
-                        , String "rl25"
-                        ]
-                    , Array
-                        [ String "rl30"
-                        , String "rl23"
-                        , String "rl22"
-                        ]
-                    , Array
-                        [ String "rl30"
-                        , String "rl31"
-                        , String "rl23"
-                        ]
-                    , Array
-                        [ String "rl26"
-                        , String "rl27"
-                        , String "rl32"
-                        ]
-                    , Array
-                        [ String "rl33"
-                        , String "rl32"
-                        , String "rl27"
-                        ]
-                    ]
-                )
-            , ObjectKey
-                ( String "flexbodies"
-                , Array
-                    [ Array
-                        [ String "mesh"
-                        , String "[group]:"
-                        , String "nonFlexMaterials"
-                        ]
-                    , Array
-                        [ String "rails"
-                        , Array
-                            [ String "chassis_rails" ]
-                        ]
-                    ]
-                )
-            , ObjectKey
-                ( String "glowMap"
-                , Object
-                    [ Comment
-                        ( InternalComment
-                            { cText = "main lights"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = False
-                            }
-                        )
-                    , ObjectKey
-                        ( String "chassis_headlight_L"
-                        , Object
+                    ( ObjectValue
+                        { ovElements =
                             [ ObjectKey
-                                ( String "simpleFunction"
-                                , String "lowhighbeam_filament"
-                                )
-                            , ObjectKey
-                                ( String "off"
-                                , String "chassis_headlight"
-                                )
-                            , ObjectKey
-                                ( String "on"
-                                , String "chassis_headlight_on"
-                                )
-                            , ObjectKey
-                                ( String "materialEmissiveScaling"
+                                ( String "information"
                                 , Object
-                                    [ ObjectKey
-                                        ( String "on_max"
-                                        , Number
-                                            ( NumberValue
-                                                { nvText = "1"
-                                                , nvValue = 1.0
-                                                }
-                                            )
-                                        )
-                                    ]
-                                )
-                            ]
-                        )
-                    , ObjectKey
-                        ( String "chassis_headlight_R"
-                        , Object
-                            [ ObjectKey
-                                ( String "simpleFunction"
-                                , String "lowhighbeam_filament"
+                                    ( ObjectValue
+                                        { ovElements =
+                                            [ ObjectKey
+                                                ( String "authors"
+                                                , String "gittarrgy01"
+                                                )
+                                            , ObjectKey
+                                                ( String "name"
+                                                , String ""
+                                                )
+                                            ]
+                                        , ovTrailingComma = False
+                                        }
+                                    )
                                 )
                             , ObjectKey
-                                ( String "off"
-                                , String "chassis_headlight"
+                                ( String "slotType"
+                                , String "main"
+                                )
+                            , Comment
+                                ( InternalComment
+                                    { cText = "\nThe purpose of this file is prove that moving metadata\nalong with vertices when moving vertices works as intended.\nSee issue for #69 explanation on the transformation part of the codebase.\n"
+                                    , cMultiline = True
+                                    , cAssociationDirection = NextNode
+                                    , cHadNewlineBefore = False
+                                    }
+                                )
+                            , Comment
+                                ( InternalComment
+                                    { cText = "--Nodes--"
+                                    , cMultiline = False
+                                    , cAssociationDirection = NextNode
+                                    , cHadNewlineBefore = False
+                                    }
                                 )
                             , ObjectKey
-                                ( String "on"
-                                , String "chassis_headlight_on"
+                                ( String "nodes"
+                                , Array
+                                    ( ArrayValue
+                                        { avElements =
+                                            [ Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "id"
+                                                        , String "posX"
+                                                        , String "posY"
+                                                        , String "posZ"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "group"
+                                                            , String "chassis_rails"
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f0"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.523"
+                                                                , nvValue = 0.523
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-2.098"
+                                                                , nvValue = -2.098
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.319"
+                                                                , nvValue = 0.319
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f1"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.417"
+                                                                , nvValue = -0.417
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-2.098"
+                                                                , nvValue = -2.098
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.319"
+                                                                , nvValue = 0.319
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f2"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.053"
+                                                                , nvValue = 5.3e-2
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-2.095"
+                                                                , nvValue = -2.095
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.319"
+                                                                , nvValue = 0.319
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f3"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.523"
+                                                                , nvValue = 0.523
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-2.093"
+                                                                , nvValue = -2.093
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.268"
+                                                                , nvValue = 0.268
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f4"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.417"
+                                                                , nvValue = -0.417
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-2.093"
+                                                                , nvValue = -2.093
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.268"
+                                                                , nvValue = 0.268
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f5"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.053"
+                                                                , nvValue = 5.3e-2
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-2.090"
+                                                                , nvValue = -2.09
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.269"
+                                                                , nvValue = 0.269
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f6"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.531"
+                                                                , nvValue = 0.531
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-1.724"
+                                                                , nvValue = -1.724
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.341"
+                                                                , nvValue = 0.341
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f7"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.424"
+                                                                , nvValue = -0.424
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-1.724"
+                                                                , nvValue = -1.724
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.341"
+                                                                , nvValue = 0.341
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f8"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.531"
+                                                                , nvValue = 0.531
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-1.721"
+                                                                , nvValue = -1.721
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.289"
+                                                                , nvValue = 0.289
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f9"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.424"
+                                                                , nvValue = -0.424
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-1.721"
+                                                                , nvValue = -1.721
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.289"
+                                                                , nvValue = 0.289
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f10"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.547"
+                                                                , nvValue = 0.547
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-1.350"
+                                                                , nvValue = -1.35
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.310"
+                                                                , nvValue = 0.31
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f11"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.547"
+                                                                , nvValue = 0.547
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-1.350"
+                                                                , nvValue = -1.35
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.364"
+                                                                , nvValue = 0.364
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f12"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.440"
+                                                                , nvValue = -0.44
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-1.350"
+                                                                , nvValue = -1.35
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.310"
+                                                                , nvValue = 0.31
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f13"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.440"
+                                                                , nvValue = -0.44
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-1.350"
+                                                                , nvValue = -1.35
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.364"
+                                                                , nvValue = 0.364
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f14"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.053"
+                                                                , nvValue = 5.3e-2
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-1.314"
+                                                                , nvValue = -1.314
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.382"
+                                                                , nvValue = 0.382
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "support for front"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = PreviousNode
+                                                    , cHadNewlineBefore = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl15"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.790"
+                                                                , nvValue = 0.79
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.919"
+                                                                , nvValue = -0.919
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.182"
+                                                                , nvValue = 0.182
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl16"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.790"
+                                                                , nvValue = 0.79
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.919"
+                                                                , nvValue = -0.919
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.233"
+                                                                , nvValue = 0.233
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl17"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.683"
+                                                                , nvValue = -0.683
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.919"
+                                                                , nvValue = -0.919
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.182"
+                                                                , nvValue = 0.182
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl18"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.683"
+                                                                , nvValue = -0.683
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.919"
+                                                                , nvValue = -0.919
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.233"
+                                                                , nvValue = 0.233
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl19"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.053"
+                                                                , nvValue = 5.3e-2
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.024"
+                                                                , nvValue = -2.4e-2
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.578"
+                                                                , nvValue = 0.578
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "support"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = PreviousNode
+                                                    , cHadNewlineBefore = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl20"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.837"
+                                                                , nvValue = 0.837
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.002"
+                                                                , nvValue = 2.0e-3
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.182"
+                                                                , nvValue = 0.182
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl21"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.837"
+                                                                , nvValue = 0.837
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.002"
+                                                                , nvValue = 2.0e-3
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.233"
+                                                                , nvValue = 0.233
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl22"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.415"
+                                                                , nvValue = 0.415
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.002"
+                                                                , nvValue = 2.0e-3
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.182"
+                                                                , nvValue = 0.182
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl23"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.415"
+                                                                , nvValue = 0.415
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.002"
+                                                                , nvValue = 2.0e-3
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.233"
+                                                                , nvValue = 0.233
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl24"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.053"
+                                                                , nvValue = 5.3e-2
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.002"
+                                                                , nvValue = 2.0e-3
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.182"
+                                                                , nvValue = 0.182
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl25"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.053"
+                                                                , nvValue = 5.3e-2
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.002"
+                                                                , nvValue = 2.0e-3
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.233"
+                                                                , nvValue = 0.233
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl26"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.308"
+                                                                , nvValue = -0.308
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.002"
+                                                                , nvValue = 2.0e-3
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.182"
+                                                                , nvValue = 0.182
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl27"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.308"
+                                                                , nvValue = -0.308
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.002"
+                                                                , nvValue = 2.0e-3
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.233"
+                                                                , nvValue = 0.233
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl28"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.730"
+                                                                , nvValue = -0.73
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.002"
+                                                                , nvValue = 2.0e-3
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.182"
+                                                                , nvValue = 0.182
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl29"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.730"
+                                                                , nvValue = -0.73
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.002"
+                                                                , nvValue = 2.0e-3
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.233"
+                                                                , nvValue = 0.233
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl30"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.822"
+                                                                , nvValue = 0.822
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.791"
+                                                                , nvValue = 0.791
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.182"
+                                                                , nvValue = 0.182
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl31"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.822"
+                                                                , nvValue = 0.822
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.791"
+                                                                , nvValue = 0.791
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.233"
+                                                                , nvValue = 0.233
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl32"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.715"
+                                                                , nvValue = -0.715
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.791"
+                                                                , nvValue = 0.791
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.182"
+                                                                , nvValue = 0.182
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl33"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.715"
+                                                                , nvValue = -0.715
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.791"
+                                                                , nvValue = 0.791
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.233"
+                                                                , nvValue = 0.233
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r34"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.651"
+                                                                , nvValue = 0.651
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "1.121"
+                                                                , nvValue = 1.121
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.628"
+                                                                , nvValue = 0.628
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r35"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.053"
+                                                                , nvValue = 5.3e-2
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "1.121"
+                                                                , nvValue = 1.121
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.628"
+                                                                , nvValue = 0.628
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r36"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.544"
+                                                                , nvValue = -0.544
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "1.121"
+                                                                , nvValue = 1.121
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.628"
+                                                                , nvValue = 0.628
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r37"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.651"
+                                                                , nvValue = 0.651
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "1.152"
+                                                                , nvValue = 1.152
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.565"
+                                                                , nvValue = 0.565
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r38"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.053"
+                                                                , nvValue = 5.3e-2
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "1.152"
+                                                                , nvValue = 1.152
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.565"
+                                                                , nvValue = 0.565
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r39"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.544"
+                                                                , nvValue = -0.544
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "1.152"
+                                                                , nvValue = 1.152
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.565"
+                                                                , nvValue = 0.565
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r40"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.602"
+                                                                , nvValue = 0.602
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "1.514"
+                                                                , nvValue = 1.514
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.566"
+                                                                , nvValue = 0.566
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r41"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.495"
+                                                                , nvValue = -0.495
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "1.514"
+                                                                , nvValue = 1.514
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.566"
+                                                                , nvValue = 0.566
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r42"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.602"
+                                                                , nvValue = 0.602
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "1.532"
+                                                                , nvValue = 1.532
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.623"
+                                                                , nvValue = 0.623
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r43"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.495"
+                                                                , nvValue = -0.495
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "1.532"
+                                                                , nvValue = 1.532
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.623"
+                                                                , nvValue = 0.623
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r44"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.553"
+                                                                , nvValue = 0.553
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "1.654"
+                                                                , nvValue = 1.654
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.359"
+                                                                , nvValue = 0.359
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r45"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.446"
+                                                                , nvValue = -0.446
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "1.654"
+                                                                , nvValue = 1.654
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.359"
+                                                                , nvValue = 0.359
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r46"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.553"
+                                                                , nvValue = 0.553
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "1.679"
+                                                                , nvValue = 1.679
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.448"
+                                                                , nvValue = 0.448
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r47"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.446"
+                                                                , nvValue = -0.446
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "1.679"
+                                                                , nvValue = 1.679
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.448"
+                                                                , nvValue = 0.448
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r48"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.053"
+                                                                , nvValue = 5.3e-2
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "1.710"
+                                                                , nvValue = 1.71
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.565"
+                                                                , nvValue = 0.565
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "support for rear"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = PreviousNode
+                                                    , cHadNewlineBefore = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r49"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.558"
+                                                                , nvValue = 0.558
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "2.284"
+                                                                , nvValue = 2.284
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.364"
+                                                                , nvValue = 0.364
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r50"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.558"
+                                                                , nvValue = 0.558
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "2.284"
+                                                                , nvValue = 2.284
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.447"
+                                                                , nvValue = 0.447
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r51"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.053"
+                                                                , nvValue = 5.3e-2
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "2.284"
+                                                                , nvValue = 2.284
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.370"
+                                                                , nvValue = 0.37
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r52"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.053"
+                                                                , nvValue = 5.3e-2
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "2.284"
+                                                                , nvValue = 2.284
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.441"
+                                                                , nvValue = 0.441
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r53"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.451"
+                                                                , nvValue = -0.451
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "2.284"
+                                                                , nvValue = 2.284
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.364"
+                                                                , nvValue = 0.364
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r54"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.451"
+                                                                , nvValue = -0.451
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "2.284"
+                                                                , nvValue = 2.284
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.447"
+                                                                , nvValue = 0.447
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "group"
+                                                            , String ""
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            ]
+                                        , avTrailingComma = False
+                                        }
+                                    )
+                                )
+                            , Comment
+                                ( InternalComment
+                                    { cText = "--Beams--"
+                                    , cMultiline = False
+                                    , cAssociationDirection = NextNode
+                                    , cHadNewlineBefore = False
+                                    }
                                 )
                             , ObjectKey
-                                ( String "materialEmissiveScaling"
+                                ( String "beams"
+                                , Array
+                                    ( ArrayValue
+                                        { avElements =
+                                            [ Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "id1:"
+                                                        , String "id2:"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "Structural beams"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = True
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "beamStrength"
+                                                            , String "FLT_MAX"
+                                                            )
+                                                        , ObjectKey
+                                                            ( String "beamSpring"
+                                                            , String "3800000"
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "beamDamp"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "130"
+                                                                    , nvValue = 130.0
+                                                                    }
+                                                                )
+                                                            )
+                                                        , ObjectKey
+                                                            ( String "deformLimit"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "1.1"
+                                                                    , nvValue = 1.1
+                                                                    }
+                                                                )
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "Front end"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = True
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "beamDeform"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "20600"
+                                                                    , nvValue = 20600.0
+                                                                    }
+                                                                )
+                                                            )
+                                                        , ObjectKey
+                                                            ( String "deformLimit"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "1.1"
+                                                                    , nvValue = 1.1
+                                                                    }
+                                                                )
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f3"
+                                                        , String "rl_f5"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f0"
+                                                        , String "rl_f3"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f8"
+                                                        , String "rl_f3"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl15"
+                                                        , String "rl_f10"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f8"
+                                                        , String "rl_f6"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f11"
+                                                        , String "rl_f10"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f10"
+                                                        , String "rl_f8"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f9"
+                                                        , String "rl_f7"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl17"
+                                                        , String "rl_f12"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f6"
+                                                        , String "rl_f11"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f11"
+                                                        , String "rl16"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f13"
+                                                        , String "rl18"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f13"
+                                                        , String "rl_f12"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f1"
+                                                        , String "rl_f4"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f2"
+                                                        , String "rl_f1"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f2"
+                                                        , String "rl_f5"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f12"
+                                                        , String "rl_f9"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f7"
+                                                        , String "rl_f13"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f0"
+                                                        , String "rl_f6"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f9"
+                                                        , String "rl_f4"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f2"
+                                                        , String "rl_f0"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f4"
+                                                        , String "rl_f5"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f1"
+                                                        , String "rl_f7"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "Middle"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = True
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "beamDeform"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "27000"
+                                                                    , nvValue = 27000.0
+                                                                    }
+                                                                )
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl16"
+                                                        , String "rl15"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl20"
+                                                        , String "rl30"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl16"
+                                                        , String "rl23"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl18"
+                                                        , String "rl17"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl17"
+                                                        , String "rl28"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl26"
+                                                        , String "rl17"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl18"
+                                                        , String "rl27"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl26"
+                                                        , String "rl24"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl25"
+                                                        , String "rl24"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl25"
+                                                        , String "rl27"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl21"
+                                                        , String "rl16"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl22"
+                                                        , String "rl15"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl15"
+                                                        , String "rl20"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl29"
+                                                        , String "rl27"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl28"
+                                                        , String "rl32"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl29"
+                                                        , String "rl18"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl22"
+                                                        , String "rl24"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl31"
+                                                        , String "rl21"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl28"
+                                                        , String "rl29"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl32"
+                                                        , String "rl33"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl30"
+                                                        , String "rl31"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl33"
+                                                        , String "rl29"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl30"
+                                                        , String "rl22"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl25"
+                                                        , String "rl23"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl32"
+                                                        , String "rl26"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl20"
+                                                        , String "rl21"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl31"
+                                                        , String "rl23"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl20"
+                                                        , String "rl22"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl21"
+                                                        , String "rl23"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl33"
+                                                        , String "rl27"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl23"
+                                                        , String "rl22"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl28"
+                                                        , String "rl26"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl27"
+                                                        , String "rl26"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "Rear end"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = True
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "beamDeform"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "22000"
+                                                                    , nvValue = 22000.0
+                                                                    }
+                                                                )
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r37"
+                                                        , String "rl_r34"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r39"
+                                                        , String "rl_r41"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r44"
+                                                        , String "rl_r46"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl33"
+                                                        , String "rl_r36"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r46"
+                                                        , String "rl_r42"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl31"
+                                                        , String "rl_r34"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r37"
+                                                        , String "rl30"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r49"
+                                                        , String "rl_r51"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r52"
+                                                        , String "rl_r50"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r50"
+                                                        , String "rl_r46"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r49"
+                                                        , String "rl_r50"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r42"
+                                                        , String "rl_r34"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r40"
+                                                        , String "rl_r44"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r40"
+                                                        , String "rl_r42"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r41"
+                                                        , String "rl_r45"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r39"
+                                                        , String "rl_r36"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r36"
+                                                        , String "rl_r35"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r38"
+                                                        , String "rl_r35"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r53"
+                                                        , String "rl_r54"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r52"
+                                                        , String "rl_r54"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r51"
+                                                        , String "rl_r52"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r45"
+                                                        , String "rl_r53"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r54"
+                                                        , String "rl_r47"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r43"
+                                                        , String "rl_r36"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r53"
+                                                        , String "rl_r51"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r34"
+                                                        , String "rl_r35"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r38"
+                                                        , String "rl_r37"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r45"
+                                                        , String "rl_r47"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r41"
+                                                        , String "rl_r43"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r38"
+                                                        , String "rl_r39"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r39"
+                                                        , String "rl32"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r47"
+                                                        , String "rl_r43"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r44"
+                                                        , String "rl_r49"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r37"
+                                                        , String "rl_r40"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "Crossing beams"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = True
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "Front end"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = True
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "beamDeform"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "16000"
+                                                                    , nvValue = 16000.0
+                                                                    }
+                                                                )
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f4"
+                                                        , String "rl_f2"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f0"
+                                                        , String "rl_f8"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl16"
+                                                        , String "rl_f10"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl15"
+                                                        , String "rl_f11"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f10"
+                                                        , String "rl_f6"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f11"
+                                                        , String "rl_f8"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f1"
+                                                        , String "rl_f5"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f4"
+                                                        , String "rl_f7"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f1"
+                                                        , String "rl_f9"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f12"
+                                                        , String "rl_f7"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f3"
+                                                        , String "rl_f6"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f0"
+                                                        , String "rl_f5"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f3"
+                                                        , String "rl_f2"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f13"
+                                                        , String "rl_f9"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl17"
+                                                        , String "rl_f13"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl18"
+                                                        , String "rl_f12"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "Middle"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = True
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "beamDeform"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "6500"
+                                                                    , nvValue = 6500.0
+                                                                    }
+                                                                )
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl16"
+                                                        , String "rl20"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl15"
+                                                        , String "rl23"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl18"
+                                                        , String "rl28"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl18"
+                                                        , String "rl26"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl17"
+                                                        , String "rl27"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl27"
+                                                        , String "rl24"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl26"
+                                                        , String "rl25"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl31"
+                                                        , String "rl20"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl15"
+                                                        , String "rl21"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl16"
+                                                        , String "rl22"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl32"
+                                                        , String "rl29"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl30"
+                                                        , String "rl21"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl23"
+                                                        , String "rl24"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl32"
+                                                        , String "rl27"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl17"
+                                                        , String "rl29"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl33"
+                                                        , String "rl28"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl29"
+                                                        , String "rl26"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl30"
+                                                        , String "rl23"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl33"
+                                                        , String "rl26"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl22"
+                                                        , String "rl25"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl20"
+                                                        , String "rl23"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl28"
+                                                        , String "rl27"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl31"
+                                                        , String "rl22"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl21"
+                                                        , String "rl22"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "Rear end"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = True
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "beamDeform"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "16000"
+                                                                    , nvValue = 16000.0
+                                                                    }
+                                                                )
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r54"
+                                                        , String "rl_r45"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl32"
+                                                        , String "rl_r36"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r36"
+                                                        , String "rl_r41"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r50"
+                                                        , String "rl_r51"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl31"
+                                                        , String "rl_r37"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl30"
+                                                        , String "rl_r34"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r46"
+                                                        , String "rl_r40"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r53"
+                                                        , String "rl_r47"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r50"
+                                                        , String "rl_r44"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r49"
+                                                        , String "rl_r46"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r37"
+                                                        , String "rl_r42"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r34"
+                                                        , String "rl_r40"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r34"
+                                                        , String "rl_r38"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl33"
+                                                        , String "rl_r39"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r39"
+                                                        , String "rl_r35"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r36"
+                                                        , String "rl_r38"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r53"
+                                                        , String "rl_r52"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r54"
+                                                        , String "rl_r51"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r45"
+                                                        , String "rl_r43"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r47"
+                                                        , String "rl_r41"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r39"
+                                                        , String "rl_r43"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r37"
+                                                        , String "rl_r35"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r49"
+                                                        , String "rl_r52"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r44"
+                                                        , String "rl_r42"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "Support beams"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = True
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "Front end"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = True
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "beamDeform"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "19000"
+                                                                    , nvValue = 19000.0
+                                                                    }
+                                                                )
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f8"
+                                                        , String "rl_f14"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f9"
+                                                        , String "rl_f14"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f"
+                                                        , String "rl_f3"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f10"
+                                                        , String "rl_f14"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f14"
+                                                        , String "rl_f13"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f1"
+                                                        , String "rl_f14"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f0"
+                                                        , String "rl_f14"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f12"
+                                                        , String "rl_f14"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f5"
+                                                        , String "rl_f14"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f14"
+                                                        , String "rl_f4"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f14"
+                                                        , String "rl_f6"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f14"
+                                                        , String "rl_f7"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f14"
+                                                        , String "rl_f2"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f14"
+                                                        , String "rl_f11"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "Middle"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = True
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "beamDeform"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "11000"
+                                                                    , nvValue = 11000.0
+                                                                    }
+                                                                )
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl27"
+                                                        , String "rl19"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl26"
+                                                        , String "rl19"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl24"
+                                                        , String "rl19"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl23"
+                                                        , String "rl19"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl20"
+                                                        , String "rl19"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl19"
+                                                        , String "rl16"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl19"
+                                                        , String "rl15"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl31"
+                                                        , String "rl19"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl33"
+                                                        , String "rl19"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl28"
+                                                        , String "rl19"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl19"
+                                                        , String "rl25"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl21"
+                                                        , String "rl19"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl22"
+                                                        , String "rl19"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl19"
+                                                        , String "rl32"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl29"
+                                                        , String "rl19"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl19"
+                                                        , String "rl18"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl19"
+                                                        , String "rl17"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl19"
+                                                        , String "rl30"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "Rear end"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = True
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "beamDeform"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "19000"
+                                                                    , nvValue = 19000.0
+                                                                    }
+                                                                )
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r48"
+                                                        , String "rl_r51"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r48"
+                                                        , String "rl_r54"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r45"
+                                                        , String "rl_r48"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r48"
+                                                        , String "rl_r50"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r48"
+                                                        , String "rl_r42"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r48"
+                                                        , String "rl_r47"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r49"
+                                                        , String "rl_r48"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r35"
+                                                        , String "rl_r48"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r48"
+                                                        , String "rl_r43"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r44"
+                                                        , String "rl_r48"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r53"
+                                                        , String "rl_r48"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r52"
+                                                        , String "rl_r48"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r40"
+                                                        , String "rl_r48"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r48"
+                                                        , String "rl_r38"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r41"
+                                                        , String "rl_r48"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r4"
+                                                        , String "rl_r46"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "Front crush"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = True
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "beamDeform"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "8500"
+                                                                    , nvValue = 8500.0
+                                                                    }
+                                                                )
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl17"
+                                                        , String "rl_f9"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl15"
+                                                        , String "rl_f8"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            ]
+                                        , avTrailingComma = False
+                                        }
+                                    )
+                                )
+                            , Comment
+                                ( InternalComment
+                                    { cText = "--Collision Triangles--"
+                                    , cMultiline = False
+                                    , cAssociationDirection = NextNode
+                                    , cHadNewlineBefore = False
+                                    }
+                                )
+                            , ObjectKey
+                                ( String "triangles"
+                                , Array
+                                    ( ArrayValue
+                                        { avElements =
+                                            [ Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "id1:"
+                                                        , String "id2:"
+                                                        , String "id3:"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f5"
+                                                        , String "rl_f3"
+                                                        , String "rl_f2"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f0"
+                                                        , String "rl_f2"
+                                                        , String "rl_f3"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f5"
+                                                        , String "rl_f2"
+                                                        , String "rl_f4"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f1"
+                                                        , String "rl_f4"
+                                                        , String "rl_f2"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f4"
+                                                        , String "rl_f1"
+                                                        , String "rl_f7"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f4"
+                                                        , String "rl_f7"
+                                                        , String "rl_f9"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f7"
+                                                        , String "rl_f13"
+                                                        , String "rl_f9"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f12"
+                                                        , String "rl_f9"
+                                                        , String "rl_f13"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f12"
+                                                        , String "rl_f13"
+                                                        , String "rl18"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl18"
+                                                        , String "rl17"
+                                                        , String "rl_f12"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f3"
+                                                        , String "rl_f6"
+                                                        , String "rl_f0"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f3"
+                                                        , String "rl_f8"
+                                                        , String "rl_f6"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f10"
+                                                        , String "rl_f11"
+                                                        , String "rl_f8"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f6"
+                                                        , String "rl_f8"
+                                                        , String "rl_f11"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_f10"
+                                                        , String "rl16"
+                                                        , String "rl_f11"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl16"
+                                                        , String "rl_f10"
+                                                        , String "rl15"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl15"
+                                                        , String "rl20"
+                                                        , String "rl16"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl21"
+                                                        , String "rl16"
+                                                        , String "rl20"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl30"
+                                                        , String "rl21"
+                                                        , String "rl20"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl31"
+                                                        , String "rl21"
+                                                        , String "rl30"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl17"
+                                                        , String "rl18"
+                                                        , String "rl28"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl29"
+                                                        , String "rl28"
+                                                        , String "rl18"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl32"
+                                                        , String "rl28"
+                                                        , String "rl29"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl33"
+                                                        , String "rl32"
+                                                        , String "rl29"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl32"
+                                                        , String "rl33"
+                                                        , String "rl_r39"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r39"
+                                                        , String "rl33"
+                                                        , String "rl_r36"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r36"
+                                                        , String "rl_r41"
+                                                        , String "rl_r39"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r43"
+                                                        , String "rl_r41"
+                                                        , String "rl_r36"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r45"
+                                                        , String "rl_r41"
+                                                        , String "rl_r43"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r47"
+                                                        , String "rl_r45"
+                                                        , String "rl_r43"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r53"
+                                                        , String "rl_r45"
+                                                        , String "rl_r47"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r54"
+                                                        , String "rl_r53"
+                                                        , String "rl_r47"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r54"
+                                                        , String "rl_r51"
+                                                        , String "rl_r53"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r51"
+                                                        , String "rl_r54"
+                                                        , String "rl_r52"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r52"
+                                                        , String "rl_r50"
+                                                        , String "rl_r51"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r50"
+                                                        , String "rl_r49"
+                                                        , String "rl_r51"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r46"
+                                                        , String "rl_r44"
+                                                        , String "rl_r49"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r50"
+                                                        , String "rl_r46"
+                                                        , String "rl_r49"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r46"
+                                                        , String "rl_r42"
+                                                        , String "rl_r44"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r44"
+                                                        , String "rl_r42"
+                                                        , String "rl_r40"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r34"
+                                                        , String "rl_r37"
+                                                        , String "rl_r40"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r42"
+                                                        , String "rl_r34"
+                                                        , String "rl_r40"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r34"
+                                                        , String "rl_r35"
+                                                        , String "rl_r37"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r35"
+                                                        , String "rl_r38"
+                                                        , String "rl_r37"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r35"
+                                                        , String "rl_r39"
+                                                        , String "rl_r38"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r39"
+                                                        , String "rl_r35"
+                                                        , String "rl_r36"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl30"
+                                                        , String "rl_r37"
+                                                        , String "rl31"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl_r37"
+                                                        , String "rl_r34"
+                                                        , String "rl31"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl16"
+                                                        , String "rl15"
+                                                        , String "rl22"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl16"
+                                                        , String "rl22"
+                                                        , String "rl23"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl23"
+                                                        , String "rl22"
+                                                        , String "rl21"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl21"
+                                                        , String "rl22"
+                                                        , String "rl20"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl27"
+                                                        , String "rl29"
+                                                        , String "rl26"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl29"
+                                                        , String "rl28"
+                                                        , String "rl26"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl18"
+                                                        , String "rl26"
+                                                        , String "rl17"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl27"
+                                                        , String "rl26"
+                                                        , String "rl18"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl24"
+                                                        , String "rl22"
+                                                        , String "rl23"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl27"
+                                                        , String "rl26"
+                                                        , String "rl24"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl24"
+                                                        , String "rl25"
+                                                        , String "rl27"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl24"
+                                                        , String "rl23"
+                                                        , String "rl25"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl30"
+                                                        , String "rl23"
+                                                        , String "rl22"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl30"
+                                                        , String "rl31"
+                                                        , String "rl23"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl26"
+                                                        , String "rl27"
+                                                        , String "rl32"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl33"
+                                                        , String "rl32"
+                                                        , String "rl27"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            ]
+                                        , avTrailingComma = False
+                                        }
+                                    )
+                                )
+                            , ObjectKey
+                                ( String "flexbodies"
+                                , Array
+                                    ( ArrayValue
+                                        { avElements =
+                                            [ Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "mesh"
+                                                        , String "[group]:"
+                                                        , String "nonFlexMaterials"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rails"
+                                                        , Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [ String "chassis_rails" ]
+                                                                , avTrailingComma = False
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            ]
+                                        , avTrailingComma = False
+                                        }
+                                    )
+                                )
+                            , ObjectKey
+                                ( String "glowMap"
                                 , Object
-                                    [ ObjectKey
-                                        ( String "on_max"
-                                        , Number
-                                            ( NumberValue
-                                                { nvText = "1"
-                                                , nvValue = 1.0
-                                                }
-                                            )
-                                        )
-                                    ]
+                                    ( ObjectValue
+                                        { ovElements =
+                                            [ Comment
+                                                ( InternalComment
+                                                    { cText = "main lights"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = False
+                                                    }
+                                                )
+                                            , ObjectKey
+                                                ( String "chassis_headlight_L"
+                                                , Object
+                                                    ( ObjectValue
+                                                        { ovElements =
+                                                            [ ObjectKey
+                                                                ( String "simpleFunction"
+                                                                , String "lowhighbeam_filament"
+                                                                )
+                                                            , ObjectKey
+                                                                ( String "off"
+                                                                , String "chassis_headlight"
+                                                                )
+                                                            , ObjectKey
+                                                                ( String "on"
+                                                                , String "chassis_headlight_on"
+                                                                )
+                                                            , ObjectKey
+                                                                ( String "materialEmissiveScaling"
+                                                                , Object
+                                                                    ( ObjectValue
+                                                                        { ovElements =
+                                                                            [ ObjectKey
+                                                                                ( String "on_max"
+                                                                                , Number
+                                                                                    ( NumberValue
+                                                                                        { nvText = "1"
+                                                                                        , nvValue = 1.0
+                                                                                        }
+                                                                                    )
+                                                                                )
+                                                                            ]
+                                                                        , ovTrailingComma = False
+                                                                        }
+                                                                    )
+                                                                )
+                                                            ]
+                                                        , ovTrailingComma = False
+                                                        }
+                                                    )
+                                                )
+                                            , ObjectKey
+                                                ( String "chassis_headlight_R"
+                                                , Object
+                                                    ( ObjectValue
+                                                        { ovElements =
+                                                            [ ObjectKey
+                                                                ( String "simpleFunction"
+                                                                , String "lowhighbeam_filament"
+                                                                )
+                                                            , ObjectKey
+                                                                ( String "off"
+                                                                , String "chassis_headlight"
+                                                                )
+                                                            , ObjectKey
+                                                                ( String "on"
+                                                                , String "chassis_headlight_on"
+                                                                )
+                                                            , ObjectKey
+                                                                ( String "materialEmissiveScaling"
+                                                                , Object
+                                                                    ( ObjectValue
+                                                                        { ovElements =
+                                                                            [ ObjectKey
+                                                                                ( String "on_max"
+                                                                                , Number
+                                                                                    ( NumberValue
+                                                                                        { nvText = "1"
+                                                                                        , nvValue = 1.0
+                                                                                        }
+                                                                                    )
+                                                                                )
+                                                                            ]
+                                                                        , ovTrailingComma = False
+                                                                        }
+                                                                    )
+                                                                )
+                                                            ]
+                                                        , ovTrailingComma = False
+                                                        }
+                                                    )
+                                                )
+                                            , ObjectKey
+                                                ( String "chassis_signal_L"
+                                                , Object
+                                                    ( ObjectValue
+                                                        { ovElements =
+                                                            [ ObjectKey
+                                                                ( String "simpleFunction"
+                                                                , String "signal_L_filament"
+                                                                )
+                                                            , ObjectKey
+                                                                ( String "off"
+                                                                , String "chassis_signal_amber"
+                                                                )
+                                                            , ObjectKey
+                                                                ( String "on"
+                                                                , String "chassis_signal_amber_on"
+                                                                )
+                                                            , ObjectKey
+                                                                ( String "materialEmissiveScaling"
+                                                                , Object
+                                                                    ( ObjectValue
+                                                                        { ovElements =
+                                                                            [ ObjectKey
+                                                                                ( String "on_max"
+                                                                                , Number
+                                                                                    ( NumberValue
+                                                                                        { nvText = "1"
+                                                                                        , nvValue = 1.0
+                                                                                        }
+                                                                                    )
+                                                                                )
+                                                                            ]
+                                                                        , ovTrailingComma = False
+                                                                        }
+                                                                    )
+                                                                )
+                                                            ]
+                                                        , ovTrailingComma = False
+                                                        }
+                                                    )
+                                                )
+                                            , ObjectKey
+                                                ( String "chassis_signal_R"
+                                                , Object
+                                                    ( ObjectValue
+                                                        { ovElements =
+                                                            [ ObjectKey
+                                                                ( String "simpleFunction"
+                                                                , String "signal_R_filament"
+                                                                )
+                                                            , ObjectKey
+                                                                ( String "off"
+                                                                , String "chassis_signal_amber"
+                                                                )
+                                                            , ObjectKey
+                                                                ( String "on"
+                                                                , String "chassis_signal_amber_on"
+                                                                )
+                                                            , ObjectKey
+                                                                ( String "materialEmissiveScaling"
+                                                                , Object
+                                                                    ( ObjectValue
+                                                                        { ovElements =
+                                                                            [ ObjectKey
+                                                                                ( String "on_max"
+                                                                                , Number
+                                                                                    ( NumberValue
+                                                                                        { nvText = "1"
+                                                                                        , nvValue = 1.0
+                                                                                        }
+                                                                                    )
+                                                                                )
+                                                                            ]
+                                                                        , ovTrailingComma = False
+                                                                        }
+                                                                    )
+                                                                )
+                                                            ]
+                                                        , ovTrailingComma = False
+                                                        }
+                                                    )
+                                                )
+                                            , ObjectKey
+                                                ( String "chassis_reverselight"
+                                                , Object
+                                                    ( ObjectValue
+                                                        { ovElements =
+                                                            [ ObjectKey
+                                                                ( String "simpleFunction"
+                                                                , String "reverselight_filament"
+                                                                )
+                                                            , ObjectKey
+                                                                ( String "off"
+                                                                , String "chassis_reverselight"
+                                                                )
+                                                            , ObjectKey
+                                                                ( String "on"
+                                                                , String "chassis_reverselight_on"
+                                                                )
+                                                            , ObjectKey
+                                                                ( String "materialEmissiveScaling"
+                                                                , Object
+                                                                    ( ObjectValue
+                                                                        { ovElements =
+                                                                            [ ObjectKey
+                                                                                ( String "on_max"
+                                                                                , Number
+                                                                                    ( NumberValue
+                                                                                        { nvText = "1"
+                                                                                        , nvValue = 1.0
+                                                                                        }
+                                                                                    )
+                                                                                )
+                                                                            ]
+                                                                        , ovTrailingComma = False
+                                                                        }
+                                                                    )
+                                                                )
+                                                            ]
+                                                        , ovTrailingComma = False
+                                                        }
+                                                    )
+                                                )
+                                            , ObjectKey
+                                                ( String "chassis_brakelight_L"
+                                                , Object
+                                                    ( ObjectValue
+                                                        { ovElements =
+                                                            [ ObjectKey
+                                                                ( String "simpleFunction"
+                                                                , String "brakelight_filament"
+                                                                )
+                                                            , ObjectKey
+                                                                ( String "off"
+                                                                , String "chassis_taillight"
+                                                                )
+                                                            , ObjectKey
+                                                                ( String "on"
+                                                                , String "chassis_taillight_on"
+                                                                )
+                                                            , ObjectKey
+                                                                ( String "materialEmissiveScaling"
+                                                                , Object
+                                                                    ( ObjectValue
+                                                                        { ovElements =
+                                                                            [ ObjectKey
+                                                                                ( String "on_max"
+                                                                                , Number
+                                                                                    ( NumberValue
+                                                                                        { nvText = "1"
+                                                                                        , nvValue = 1.0
+                                                                                        }
+                                                                                    )
+                                                                                )
+                                                                            ]
+                                                                        , ovTrailingComma = False
+                                                                        }
+                                                                    )
+                                                                )
+                                                            ]
+                                                        , ovTrailingComma = False
+                                                        }
+                                                    )
+                                                )
+                                            , ObjectKey
+                                                ( String "chassis_brakelight_R"
+                                                , Object
+                                                    ( ObjectValue
+                                                        { ovElements =
+                                                            [ ObjectKey
+                                                                ( String "simpleFunction"
+                                                                , String "brakelight_filament"
+                                                                )
+                                                            , ObjectKey
+                                                                ( String "off"
+                                                                , String "chassis_taillight"
+                                                                )
+                                                            , ObjectKey
+                                                                ( String "on"
+                                                                , String "chassis_taillight_on"
+                                                                )
+                                                            , ObjectKey
+                                                                ( String "materialEmissiveScaling"
+                                                                , Object
+                                                                    ( ObjectValue
+                                                                        { ovElements =
+                                                                            [ ObjectKey
+                                                                                ( String "on_max"
+                                                                                , Number
+                                                                                    ( NumberValue
+                                                                                        { nvText = "1"
+                                                                                        , nvValue = 1.0
+                                                                                        }
+                                                                                    )
+                                                                                )
+                                                                            ]
+                                                                        , ovTrailingComma = False
+                                                                        }
+                                                                    )
+                                                                )
+                                                            ]
+                                                        , ovTrailingComma = False
+                                                        }
+                                                    )
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "gauge lights"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "(turn signals, battery, parking brake, highbeam)"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = True
+                                                    }
+                                                )
+                                            , ObjectKey
+                                                ( String "chassis_gaugelight_highbeam"
+                                                , Object
+                                                    ( ObjectValue
+                                                        { ovElements =
+                                                            [ ObjectKey
+                                                                ( String "simpleFunction"
+                                                                , String "highbeam"
+                                                                )
+                                                            , ObjectKey
+                                                                ( String "off"
+                                                                , String "chassis_gauges"
+                                                                )
+                                                            , ObjectKey
+                                                                ( String "on"
+                                                                , String "chassis_gauges_on"
+                                                                )
+                                                            ]
+                                                        , ovTrailingComma = False
+                                                        }
+                                                    )
+                                                )
+                                            , ObjectKey
+                                                ( String "chassis_gaugelight_signal_L"
+                                                , Object
+                                                    ( ObjectValue
+                                                        { ovElements =
+                                                            [ ObjectKey
+                                                                ( String "simpleFunction"
+                                                                , String "signal_L"
+                                                                )
+                                                            , ObjectKey
+                                                                ( String "off"
+                                                                , String "chassis_gauges"
+                                                                )
+                                                            , ObjectKey
+                                                                ( String "on"
+                                                                , String "chassis_gauges_on"
+                                                                )
+                                                            ]
+                                                        , ovTrailingComma = False
+                                                        }
+                                                    )
+                                                )
+                                            , ObjectKey
+                                                ( String "chassis_gaugelight_signal_R"
+                                                , Object
+                                                    ( ObjectValue
+                                                        { ovElements =
+                                                            [ ObjectKey
+                                                                ( String "simpleFunction"
+                                                                , String "signal_R"
+                                                                )
+                                                            , ObjectKey
+                                                                ( String "off"
+                                                                , String "chassis_gauges"
+                                                                )
+                                                            , ObjectKey
+                                                                ( String "on"
+                                                                , String "chassis_gauges_on"
+                                                                )
+                                                            ]
+                                                        , ovTrailingComma = False
+                                                        }
+                                                    )
+                                                )
+                                            , ObjectKey
+                                                ( String "chassis_gaugelight_battery"
+                                                , Object
+                                                    ( ObjectValue
+                                                        { ovElements =
+                                                            [ ObjectKey
+                                                                ( String "simpleFunction"
+                                                                , String "battery"
+                                                                )
+                                                            , ObjectKey
+                                                                ( String "off"
+                                                                , String "chassis_gauges"
+                                                                )
+                                                            , ObjectKey
+                                                                ( String "on"
+                                                                , String "chassis_gauges_on"
+                                                                )
+                                                            ]
+                                                        , ovTrailingComma = False
+                                                        }
+                                                    )
+                                                )
+                                            , ObjectKey
+                                                ( String "chassis_gaugelight_parkbrake"
+                                                , Object
+                                                    ( ObjectValue
+                                                        { ovElements =
+                                                            [ ObjectKey
+                                                                ( String "simpleFunction"
+                                                                , String "parkingbrakelight"
+                                                                )
+                                                            , ObjectKey
+                                                                ( String "off"
+                                                                , String "chassis_gauges"
+                                                                )
+                                                            , ObjectKey
+                                                                ( String "on"
+                                                                , String "chassis_gauges_on"
+                                                                )
+                                                            ]
+                                                        , ovTrailingComma = False
+                                                        }
+                                                    )
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "multi-condition warning light"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = True
+                                                    }
+                                                )
+                                            , ObjectKey
+                                                ( String "chassis_gaugelight_warning"
+                                                , Object
+                                                    ( ObjectValue
+                                                        { ovElements =
+                                                            [ ObjectKey
+                                                                ( String "simpleFunction"
+                                                                , Object
+                                                                    ( ObjectValue
+                                                                        { ovElements =
+                                                                            [ ObjectKey
+                                                                                ( String "checkengine"
+                                                                                , Number
+                                                                                    ( NumberValue
+                                                                                        { nvText = "1"
+                                                                                        , nvValue = 1.0
+                                                                                        }
+                                                                                    )
+                                                                                )
+                                                                            , ObjectKey
+                                                                                ( String "battery"
+                                                                                , Number
+                                                                                    ( NumberValue
+                                                                                        { nvText = "1"
+                                                                                        , nvValue = 1.0
+                                                                                        }
+                                                                                    )
+                                                                                )
+                                                                            , ObjectKey
+                                                                                ( String "lowpressure"
+                                                                                , Number
+                                                                                    ( NumberValue
+                                                                                        { nvText = "1"
+                                                                                        , nvValue = 1.0
+                                                                                        }
+                                                                                    )
+                                                                                )
+                                                                            ]
+                                                                        , ovTrailingComma = False
+                                                                        }
+                                                                    )
+                                                                )
+                                                            , ObjectKey
+                                                                ( String "off"
+                                                                , String "chassis_gauges"
+                                                                )
+                                                            , ObjectKey
+                                                                ( String "on"
+                                                                , String "chassis_gauges_on"
+                                                                )
+                                                            ]
+                                                        , ovTrailingComma = False
+                                                        }
+                                                    )
+                                                )
+                                            ]
+                                        , ovTrailingComma = False
+                                        }
+                                    )
                                 )
                             ]
-                        )
-                    , ObjectKey
-                        ( String "chassis_signal_L"
-                        , Object
-                            [ ObjectKey
-                                ( String "simpleFunction"
-                                , String "signal_L_filament"
-                                )
-                            , ObjectKey
-                                ( String "off"
-                                , String "chassis_signal_amber"
-                                )
-                            , ObjectKey
-                                ( String "on"
-                                , String "chassis_signal_amber_on"
-                                )
-                            , ObjectKey
-                                ( String "materialEmissiveScaling"
-                                , Object
-                                    [ ObjectKey
-                                        ( String "on_max"
-                                        , Number
-                                            ( NumberValue
-                                                { nvText = "1"
-                                                , nvValue = 1.0
-                                                }
-                                            )
-                                        )
-                                    ]
-                                )
-                            ]
-                        )
-                    , ObjectKey
-                        ( String "chassis_signal_R"
-                        , Object
-                            [ ObjectKey
-                                ( String "simpleFunction"
-                                , String "signal_R_filament"
-                                )
-                            , ObjectKey
-                                ( String "off"
-                                , String "chassis_signal_amber"
-                                )
-                            , ObjectKey
-                                ( String "on"
-                                , String "chassis_signal_amber_on"
-                                )
-                            , ObjectKey
-                                ( String "materialEmissiveScaling"
-                                , Object
-                                    [ ObjectKey
-                                        ( String "on_max"
-                                        , Number
-                                            ( NumberValue
-                                                { nvText = "1"
-                                                , nvValue = 1.0
-                                                }
-                                            )
-                                        )
-                                    ]
-                                )
-                            ]
-                        )
-                    , ObjectKey
-                        ( String "chassis_reverselight"
-                        , Object
-                            [ ObjectKey
-                                ( String "simpleFunction"
-                                , String "reverselight_filament"
-                                )
-                            , ObjectKey
-                                ( String "off"
-                                , String "chassis_reverselight"
-                                )
-                            , ObjectKey
-                                ( String "on"
-                                , String "chassis_reverselight_on"
-                                )
-                            , ObjectKey
-                                ( String "materialEmissiveScaling"
-                                , Object
-                                    [ ObjectKey
-                                        ( String "on_max"
-                                        , Number
-                                            ( NumberValue
-                                                { nvText = "1"
-                                                , nvValue = 1.0
-                                                }
-                                            )
-                                        )
-                                    ]
-                                )
-                            ]
-                        )
-                    , ObjectKey
-                        ( String "chassis_brakelight_L"
-                        , Object
-                            [ ObjectKey
-                                ( String "simpleFunction"
-                                , String "brakelight_filament"
-                                )
-                            , ObjectKey
-                                ( String "off"
-                                , String "chassis_taillight"
-                                )
-                            , ObjectKey
-                                ( String "on"
-                                , String "chassis_taillight_on"
-                                )
-                            , ObjectKey
-                                ( String "materialEmissiveScaling"
-                                , Object
-                                    [ ObjectKey
-                                        ( String "on_max"
-                                        , Number
-                                            ( NumberValue
-                                                { nvText = "1"
-                                                , nvValue = 1.0
-                                                }
-                                            )
-                                        )
-                                    ]
-                                )
-                            ]
-                        )
-                    , ObjectKey
-                        ( String "chassis_brakelight_R"
-                        , Object
-                            [ ObjectKey
-                                ( String "simpleFunction"
-                                , String "brakelight_filament"
-                                )
-                            , ObjectKey
-                                ( String "off"
-                                , String "chassis_taillight"
-                                )
-                            , ObjectKey
-                                ( String "on"
-                                , String "chassis_taillight_on"
-                                )
-                            , ObjectKey
-                                ( String "materialEmissiveScaling"
-                                , Object
-                                    [ ObjectKey
-                                        ( String "on_max"
-                                        , Number
-                                            ( NumberValue
-                                                { nvText = "1"
-                                                , nvValue = 1.0
-                                                }
-                                            )
-                                        )
-                                    ]
-                                )
-                            ]
-                        )
-                    , Comment
-                        ( InternalComment
-                            { cText = "gauge lights"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = False
-                            }
-                        )
-                    , Comment
-                        ( InternalComment
-                            { cText = "(turn signals, battery, parking brake, highbeam)"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = True
-                            }
-                        )
-                    , ObjectKey
-                        ( String "chassis_gaugelight_highbeam"
-                        , Object
-                            [ ObjectKey
-                                ( String "simpleFunction"
-                                , String "highbeam"
-                                )
-                            , ObjectKey
-                                ( String "off"
-                                , String "chassis_gauges"
-                                )
-                            , ObjectKey
-                                ( String "on"
-                                , String "chassis_gauges_on"
-                                )
-                            ]
-                        )
-                    , ObjectKey
-                        ( String "chassis_gaugelight_signal_L"
-                        , Object
-                            [ ObjectKey
-                                ( String "simpleFunction"
-                                , String "signal_L"
-                                )
-                            , ObjectKey
-                                ( String "off"
-                                , String "chassis_gauges"
-                                )
-                            , ObjectKey
-                                ( String "on"
-                                , String "chassis_gauges_on"
-                                )
-                            ]
-                        )
-                    , ObjectKey
-                        ( String "chassis_gaugelight_signal_R"
-                        , Object
-                            [ ObjectKey
-                                ( String "simpleFunction"
-                                , String "signal_R"
-                                )
-                            , ObjectKey
-                                ( String "off"
-                                , String "chassis_gauges"
-                                )
-                            , ObjectKey
-                                ( String "on"
-                                , String "chassis_gauges_on"
-                                )
-                            ]
-                        )
-                    , ObjectKey
-                        ( String "chassis_gaugelight_battery"
-                        , Object
-                            [ ObjectKey
-                                ( String "simpleFunction"
-                                , String "battery"
-                                )
-                            , ObjectKey
-                                ( String "off"
-                                , String "chassis_gauges"
-                                )
-                            , ObjectKey
-                                ( String "on"
-                                , String "chassis_gauges_on"
-                                )
-                            ]
-                        )
-                    , ObjectKey
-                        ( String "chassis_gaugelight_parkbrake"
-                        , Object
-                            [ ObjectKey
-                                ( String "simpleFunction"
-                                , String "parkingbrakelight"
-                                )
-                            , ObjectKey
-                                ( String "off"
-                                , String "chassis_gauges"
-                                )
-                            , ObjectKey
-                                ( String "on"
-                                , String "chassis_gauges_on"
-                                )
-                            ]
-                        )
-                    , Comment
-                        ( InternalComment
-                            { cText = "multi-condition warning light"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = True
-                            }
-                        )
-                    , ObjectKey
-                        ( String "chassis_gaugelight_warning"
-                        , Object
-                            [ ObjectKey
-                                ( String "simpleFunction"
-                                , Object
-                                    [ ObjectKey
-                                        ( String "checkengine"
-                                        , Number
-                                            ( NumberValue
-                                                { nvText = "1"
-                                                , nvValue = 1.0
-                                                }
-                                            )
-                                        )
-                                    , ObjectKey
-                                        ( String "battery"
-                                        , Number
-                                            ( NumberValue
-                                                { nvText = "1"
-                                                , nvValue = 1.0
-                                                }
-                                            )
-                                        )
-                                    , ObjectKey
-                                        ( String "lowpressure"
-                                        , Number
-                                            ( NumberValue
-                                                { nvText = "1"
-                                                , nvValue = 1.0
-                                                }
-                                            )
-                                        )
-                                    ]
-                                )
-                            , ObjectKey
-                                ( String "off"
-                                , String "chassis_gauges"
-                                )
-                            , ObjectKey
-                                ( String "on"
-                                , String "chassis_gauges_on"
-                                )
-                            ]
-                        )
-                    ]
+                        , ovTrailingComma = False
+                        }
+                    )
                 )
             ]
-        )
-    ]
+        , ovTrailingComma = False
+        }
+    )

--- a/examples/ast/jbeam/frame.hs
+++ b/examples/ast/jbeam/frame.hs
@@ -1,4925 +1,8445 @@
 Object
     ( ObjectValue
         { ovElements =
-            [ ObjectKey
-                ( String "chassis_rails"
-                , Object
-                    ( ObjectValue
-                        { ovElements =
-                            [ ObjectKey
-                                ( String "information"
-                                , Object
-                                    ( ObjectValue
-                                        { ovElements =
-                                            [ ObjectKey
-                                                ( String "authors"
-                                                , String "gittarrgy01"
-                                                )
-                                            , ObjectKey
-                                                ( String "name"
-                                                , String ""
-                                                )
-                                            ]
-                                        , ovTrailingComma = False
-                                        }
-                                    )
-                                )
-                            , ObjectKey
-                                ( String "slotType"
-                                , String "main"
-                                )
-                            , Comment
-                                ( InternalComment
-                                    { cText = "\nThe purpose of this file is prove that moving metadata\nalong with vertices when moving vertices works as intended.\nSee issue for #69 explanation on the transformation part of the codebase.\n"
-                                    , cMultiline = True
-                                    , cAssociationDirection = NextNode
-                                    , cHadNewlineBefore = False
-                                    }
-                                )
-                            , Comment
-                                ( InternalComment
-                                    { cText = "--Nodes--"
-                                    , cMultiline = False
-                                    , cAssociationDirection = NextNode
-                                    , cHadNewlineBefore = False
-                                    }
-                                )
-                            , ObjectKey
-                                ( String "nodes"
-                                , Array
-                                    ( ArrayValue
-                                        { avElements =
-                                            [ Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "id"
-                                                        , String "posX"
-                                                        , String "posY"
-                                                        , String "posZ"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "group"
-                                                            , String "chassis_rails"
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f0"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.523"
-                                                                , nvValue = 0.523
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-2.098"
-                                                                , nvValue = -2.098
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.319"
-                                                                , nvValue = 0.319
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f1"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.417"
-                                                                , nvValue = -0.417
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-2.098"
-                                                                , nvValue = -2.098
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.319"
-                                                                , nvValue = 0.319
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f2"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.053"
-                                                                , nvValue = 5.3e-2
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-2.095"
-                                                                , nvValue = -2.095
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.319"
-                                                                , nvValue = 0.319
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f3"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.523"
-                                                                , nvValue = 0.523
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-2.093"
-                                                                , nvValue = -2.093
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.268"
-                                                                , nvValue = 0.268
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f4"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.417"
-                                                                , nvValue = -0.417
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-2.093"
-                                                                , nvValue = -2.093
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.268"
-                                                                , nvValue = 0.268
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f5"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.053"
-                                                                , nvValue = 5.3e-2
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-2.090"
-                                                                , nvValue = -2.09
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.269"
-                                                                , nvValue = 0.269
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f6"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.531"
-                                                                , nvValue = 0.531
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-1.724"
-                                                                , nvValue = -1.724
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.341"
-                                                                , nvValue = 0.341
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f7"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.424"
-                                                                , nvValue = -0.424
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-1.724"
-                                                                , nvValue = -1.724
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.341"
-                                                                , nvValue = 0.341
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f8"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.531"
-                                                                , nvValue = 0.531
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-1.721"
-                                                                , nvValue = -1.721
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.289"
-                                                                , nvValue = 0.289
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f9"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.424"
-                                                                , nvValue = -0.424
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-1.721"
-                                                                , nvValue = -1.721
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.289"
-                                                                , nvValue = 0.289
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f10"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.547"
-                                                                , nvValue = 0.547
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-1.350"
-                                                                , nvValue = -1.35
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.310"
-                                                                , nvValue = 0.31
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f11"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.547"
-                                                                , nvValue = 0.547
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-1.350"
-                                                                , nvValue = -1.35
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.364"
-                                                                , nvValue = 0.364
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f12"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.440"
-                                                                , nvValue = -0.44
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-1.350"
-                                                                , nvValue = -1.35
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.310"
-                                                                , nvValue = 0.31
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f13"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.440"
-                                                                , nvValue = -0.44
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-1.350"
-                                                                , nvValue = -1.35
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.364"
-                                                                , nvValue = 0.364
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f14"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.053"
-                                                                , nvValue = 5.3e-2
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-1.314"
-                                                                , nvValue = -1.314
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.382"
-                                                                , nvValue = 0.382
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "support for front"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = PreviousNode
-                                                    , cHadNewlineBefore = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl15"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.790"
-                                                                , nvValue = 0.79
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.919"
-                                                                , nvValue = -0.919
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.182"
-                                                                , nvValue = 0.182
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl16"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.790"
-                                                                , nvValue = 0.79
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.919"
-                                                                , nvValue = -0.919
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.233"
-                                                                , nvValue = 0.233
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl17"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.683"
-                                                                , nvValue = -0.683
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.919"
-                                                                , nvValue = -0.919
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.182"
-                                                                , nvValue = 0.182
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl18"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.683"
-                                                                , nvValue = -0.683
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.919"
-                                                                , nvValue = -0.919
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.233"
-                                                                , nvValue = 0.233
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl19"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.053"
-                                                                , nvValue = 5.3e-2
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.024"
-                                                                , nvValue = -2.4e-2
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.578"
-                                                                , nvValue = 0.578
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "support"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = PreviousNode
-                                                    , cHadNewlineBefore = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl20"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.837"
-                                                                , nvValue = 0.837
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.002"
-                                                                , nvValue = 2.0e-3
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.182"
-                                                                , nvValue = 0.182
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl21"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.837"
-                                                                , nvValue = 0.837
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.002"
-                                                                , nvValue = 2.0e-3
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.233"
-                                                                , nvValue = 0.233
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl22"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.415"
-                                                                , nvValue = 0.415
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.002"
-                                                                , nvValue = 2.0e-3
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.182"
-                                                                , nvValue = 0.182
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl23"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.415"
-                                                                , nvValue = 0.415
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.002"
-                                                                , nvValue = 2.0e-3
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.233"
-                                                                , nvValue = 0.233
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl24"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.053"
-                                                                , nvValue = 5.3e-2
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.002"
-                                                                , nvValue = 2.0e-3
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.182"
-                                                                , nvValue = 0.182
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl25"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.053"
-                                                                , nvValue = 5.3e-2
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.002"
-                                                                , nvValue = 2.0e-3
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.233"
-                                                                , nvValue = 0.233
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl26"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.308"
-                                                                , nvValue = -0.308
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.002"
-                                                                , nvValue = 2.0e-3
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.182"
-                                                                , nvValue = 0.182
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl27"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.308"
-                                                                , nvValue = -0.308
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.002"
-                                                                , nvValue = 2.0e-3
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.233"
-                                                                , nvValue = 0.233
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl28"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.730"
-                                                                , nvValue = -0.73
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.002"
-                                                                , nvValue = 2.0e-3
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.182"
-                                                                , nvValue = 0.182
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl29"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.730"
-                                                                , nvValue = -0.73
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.002"
-                                                                , nvValue = 2.0e-3
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.233"
-                                                                , nvValue = 0.233
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl30"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.822"
-                                                                , nvValue = 0.822
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.791"
-                                                                , nvValue = 0.791
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.182"
-                                                                , nvValue = 0.182
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl31"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.822"
-                                                                , nvValue = 0.822
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.791"
-                                                                , nvValue = 0.791
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.233"
-                                                                , nvValue = 0.233
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl32"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.715"
-                                                                , nvValue = -0.715
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.791"
-                                                                , nvValue = 0.791
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.182"
-                                                                , nvValue = 0.182
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl33"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.715"
-                                                                , nvValue = -0.715
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.791"
-                                                                , nvValue = 0.791
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.233"
-                                                                , nvValue = 0.233
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r34"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.651"
-                                                                , nvValue = 0.651
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "1.121"
-                                                                , nvValue = 1.121
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.628"
-                                                                , nvValue = 0.628
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r35"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.053"
-                                                                , nvValue = 5.3e-2
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "1.121"
-                                                                , nvValue = 1.121
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.628"
-                                                                , nvValue = 0.628
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r36"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.544"
-                                                                , nvValue = -0.544
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "1.121"
-                                                                , nvValue = 1.121
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.628"
-                                                                , nvValue = 0.628
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r37"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.651"
-                                                                , nvValue = 0.651
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "1.152"
-                                                                , nvValue = 1.152
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.565"
-                                                                , nvValue = 0.565
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r38"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.053"
-                                                                , nvValue = 5.3e-2
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "1.152"
-                                                                , nvValue = 1.152
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.565"
-                                                                , nvValue = 0.565
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r39"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.544"
-                                                                , nvValue = -0.544
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "1.152"
-                                                                , nvValue = 1.152
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.565"
-                                                                , nvValue = 0.565
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r40"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.602"
-                                                                , nvValue = 0.602
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "1.514"
-                                                                , nvValue = 1.514
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.566"
-                                                                , nvValue = 0.566
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r41"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.495"
-                                                                , nvValue = -0.495
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "1.514"
-                                                                , nvValue = 1.514
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.566"
-                                                                , nvValue = 0.566
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r42"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.602"
-                                                                , nvValue = 0.602
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "1.532"
-                                                                , nvValue = 1.532
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.623"
-                                                                , nvValue = 0.623
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r43"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.495"
-                                                                , nvValue = -0.495
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "1.532"
-                                                                , nvValue = 1.532
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.623"
-                                                                , nvValue = 0.623
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r44"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.553"
-                                                                , nvValue = 0.553
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "1.654"
-                                                                , nvValue = 1.654
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.359"
-                                                                , nvValue = 0.359
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r45"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.446"
-                                                                , nvValue = -0.446
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "1.654"
-                                                                , nvValue = 1.654
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.359"
-                                                                , nvValue = 0.359
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r46"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.553"
-                                                                , nvValue = 0.553
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "1.679"
-                                                                , nvValue = 1.679
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.448"
-                                                                , nvValue = 0.448
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r47"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.446"
-                                                                , nvValue = -0.446
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "1.679"
-                                                                , nvValue = 1.679
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.448"
-                                                                , nvValue = 0.448
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r48"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.053"
-                                                                , nvValue = 5.3e-2
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "1.710"
-                                                                , nvValue = 1.71
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.565"
-                                                                , nvValue = 0.565
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "support for rear"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = PreviousNode
-                                                    , cHadNewlineBefore = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r49"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.558"
-                                                                , nvValue = 0.558
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "2.284"
-                                                                , nvValue = 2.284
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.364"
-                                                                , nvValue = 0.364
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r50"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.558"
-                                                                , nvValue = 0.558
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "2.284"
-                                                                , nvValue = 2.284
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.447"
-                                                                , nvValue = 0.447
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r51"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.053"
-                                                                , nvValue = 5.3e-2
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "2.284"
-                                                                , nvValue = 2.284
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.370"
-                                                                , nvValue = 0.37
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r52"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.053"
-                                                                , nvValue = 5.3e-2
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "2.284"
-                                                                , nvValue = 2.284
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.441"
-                                                                , nvValue = 0.441
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r53"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.451"
-                                                                , nvValue = -0.451
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "2.284"
-                                                                , nvValue = 2.284
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.364"
-                                                                , nvValue = 0.364
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r54"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.451"
-                                                                , nvValue = -0.451
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "2.284"
-                                                                , nvValue = 2.284
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.447"
-                                                                , nvValue = 0.447
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "group"
+            [
+                ( ObjectKey
+                    ( String "chassis_rails"
+                    , Object
+                        ( ObjectValue
+                            { ovElements =
+                                [
+                                    ( ObjectKey
+                                        ( String "information"
+                                        , Object
+                                            ( ObjectValue
+                                                { ovElements =
+                                                    [
+                                                        ( ObjectKey
+                                                            ( String "authors"
+                                                            , String "gittarrgy01"
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( ObjectKey
+                                                            ( String "name"
                                                             , String ""
                                                             )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            ]
-                                        , avTrailingComma = False
-                                        }
+                                                        , False
+                                                        )
+                                                    ]
+                                                }
+                                            )
+                                        )
+                                    , True
                                     )
-                                )
-                            , Comment
-                                ( InternalComment
-                                    { cText = "--Beams--"
-                                    , cMultiline = False
-                                    , cAssociationDirection = NextNode
-                                    , cHadNewlineBefore = False
-                                    }
-                                )
-                            , ObjectKey
-                                ( String "beams"
-                                , Array
-                                    ( ArrayValue
-                                        { avElements =
-                                            [ Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "id1:"
-                                                        , String "id2:"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "Structural beams"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = True
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "beamStrength"
-                                                            , String "FLT_MAX"
-                                                            )
-                                                        , ObjectKey
-                                                            ( String "beamSpring"
-                                                            , String "3800000"
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "beamDamp"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "130"
-                                                                    , nvValue = 130.0
-                                                                    }
-                                                                )
-                                                            )
-                                                        , ObjectKey
-                                                            ( String "deformLimit"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "1.1"
-                                                                    , nvValue = 1.1
-                                                                    }
-                                                                )
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "Front end"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = True
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "beamDeform"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "20600"
-                                                                    , nvValue = 20600.0
-                                                                    }
-                                                                )
-                                                            )
-                                                        , ObjectKey
-                                                            ( String "deformLimit"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "1.1"
-                                                                    , nvValue = 1.1
-                                                                    }
-                                                                )
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f3"
-                                                        , String "rl_f5"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f0"
-                                                        , String "rl_f3"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f8"
-                                                        , String "rl_f3"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl15"
-                                                        , String "rl_f10"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f8"
-                                                        , String "rl_f6"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f11"
-                                                        , String "rl_f10"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f10"
-                                                        , String "rl_f8"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f9"
-                                                        , String "rl_f7"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl17"
-                                                        , String "rl_f12"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f6"
-                                                        , String "rl_f11"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f11"
-                                                        , String "rl16"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f13"
-                                                        , String "rl18"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f13"
-                                                        , String "rl_f12"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f1"
-                                                        , String "rl_f4"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f2"
-                                                        , String "rl_f1"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f2"
-                                                        , String "rl_f5"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f12"
-                                                        , String "rl_f9"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f7"
-                                                        , String "rl_f13"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f0"
-                                                        , String "rl_f6"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f9"
-                                                        , String "rl_f4"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f2"
-                                                        , String "rl_f0"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f4"
-                                                        , String "rl_f5"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f1"
-                                                        , String "rl_f7"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "Middle"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = True
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "beamDeform"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "27000"
-                                                                    , nvValue = 27000.0
-                                                                    }
-                                                                )
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl16"
-                                                        , String "rl15"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl20"
-                                                        , String "rl30"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl16"
-                                                        , String "rl23"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl18"
-                                                        , String "rl17"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl17"
-                                                        , String "rl28"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl26"
-                                                        , String "rl17"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl18"
-                                                        , String "rl27"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl26"
-                                                        , String "rl24"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl25"
-                                                        , String "rl24"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl25"
-                                                        , String "rl27"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl21"
-                                                        , String "rl16"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl22"
-                                                        , String "rl15"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl15"
-                                                        , String "rl20"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl29"
-                                                        , String "rl27"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl28"
-                                                        , String "rl32"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl29"
-                                                        , String "rl18"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl22"
-                                                        , String "rl24"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl31"
-                                                        , String "rl21"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl28"
-                                                        , String "rl29"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl32"
-                                                        , String "rl33"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl30"
-                                                        , String "rl31"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl33"
-                                                        , String "rl29"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl30"
-                                                        , String "rl22"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl25"
-                                                        , String "rl23"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl32"
-                                                        , String "rl26"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl20"
-                                                        , String "rl21"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl31"
-                                                        , String "rl23"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl20"
-                                                        , String "rl22"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl21"
-                                                        , String "rl23"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl33"
-                                                        , String "rl27"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl23"
-                                                        , String "rl22"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl28"
-                                                        , String "rl26"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl27"
-                                                        , String "rl26"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "Rear end"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = True
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "beamDeform"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "22000"
-                                                                    , nvValue = 22000.0
-                                                                    }
-                                                                )
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r37"
-                                                        , String "rl_r34"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r39"
-                                                        , String "rl_r41"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r44"
-                                                        , String "rl_r46"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl33"
-                                                        , String "rl_r36"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r46"
-                                                        , String "rl_r42"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl31"
-                                                        , String "rl_r34"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r37"
-                                                        , String "rl30"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r49"
-                                                        , String "rl_r51"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r52"
-                                                        , String "rl_r50"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r50"
-                                                        , String "rl_r46"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r49"
-                                                        , String "rl_r50"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r42"
-                                                        , String "rl_r34"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r40"
-                                                        , String "rl_r44"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r40"
-                                                        , String "rl_r42"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r41"
-                                                        , String "rl_r45"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r39"
-                                                        , String "rl_r36"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r36"
-                                                        , String "rl_r35"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r38"
-                                                        , String "rl_r35"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r53"
-                                                        , String "rl_r54"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r52"
-                                                        , String "rl_r54"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r51"
-                                                        , String "rl_r52"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r45"
-                                                        , String "rl_r53"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r54"
-                                                        , String "rl_r47"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r43"
-                                                        , String "rl_r36"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r53"
-                                                        , String "rl_r51"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r34"
-                                                        , String "rl_r35"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r38"
-                                                        , String "rl_r37"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r45"
-                                                        , String "rl_r47"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r41"
-                                                        , String "rl_r43"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r38"
-                                                        , String "rl_r39"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r39"
-                                                        , String "rl32"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r47"
-                                                        , String "rl_r43"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r44"
-                                                        , String "rl_r49"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r37"
-                                                        , String "rl_r40"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "Crossing beams"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = True
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "Front end"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = True
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "beamDeform"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "16000"
-                                                                    , nvValue = 16000.0
-                                                                    }
-                                                                )
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f4"
-                                                        , String "rl_f2"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f0"
-                                                        , String "rl_f8"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl16"
-                                                        , String "rl_f10"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl15"
-                                                        , String "rl_f11"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f10"
-                                                        , String "rl_f6"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f11"
-                                                        , String "rl_f8"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f1"
-                                                        , String "rl_f5"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f4"
-                                                        , String "rl_f7"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f1"
-                                                        , String "rl_f9"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f12"
-                                                        , String "rl_f7"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f3"
-                                                        , String "rl_f6"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f0"
-                                                        , String "rl_f5"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f3"
-                                                        , String "rl_f2"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f13"
-                                                        , String "rl_f9"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl17"
-                                                        , String "rl_f13"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl18"
-                                                        , String "rl_f12"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "Middle"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = True
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "beamDeform"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "6500"
-                                                                    , nvValue = 6500.0
-                                                                    }
-                                                                )
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl16"
-                                                        , String "rl20"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl15"
-                                                        , String "rl23"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl18"
-                                                        , String "rl28"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl18"
-                                                        , String "rl26"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl17"
-                                                        , String "rl27"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl27"
-                                                        , String "rl24"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl26"
-                                                        , String "rl25"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl31"
-                                                        , String "rl20"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl15"
-                                                        , String "rl21"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl16"
-                                                        , String "rl22"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl32"
-                                                        , String "rl29"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl30"
-                                                        , String "rl21"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl23"
-                                                        , String "rl24"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl32"
-                                                        , String "rl27"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl17"
-                                                        , String "rl29"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl33"
-                                                        , String "rl28"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl29"
-                                                        , String "rl26"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl30"
-                                                        , String "rl23"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl33"
-                                                        , String "rl26"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl22"
-                                                        , String "rl25"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl20"
-                                                        , String "rl23"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl28"
-                                                        , String "rl27"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl31"
-                                                        , String "rl22"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl21"
-                                                        , String "rl22"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "Rear end"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = True
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "beamDeform"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "16000"
-                                                                    , nvValue = 16000.0
-                                                                    }
-                                                                )
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r54"
-                                                        , String "rl_r45"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl32"
-                                                        , String "rl_r36"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r36"
-                                                        , String "rl_r41"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r50"
-                                                        , String "rl_r51"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl31"
-                                                        , String "rl_r37"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl30"
-                                                        , String "rl_r34"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r46"
-                                                        , String "rl_r40"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r53"
-                                                        , String "rl_r47"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r50"
-                                                        , String "rl_r44"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r49"
-                                                        , String "rl_r46"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r37"
-                                                        , String "rl_r42"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r34"
-                                                        , String "rl_r40"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r34"
-                                                        , String "rl_r38"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl33"
-                                                        , String "rl_r39"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r39"
-                                                        , String "rl_r35"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r36"
-                                                        , String "rl_r38"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r53"
-                                                        , String "rl_r52"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r54"
-                                                        , String "rl_r51"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r45"
-                                                        , String "rl_r43"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r47"
-                                                        , String "rl_r41"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r39"
-                                                        , String "rl_r43"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r37"
-                                                        , String "rl_r35"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r49"
-                                                        , String "rl_r52"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r44"
-                                                        , String "rl_r42"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "Support beams"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = True
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "Front end"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = True
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "beamDeform"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "19000"
-                                                                    , nvValue = 19000.0
-                                                                    }
-                                                                )
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f8"
-                                                        , String "rl_f14"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f9"
-                                                        , String "rl_f14"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f"
-                                                        , String "rl_f3"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f10"
-                                                        , String "rl_f14"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f14"
-                                                        , String "rl_f13"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f1"
-                                                        , String "rl_f14"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f0"
-                                                        , String "rl_f14"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f12"
-                                                        , String "rl_f14"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f5"
-                                                        , String "rl_f14"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f14"
-                                                        , String "rl_f4"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f14"
-                                                        , String "rl_f6"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f14"
-                                                        , String "rl_f7"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f14"
-                                                        , String "rl_f2"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f14"
-                                                        , String "rl_f11"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "Middle"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = True
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "beamDeform"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "11000"
-                                                                    , nvValue = 11000.0
-                                                                    }
-                                                                )
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl27"
-                                                        , String "rl19"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl26"
-                                                        , String "rl19"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl24"
-                                                        , String "rl19"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl23"
-                                                        , String "rl19"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl20"
-                                                        , String "rl19"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl19"
-                                                        , String "rl16"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl19"
-                                                        , String "rl15"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl31"
-                                                        , String "rl19"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl33"
-                                                        , String "rl19"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl28"
-                                                        , String "rl19"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl19"
-                                                        , String "rl25"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl21"
-                                                        , String "rl19"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl22"
-                                                        , String "rl19"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl19"
-                                                        , String "rl32"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl29"
-                                                        , String "rl19"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl19"
-                                                        , String "rl18"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl19"
-                                                        , String "rl17"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl19"
-                                                        , String "rl30"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "Rear end"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = True
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "beamDeform"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "19000"
-                                                                    , nvValue = 19000.0
-                                                                    }
-                                                                )
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r48"
-                                                        , String "rl_r51"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r48"
-                                                        , String "rl_r54"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r45"
-                                                        , String "rl_r48"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r48"
-                                                        , String "rl_r50"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r48"
-                                                        , String "rl_r42"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r48"
-                                                        , String "rl_r47"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r49"
-                                                        , String "rl_r48"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r35"
-                                                        , String "rl_r48"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r48"
-                                                        , String "rl_r43"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r44"
-                                                        , String "rl_r48"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r53"
-                                                        , String "rl_r48"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r52"
-                                                        , String "rl_r48"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r40"
-                                                        , String "rl_r48"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r48"
-                                                        , String "rl_r38"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r41"
-                                                        , String "rl_r48"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r4"
-                                                        , String "rl_r46"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "Front crush"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = True
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "beamDeform"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "8500"
-                                                                    , nvValue = 8500.0
-                                                                    }
-                                                                )
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl17"
-                                                        , String "rl_f9"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl15"
-                                                        , String "rl_f8"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            ]
-                                        , avTrailingComma = False
-                                        }
+                                ,
+                                    ( ObjectKey
+                                        ( String "slotType"
+                                        , String "main"
+                                        )
+                                    , True
                                     )
-                                )
-                            , Comment
-                                ( InternalComment
-                                    { cText = "--Collision Triangles--"
-                                    , cMultiline = False
-                                    , cAssociationDirection = NextNode
-                                    , cHadNewlineBefore = False
-                                    }
-                                )
-                            , ObjectKey
-                                ( String "triangles"
-                                , Array
-                                    ( ArrayValue
-                                        { avElements =
-                                            [ Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "id1:"
-                                                        , String "id2:"
-                                                        , String "id3:"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f5"
-                                                        , String "rl_f3"
-                                                        , String "rl_f2"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f0"
-                                                        , String "rl_f2"
-                                                        , String "rl_f3"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f5"
-                                                        , String "rl_f2"
-                                                        , String "rl_f4"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f1"
-                                                        , String "rl_f4"
-                                                        , String "rl_f2"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f4"
-                                                        , String "rl_f1"
-                                                        , String "rl_f7"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f4"
-                                                        , String "rl_f7"
-                                                        , String "rl_f9"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f7"
-                                                        , String "rl_f13"
-                                                        , String "rl_f9"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f12"
-                                                        , String "rl_f9"
-                                                        , String "rl_f13"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f12"
-                                                        , String "rl_f13"
-                                                        , String "rl18"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl18"
-                                                        , String "rl17"
-                                                        , String "rl_f12"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f3"
-                                                        , String "rl_f6"
-                                                        , String "rl_f0"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f3"
-                                                        , String "rl_f8"
-                                                        , String "rl_f6"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f10"
-                                                        , String "rl_f11"
-                                                        , String "rl_f8"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f6"
-                                                        , String "rl_f8"
-                                                        , String "rl_f11"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_f10"
-                                                        , String "rl16"
-                                                        , String "rl_f11"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl16"
-                                                        , String "rl_f10"
-                                                        , String "rl15"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl15"
-                                                        , String "rl20"
-                                                        , String "rl16"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl21"
-                                                        , String "rl16"
-                                                        , String "rl20"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl30"
-                                                        , String "rl21"
-                                                        , String "rl20"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl31"
-                                                        , String "rl21"
-                                                        , String "rl30"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl17"
-                                                        , String "rl18"
-                                                        , String "rl28"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl29"
-                                                        , String "rl28"
-                                                        , String "rl18"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl32"
-                                                        , String "rl28"
-                                                        , String "rl29"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl33"
-                                                        , String "rl32"
-                                                        , String "rl29"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl32"
-                                                        , String "rl33"
-                                                        , String "rl_r39"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r39"
-                                                        , String "rl33"
-                                                        , String "rl_r36"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r36"
-                                                        , String "rl_r41"
-                                                        , String "rl_r39"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r43"
-                                                        , String "rl_r41"
-                                                        , String "rl_r36"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r45"
-                                                        , String "rl_r41"
-                                                        , String "rl_r43"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r47"
-                                                        , String "rl_r45"
-                                                        , String "rl_r43"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r53"
-                                                        , String "rl_r45"
-                                                        , String "rl_r47"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r54"
-                                                        , String "rl_r53"
-                                                        , String "rl_r47"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r54"
-                                                        , String "rl_r51"
-                                                        , String "rl_r53"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r51"
-                                                        , String "rl_r54"
-                                                        , String "rl_r52"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r52"
-                                                        , String "rl_r50"
-                                                        , String "rl_r51"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r50"
-                                                        , String "rl_r49"
-                                                        , String "rl_r51"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r46"
-                                                        , String "rl_r44"
-                                                        , String "rl_r49"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r50"
-                                                        , String "rl_r46"
-                                                        , String "rl_r49"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r46"
-                                                        , String "rl_r42"
-                                                        , String "rl_r44"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r44"
-                                                        , String "rl_r42"
-                                                        , String "rl_r40"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r34"
-                                                        , String "rl_r37"
-                                                        , String "rl_r40"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r42"
-                                                        , String "rl_r34"
-                                                        , String "rl_r40"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r34"
-                                                        , String "rl_r35"
-                                                        , String "rl_r37"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r35"
-                                                        , String "rl_r38"
-                                                        , String "rl_r37"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r35"
-                                                        , String "rl_r39"
-                                                        , String "rl_r38"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r39"
-                                                        , String "rl_r35"
-                                                        , String "rl_r36"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl30"
-                                                        , String "rl_r37"
-                                                        , String "rl31"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl_r37"
-                                                        , String "rl_r34"
-                                                        , String "rl31"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl16"
-                                                        , String "rl15"
-                                                        , String "rl22"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl16"
-                                                        , String "rl22"
-                                                        , String "rl23"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl23"
-                                                        , String "rl22"
-                                                        , String "rl21"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl21"
-                                                        , String "rl22"
-                                                        , String "rl20"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl27"
-                                                        , String "rl29"
-                                                        , String "rl26"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl29"
-                                                        , String "rl28"
-                                                        , String "rl26"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl18"
-                                                        , String "rl26"
-                                                        , String "rl17"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl27"
-                                                        , String "rl26"
-                                                        , String "rl18"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl24"
-                                                        , String "rl22"
-                                                        , String "rl23"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl27"
-                                                        , String "rl26"
-                                                        , String "rl24"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl24"
-                                                        , String "rl25"
-                                                        , String "rl27"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl24"
-                                                        , String "rl23"
-                                                        , String "rl25"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl30"
-                                                        , String "rl23"
-                                                        , String "rl22"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl30"
-                                                        , String "rl31"
-                                                        , String "rl23"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl26"
-                                                        , String "rl27"
-                                                        , String "rl32"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl33"
-                                                        , String "rl32"
-                                                        , String "rl27"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            ]
-                                        , avTrailingComma = False
-                                        }
+                                ,
+                                    ( Comment
+                                        ( InternalComment
+                                            { cText = "\nThe purpose of this file is prove that moving metadata\nalong with vertices when moving vertices works as intended.\nSee issue for #69 explanation on the transformation part of the codebase.\n"
+                                            , cMultiline = True
+                                            , cAssociationDirection = NextNode
+                                            , cHadNewlineBefore = False
+                                            }
+                                        )
+                                    , False
                                     )
-                                )
-                            , ObjectKey
-                                ( String "flexbodies"
-                                , Array
-                                    ( ArrayValue
-                                        { avElements =
-                                            [ Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "mesh"
-                                                        , String "[group]:"
-                                                        , String "nonFlexMaterials"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rails"
-                                                        , Array
+                                ,
+                                    ( Comment
+                                        ( InternalComment
+                                            { cText = "--Nodes--"
+                                            , cMultiline = False
+                                            , cAssociationDirection = NextNode
+                                            , cHadNewlineBefore = False
+                                            }
+                                        )
+                                    , False
+                                    )
+                                ,
+                                    ( ObjectKey
+                                        ( String "nodes"
+                                        , Array
+                                            ( ArrayValue
+                                                { avElements =
+                                                    [
+                                                        ( Array
                                                             ( ArrayValue
                                                                 { avElements =
-                                                                    [ String "chassis_rails" ]
-                                                                , avTrailingComma = False
+                                                                    [
+                                                                        ( String "id"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "posX"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "posY"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "posZ"
+                                                                        , False
+                                                                        )
+                                                                    ]
                                                                 }
                                                             )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            ]
-                                        , avTrailingComma = False
-                                        }
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "group"
+                                                                            , String "chassis_rails"
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f0"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.523"
+                                                                                , nvValue = 0.523
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-2.098"
+                                                                                , nvValue = -2.098
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.319"
+                                                                                , nvValue = 0.319
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f1"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.417"
+                                                                                , nvValue = -0.417
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-2.098"
+                                                                                , nvValue = -2.098
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.319"
+                                                                                , nvValue = 0.319
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f2"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.053"
+                                                                                , nvValue = 5.3e-2
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-2.095"
+                                                                                , nvValue = -2.095
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.319"
+                                                                                , nvValue = 0.319
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f3"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.523"
+                                                                                , nvValue = 0.523
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-2.093"
+                                                                                , nvValue = -2.093
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.268"
+                                                                                , nvValue = 0.268
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f4"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.417"
+                                                                                , nvValue = -0.417
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-2.093"
+                                                                                , nvValue = -2.093
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.268"
+                                                                                , nvValue = 0.268
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f5"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.053"
+                                                                                , nvValue = 5.3e-2
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-2.090"
+                                                                                , nvValue = -2.09
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.269"
+                                                                                , nvValue = 0.269
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f6"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.531"
+                                                                                , nvValue = 0.531
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-1.724"
+                                                                                , nvValue = -1.724
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.341"
+                                                                                , nvValue = 0.341
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f7"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.424"
+                                                                                , nvValue = -0.424
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-1.724"
+                                                                                , nvValue = -1.724
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.341"
+                                                                                , nvValue = 0.341
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f8"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.531"
+                                                                                , nvValue = 0.531
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-1.721"
+                                                                                , nvValue = -1.721
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.289"
+                                                                                , nvValue = 0.289
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f9"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.424"
+                                                                                , nvValue = -0.424
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-1.721"
+                                                                                , nvValue = -1.721
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.289"
+                                                                                , nvValue = 0.289
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f10"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.547"
+                                                                                , nvValue = 0.547
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-1.350"
+                                                                                , nvValue = -1.35
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.310"
+                                                                                , nvValue = 0.31
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f11"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.547"
+                                                                                , nvValue = 0.547
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-1.350"
+                                                                                , nvValue = -1.35
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.364"
+                                                                                , nvValue = 0.364
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f12"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.440"
+                                                                                , nvValue = -0.44
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-1.350"
+                                                                                , nvValue = -1.35
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.310"
+                                                                                , nvValue = 0.31
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f13"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.440"
+                                                                                , nvValue = -0.44
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-1.350"
+                                                                                , nvValue = -1.35
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.364"
+                                                                                , nvValue = 0.364
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f14"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.053"
+                                                                                , nvValue = 5.3e-2
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-1.314"
+                                                                                , nvValue = -1.314
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.382"
+                                                                                , nvValue = 0.382
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "support for front"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = PreviousNode
+                                                                , cHadNewlineBefore = False
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl15"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.790"
+                                                                                , nvValue = 0.79
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.919"
+                                                                                , nvValue = -0.919
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.182"
+                                                                                , nvValue = 0.182
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl16"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.790"
+                                                                                , nvValue = 0.79
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.919"
+                                                                                , nvValue = -0.919
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.233"
+                                                                                , nvValue = 0.233
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl17"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.683"
+                                                                                , nvValue = -0.683
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.919"
+                                                                                , nvValue = -0.919
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.182"
+                                                                                , nvValue = 0.182
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl18"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.683"
+                                                                                , nvValue = -0.683
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.919"
+                                                                                , nvValue = -0.919
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.233"
+                                                                                , nvValue = 0.233
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl19"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.053"
+                                                                                , nvValue = 5.3e-2
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.024"
+                                                                                , nvValue = -2.4e-2
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.578"
+                                                                                , nvValue = 0.578
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "support"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = PreviousNode
+                                                                , cHadNewlineBefore = False
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl20"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.837"
+                                                                                , nvValue = 0.837
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.002"
+                                                                                , nvValue = 2.0e-3
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.182"
+                                                                                , nvValue = 0.182
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl21"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.837"
+                                                                                , nvValue = 0.837
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.002"
+                                                                                , nvValue = 2.0e-3
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.233"
+                                                                                , nvValue = 0.233
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl22"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.415"
+                                                                                , nvValue = 0.415
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.002"
+                                                                                , nvValue = 2.0e-3
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.182"
+                                                                                , nvValue = 0.182
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl23"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.415"
+                                                                                , nvValue = 0.415
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.002"
+                                                                                , nvValue = 2.0e-3
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.233"
+                                                                                , nvValue = 0.233
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl24"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.053"
+                                                                                , nvValue = 5.3e-2
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.002"
+                                                                                , nvValue = 2.0e-3
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.182"
+                                                                                , nvValue = 0.182
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl25"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.053"
+                                                                                , nvValue = 5.3e-2
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.002"
+                                                                                , nvValue = 2.0e-3
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.233"
+                                                                                , nvValue = 0.233
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl26"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.308"
+                                                                                , nvValue = -0.308
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.002"
+                                                                                , nvValue = 2.0e-3
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.182"
+                                                                                , nvValue = 0.182
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl27"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.308"
+                                                                                , nvValue = -0.308
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.002"
+                                                                                , nvValue = 2.0e-3
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.233"
+                                                                                , nvValue = 0.233
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl28"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.730"
+                                                                                , nvValue = -0.73
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.002"
+                                                                                , nvValue = 2.0e-3
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.182"
+                                                                                , nvValue = 0.182
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl29"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.730"
+                                                                                , nvValue = -0.73
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.002"
+                                                                                , nvValue = 2.0e-3
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.233"
+                                                                                , nvValue = 0.233
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl30"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.822"
+                                                                                , nvValue = 0.822
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.791"
+                                                                                , nvValue = 0.791
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.182"
+                                                                                , nvValue = 0.182
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl31"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.822"
+                                                                                , nvValue = 0.822
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.791"
+                                                                                , nvValue = 0.791
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.233"
+                                                                                , nvValue = 0.233
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl32"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.715"
+                                                                                , nvValue = -0.715
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.791"
+                                                                                , nvValue = 0.791
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.182"
+                                                                                , nvValue = 0.182
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl33"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.715"
+                                                                                , nvValue = -0.715
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.791"
+                                                                                , nvValue = 0.791
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.233"
+                                                                                , nvValue = 0.233
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r34"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.651"
+                                                                                , nvValue = 0.651
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "1.121"
+                                                                                , nvValue = 1.121
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.628"
+                                                                                , nvValue = 0.628
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r35"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.053"
+                                                                                , nvValue = 5.3e-2
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "1.121"
+                                                                                , nvValue = 1.121
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.628"
+                                                                                , nvValue = 0.628
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r36"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.544"
+                                                                                , nvValue = -0.544
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "1.121"
+                                                                                , nvValue = 1.121
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.628"
+                                                                                , nvValue = 0.628
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r37"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.651"
+                                                                                , nvValue = 0.651
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "1.152"
+                                                                                , nvValue = 1.152
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.565"
+                                                                                , nvValue = 0.565
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r38"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.053"
+                                                                                , nvValue = 5.3e-2
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "1.152"
+                                                                                , nvValue = 1.152
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.565"
+                                                                                , nvValue = 0.565
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r39"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.544"
+                                                                                , nvValue = -0.544
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "1.152"
+                                                                                , nvValue = 1.152
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.565"
+                                                                                , nvValue = 0.565
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r40"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.602"
+                                                                                , nvValue = 0.602
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "1.514"
+                                                                                , nvValue = 1.514
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.566"
+                                                                                , nvValue = 0.566
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r41"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.495"
+                                                                                , nvValue = -0.495
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "1.514"
+                                                                                , nvValue = 1.514
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.566"
+                                                                                , nvValue = 0.566
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r42"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.602"
+                                                                                , nvValue = 0.602
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "1.532"
+                                                                                , nvValue = 1.532
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.623"
+                                                                                , nvValue = 0.623
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r43"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.495"
+                                                                                , nvValue = -0.495
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "1.532"
+                                                                                , nvValue = 1.532
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.623"
+                                                                                , nvValue = 0.623
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r44"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.553"
+                                                                                , nvValue = 0.553
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "1.654"
+                                                                                , nvValue = 1.654
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.359"
+                                                                                , nvValue = 0.359
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r45"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.446"
+                                                                                , nvValue = -0.446
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "1.654"
+                                                                                , nvValue = 1.654
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.359"
+                                                                                , nvValue = 0.359
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r46"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.553"
+                                                                                , nvValue = 0.553
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "1.679"
+                                                                                , nvValue = 1.679
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.448"
+                                                                                , nvValue = 0.448
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r47"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.446"
+                                                                                , nvValue = -0.446
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "1.679"
+                                                                                , nvValue = 1.679
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.448"
+                                                                                , nvValue = 0.448
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r48"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.053"
+                                                                                , nvValue = 5.3e-2
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "1.710"
+                                                                                , nvValue = 1.71
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.565"
+                                                                                , nvValue = 0.565
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "support for rear"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = PreviousNode
+                                                                , cHadNewlineBefore = False
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r49"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.558"
+                                                                                , nvValue = 0.558
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "2.284"
+                                                                                , nvValue = 2.284
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.364"
+                                                                                , nvValue = 0.364
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r50"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.558"
+                                                                                , nvValue = 0.558
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "2.284"
+                                                                                , nvValue = 2.284
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.447"
+                                                                                , nvValue = 0.447
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r51"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.053"
+                                                                                , nvValue = 5.3e-2
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "2.284"
+                                                                                , nvValue = 2.284
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.370"
+                                                                                , nvValue = 0.37
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r52"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.053"
+                                                                                , nvValue = 5.3e-2
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "2.284"
+                                                                                , nvValue = 2.284
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.441"
+                                                                                , nvValue = 0.441
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r53"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.451"
+                                                                                , nvValue = -0.451
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "2.284"
+                                                                                , nvValue = 2.284
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.364"
+                                                                                , nvValue = 0.364
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r54"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.451"
+                                                                                , nvValue = -0.451
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "2.284"
+                                                                                , nvValue = 2.284
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.447"
+                                                                                , nvValue = 0.447
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "group"
+                                                                            , String ""
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ]
+                                                }
+                                            )
+                                        )
+                                    , True
                                     )
-                                )
-                            , ObjectKey
-                                ( String "glowMap"
-                                , Object
-                                    ( ObjectValue
-                                        { ovElements =
-                                            [ Comment
-                                                ( InternalComment
-                                                    { cText = "main lights"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = False
-                                                    }
-                                                )
-                                            , ObjectKey
-                                                ( String "chassis_headlight_L"
-                                                , Object
-                                                    ( ObjectValue
-                                                        { ovElements =
-                                                            [ ObjectKey
-                                                                ( String "simpleFunction"
-                                                                , String "lowhighbeam_filament"
-                                                                )
-                                                            , ObjectKey
-                                                                ( String "off"
-                                                                , String "chassis_headlight"
-                                                                )
-                                                            , ObjectKey
-                                                                ( String "on"
-                                                                , String "chassis_headlight_on"
-                                                                )
-                                                            , ObjectKey
-                                                                ( String "materialEmissiveScaling"
-                                                                , Object
-                                                                    ( ObjectValue
-                                                                        { ovElements =
-                                                                            [ ObjectKey
-                                                                                ( String "on_max"
-                                                                                , Number
-                                                                                    ( NumberValue
-                                                                                        { nvText = "1"
-                                                                                        , nvValue = 1.0
-                                                                                        }
-                                                                                    )
-                                                                                )
-                                                                            ]
-                                                                        , ovTrailingComma = False
-                                                                        }
-                                                                    )
-                                                                )
-                                                            ]
-                                                        , ovTrailingComma = False
-                                                        }
-                                                    )
-                                                )
-                                            , ObjectKey
-                                                ( String "chassis_headlight_R"
-                                                , Object
-                                                    ( ObjectValue
-                                                        { ovElements =
-                                                            [ ObjectKey
-                                                                ( String "simpleFunction"
-                                                                , String "lowhighbeam_filament"
-                                                                )
-                                                            , ObjectKey
-                                                                ( String "off"
-                                                                , String "chassis_headlight"
-                                                                )
-                                                            , ObjectKey
-                                                                ( String "on"
-                                                                , String "chassis_headlight_on"
-                                                                )
-                                                            , ObjectKey
-                                                                ( String "materialEmissiveScaling"
-                                                                , Object
-                                                                    ( ObjectValue
-                                                                        { ovElements =
-                                                                            [ ObjectKey
-                                                                                ( String "on_max"
-                                                                                , Number
-                                                                                    ( NumberValue
-                                                                                        { nvText = "1"
-                                                                                        , nvValue = 1.0
-                                                                                        }
-                                                                                    )
-                                                                                )
-                                                                            ]
-                                                                        , ovTrailingComma = False
-                                                                        }
-                                                                    )
-                                                                )
-                                                            ]
-                                                        , ovTrailingComma = False
-                                                        }
-                                                    )
-                                                )
-                                            , ObjectKey
-                                                ( String "chassis_signal_L"
-                                                , Object
-                                                    ( ObjectValue
-                                                        { ovElements =
-                                                            [ ObjectKey
-                                                                ( String "simpleFunction"
-                                                                , String "signal_L_filament"
-                                                                )
-                                                            , ObjectKey
-                                                                ( String "off"
-                                                                , String "chassis_signal_amber"
-                                                                )
-                                                            , ObjectKey
-                                                                ( String "on"
-                                                                , String "chassis_signal_amber_on"
-                                                                )
-                                                            , ObjectKey
-                                                                ( String "materialEmissiveScaling"
-                                                                , Object
-                                                                    ( ObjectValue
-                                                                        { ovElements =
-                                                                            [ ObjectKey
-                                                                                ( String "on_max"
-                                                                                , Number
-                                                                                    ( NumberValue
-                                                                                        { nvText = "1"
-                                                                                        , nvValue = 1.0
-                                                                                        }
-                                                                                    )
-                                                                                )
-                                                                            ]
-                                                                        , ovTrailingComma = False
-                                                                        }
-                                                                    )
-                                                                )
-                                                            ]
-                                                        , ovTrailingComma = False
-                                                        }
-                                                    )
-                                                )
-                                            , ObjectKey
-                                                ( String "chassis_signal_R"
-                                                , Object
-                                                    ( ObjectValue
-                                                        { ovElements =
-                                                            [ ObjectKey
-                                                                ( String "simpleFunction"
-                                                                , String "signal_R_filament"
-                                                                )
-                                                            , ObjectKey
-                                                                ( String "off"
-                                                                , String "chassis_signal_amber"
-                                                                )
-                                                            , ObjectKey
-                                                                ( String "on"
-                                                                , String "chassis_signal_amber_on"
-                                                                )
-                                                            , ObjectKey
-                                                                ( String "materialEmissiveScaling"
-                                                                , Object
-                                                                    ( ObjectValue
-                                                                        { ovElements =
-                                                                            [ ObjectKey
-                                                                                ( String "on_max"
-                                                                                , Number
-                                                                                    ( NumberValue
-                                                                                        { nvText = "1"
-                                                                                        , nvValue = 1.0
-                                                                                        }
-                                                                                    )
-                                                                                )
-                                                                            ]
-                                                                        , ovTrailingComma = False
-                                                                        }
-                                                                    )
-                                                                )
-                                                            ]
-                                                        , ovTrailingComma = False
-                                                        }
-                                                    )
-                                                )
-                                            , ObjectKey
-                                                ( String "chassis_reverselight"
-                                                , Object
-                                                    ( ObjectValue
-                                                        { ovElements =
-                                                            [ ObjectKey
-                                                                ( String "simpleFunction"
-                                                                , String "reverselight_filament"
-                                                                )
-                                                            , ObjectKey
-                                                                ( String "off"
-                                                                , String "chassis_reverselight"
-                                                                )
-                                                            , ObjectKey
-                                                                ( String "on"
-                                                                , String "chassis_reverselight_on"
-                                                                )
-                                                            , ObjectKey
-                                                                ( String "materialEmissiveScaling"
-                                                                , Object
-                                                                    ( ObjectValue
-                                                                        { ovElements =
-                                                                            [ ObjectKey
-                                                                                ( String "on_max"
-                                                                                , Number
-                                                                                    ( NumberValue
-                                                                                        { nvText = "1"
-                                                                                        , nvValue = 1.0
-                                                                                        }
-                                                                                    )
-                                                                                )
-                                                                            ]
-                                                                        , ovTrailingComma = False
-                                                                        }
-                                                                    )
-                                                                )
-                                                            ]
-                                                        , ovTrailingComma = False
-                                                        }
-                                                    )
-                                                )
-                                            , ObjectKey
-                                                ( String "chassis_brakelight_L"
-                                                , Object
-                                                    ( ObjectValue
-                                                        { ovElements =
-                                                            [ ObjectKey
-                                                                ( String "simpleFunction"
-                                                                , String "brakelight_filament"
-                                                                )
-                                                            , ObjectKey
-                                                                ( String "off"
-                                                                , String "chassis_taillight"
-                                                                )
-                                                            , ObjectKey
-                                                                ( String "on"
-                                                                , String "chassis_taillight_on"
-                                                                )
-                                                            , ObjectKey
-                                                                ( String "materialEmissiveScaling"
-                                                                , Object
-                                                                    ( ObjectValue
-                                                                        { ovElements =
-                                                                            [ ObjectKey
-                                                                                ( String "on_max"
-                                                                                , Number
-                                                                                    ( NumberValue
-                                                                                        { nvText = "1"
-                                                                                        , nvValue = 1.0
-                                                                                        }
-                                                                                    )
-                                                                                )
-                                                                            ]
-                                                                        , ovTrailingComma = False
-                                                                        }
-                                                                    )
-                                                                )
-                                                            ]
-                                                        , ovTrailingComma = False
-                                                        }
-                                                    )
-                                                )
-                                            , ObjectKey
-                                                ( String "chassis_brakelight_R"
-                                                , Object
-                                                    ( ObjectValue
-                                                        { ovElements =
-                                                            [ ObjectKey
-                                                                ( String "simpleFunction"
-                                                                , String "brakelight_filament"
-                                                                )
-                                                            , ObjectKey
-                                                                ( String "off"
-                                                                , String "chassis_taillight"
-                                                                )
-                                                            , ObjectKey
-                                                                ( String "on"
-                                                                , String "chassis_taillight_on"
-                                                                )
-                                                            , ObjectKey
-                                                                ( String "materialEmissiveScaling"
-                                                                , Object
-                                                                    ( ObjectValue
-                                                                        { ovElements =
-                                                                            [ ObjectKey
-                                                                                ( String "on_max"
-                                                                                , Number
-                                                                                    ( NumberValue
-                                                                                        { nvText = "1"
-                                                                                        , nvValue = 1.0
-                                                                                        }
-                                                                                    )
-                                                                                )
-                                                                            ]
-                                                                        , ovTrailingComma = False
-                                                                        }
-                                                                    )
-                                                                )
-                                                            ]
-                                                        , ovTrailingComma = False
-                                                        }
-                                                    )
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "gauge lights"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "(turn signals, battery, parking brake, highbeam)"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = True
-                                                    }
-                                                )
-                                            , ObjectKey
-                                                ( String "chassis_gaugelight_highbeam"
-                                                , Object
-                                                    ( ObjectValue
-                                                        { ovElements =
-                                                            [ ObjectKey
-                                                                ( String "simpleFunction"
-                                                                , String "highbeam"
-                                                                )
-                                                            , ObjectKey
-                                                                ( String "off"
-                                                                , String "chassis_gauges"
-                                                                )
-                                                            , ObjectKey
-                                                                ( String "on"
-                                                                , String "chassis_gauges_on"
-                                                                )
-                                                            ]
-                                                        , ovTrailingComma = False
-                                                        }
-                                                    )
-                                                )
-                                            , ObjectKey
-                                                ( String "chassis_gaugelight_signal_L"
-                                                , Object
-                                                    ( ObjectValue
-                                                        { ovElements =
-                                                            [ ObjectKey
-                                                                ( String "simpleFunction"
-                                                                , String "signal_L"
-                                                                )
-                                                            , ObjectKey
-                                                                ( String "off"
-                                                                , String "chassis_gauges"
-                                                                )
-                                                            , ObjectKey
-                                                                ( String "on"
-                                                                , String "chassis_gauges_on"
-                                                                )
-                                                            ]
-                                                        , ovTrailingComma = False
-                                                        }
-                                                    )
-                                                )
-                                            , ObjectKey
-                                                ( String "chassis_gaugelight_signal_R"
-                                                , Object
-                                                    ( ObjectValue
-                                                        { ovElements =
-                                                            [ ObjectKey
-                                                                ( String "simpleFunction"
-                                                                , String "signal_R"
-                                                                )
-                                                            , ObjectKey
-                                                                ( String "off"
-                                                                , String "chassis_gauges"
-                                                                )
-                                                            , ObjectKey
-                                                                ( String "on"
-                                                                , String "chassis_gauges_on"
-                                                                )
-                                                            ]
-                                                        , ovTrailingComma = False
-                                                        }
-                                                    )
-                                                )
-                                            , ObjectKey
-                                                ( String "chassis_gaugelight_battery"
-                                                , Object
-                                                    ( ObjectValue
-                                                        { ovElements =
-                                                            [ ObjectKey
-                                                                ( String "simpleFunction"
-                                                                , String "battery"
-                                                                )
-                                                            , ObjectKey
-                                                                ( String "off"
-                                                                , String "chassis_gauges"
-                                                                )
-                                                            , ObjectKey
-                                                                ( String "on"
-                                                                , String "chassis_gauges_on"
-                                                                )
-                                                            ]
-                                                        , ovTrailingComma = False
-                                                        }
-                                                    )
-                                                )
-                                            , ObjectKey
-                                                ( String "chassis_gaugelight_parkbrake"
-                                                , Object
-                                                    ( ObjectValue
-                                                        { ovElements =
-                                                            [ ObjectKey
-                                                                ( String "simpleFunction"
-                                                                , String "parkingbrakelight"
-                                                                )
-                                                            , ObjectKey
-                                                                ( String "off"
-                                                                , String "chassis_gauges"
-                                                                )
-                                                            , ObjectKey
-                                                                ( String "on"
-                                                                , String "chassis_gauges_on"
-                                                                )
-                                                            ]
-                                                        , ovTrailingComma = False
-                                                        }
-                                                    )
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "multi-condition warning light"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = True
-                                                    }
-                                                )
-                                            , ObjectKey
-                                                ( String "chassis_gaugelight_warning"
-                                                , Object
-                                                    ( ObjectValue
-                                                        { ovElements =
-                                                            [ ObjectKey
-                                                                ( String "simpleFunction"
-                                                                , Object
-                                                                    ( ObjectValue
-                                                                        { ovElements =
-                                                                            [ ObjectKey
-                                                                                ( String "checkengine"
-                                                                                , Number
-                                                                                    ( NumberValue
-                                                                                        { nvText = "1"
-                                                                                        , nvValue = 1.0
-                                                                                        }
-                                                                                    )
-                                                                                )
-                                                                            , ObjectKey
-                                                                                ( String "battery"
-                                                                                , Number
-                                                                                    ( NumberValue
-                                                                                        { nvText = "1"
-                                                                                        , nvValue = 1.0
-                                                                                        }
-                                                                                    )
-                                                                                )
-                                                                            , ObjectKey
-                                                                                ( String "lowpressure"
-                                                                                , Number
-                                                                                    ( NumberValue
-                                                                                        { nvText = "1"
-                                                                                        , nvValue = 1.0
-                                                                                        }
-                                                                                    )
-                                                                                )
-                                                                            ]
-                                                                        , ovTrailingComma = False
-                                                                        }
-                                                                    )
-                                                                )
-                                                            , ObjectKey
-                                                                ( String "off"
-                                                                , String "chassis_gauges"
-                                                                )
-                                                            , ObjectKey
-                                                                ( String "on"
-                                                                , String "chassis_gauges_on"
-                                                                )
-                                                            ]
-                                                        , ovTrailingComma = False
-                                                        }
-                                                    )
-                                                )
-                                            ]
-                                        , ovTrailingComma = False
-                                        }
+                                ,
+                                    ( Comment
+                                        ( InternalComment
+                                            { cText = "--Beams--"
+                                            , cMultiline = False
+                                            , cAssociationDirection = NextNode
+                                            , cHadNewlineBefore = False
+                                            }
+                                        )
+                                    , False
                                     )
-                                )
-                            ]
-                        , ovTrailingComma = False
-                        }
+                                ,
+                                    ( ObjectKey
+                                        ( String "beams"
+                                        , Array
+                                            ( ArrayValue
+                                                { avElements =
+                                                    [
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "id1:"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "id2:"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "Structural beams"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = True
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "beamStrength"
+                                                                            , String "FLT_MAX"
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( ObjectKey
+                                                                            ( String "beamSpring"
+                                                                            , String "3800000"
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "beamDamp"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "130"
+                                                                                    , nvValue = 130.0
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( ObjectKey
+                                                                            ( String "deformLimit"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "1.1"
+                                                                                    , nvValue = 1.1
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "Front end"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = True
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "beamDeform"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "20600"
+                                                                                    , nvValue = 20600.0
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( ObjectKey
+                                                                            ( String "deformLimit"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "1.1"
+                                                                                    , nvValue = 1.1
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f3"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f5"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f0"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f3"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f8"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f3"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl15"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f10"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f8"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f6"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f11"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f10"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f10"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f8"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f9"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f7"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl17"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f12"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f6"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f11"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f11"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl16"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f13"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl18"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f13"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f12"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f1"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f4"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f2"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f1"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f2"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f5"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f12"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f9"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f7"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f13"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f0"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f6"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f9"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f4"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f2"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f0"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f4"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f5"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f1"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f7"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "Middle"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = True
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "beamDeform"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "27000"
+                                                                                    , nvValue = 27000.0
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl16"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl15"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl20"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl30"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl16"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl23"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl18"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl17"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl17"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl28"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl26"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl17"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl18"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl27"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl26"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl24"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl25"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl24"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl25"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl27"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl21"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl16"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl22"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl15"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl15"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl20"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl29"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl27"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl28"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl32"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl29"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl18"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl22"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl24"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl31"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl21"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl28"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl29"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl32"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl33"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl30"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl31"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl33"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl29"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl30"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl22"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl25"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl23"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl32"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl26"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl20"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl21"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl31"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl23"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl20"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl22"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl21"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl23"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl33"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl27"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl23"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl22"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl28"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl26"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl27"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl26"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "Rear end"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = True
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "beamDeform"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "22000"
+                                                                                    , nvValue = 22000.0
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r37"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r34"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r39"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r41"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r44"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r46"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl33"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r36"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r46"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r42"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl31"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r34"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r37"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl30"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r49"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r51"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r52"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r50"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r50"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r46"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r49"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r50"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r42"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r34"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r40"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r44"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r40"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r42"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r41"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r45"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r39"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r36"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r36"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r35"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r38"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r35"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r53"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r54"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r52"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r54"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r51"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r52"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r45"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r53"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r54"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r47"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r43"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r36"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r53"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r51"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r34"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r35"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r38"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r37"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r45"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r47"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r41"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r43"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r38"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r39"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r39"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl32"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r47"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r43"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r44"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r49"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r37"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r40"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "Crossing beams"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = True
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "Front end"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = True
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "beamDeform"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "16000"
+                                                                                    , nvValue = 16000.0
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f4"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f2"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f0"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f8"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl16"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f10"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl15"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f11"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f10"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f6"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f11"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f8"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f1"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f5"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f4"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f7"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f1"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f9"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f12"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f7"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f3"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f6"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f0"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f5"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f3"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f2"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f13"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f9"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl17"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f13"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl18"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f12"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "Middle"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = True
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "beamDeform"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "6500"
+                                                                                    , nvValue = 6500.0
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl16"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl20"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl15"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl23"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl18"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl28"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl18"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl26"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl17"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl27"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl27"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl24"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl26"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl25"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl31"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl20"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl15"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl21"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl16"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl22"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl32"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl29"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl30"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl21"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl23"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl24"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl32"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl27"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl17"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl29"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl33"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl28"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl29"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl26"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl30"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl23"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl33"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl26"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl22"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl25"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl20"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl23"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl28"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl27"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl31"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl22"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl21"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl22"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "Rear end"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = True
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "beamDeform"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "16000"
+                                                                                    , nvValue = 16000.0
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r54"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r45"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl32"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r36"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r36"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r41"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r50"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r51"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl31"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r37"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl30"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r34"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r46"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r40"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r53"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r47"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r50"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r44"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r49"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r46"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r37"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r42"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r34"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r40"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r34"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r38"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl33"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r39"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r39"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r35"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r36"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r38"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r53"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r52"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r54"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r51"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r45"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r43"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r47"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r41"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r39"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r43"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r37"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r35"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r49"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r52"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r44"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r42"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "Support beams"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = True
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "Front end"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = True
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "beamDeform"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "19000"
+                                                                                    , nvValue = 19000.0
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f8"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f14"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f9"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f14"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f3"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f10"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f14"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f14"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f13"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f1"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f14"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f0"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f14"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f12"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f14"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f5"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f14"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f14"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f4"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f14"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f6"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f14"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f7"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f14"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f2"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f14"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f11"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "Middle"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = True
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "beamDeform"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "11000"
+                                                                                    , nvValue = 11000.0
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl27"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl19"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl26"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl19"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl24"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl19"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl23"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl19"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl20"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl19"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl19"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl16"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl19"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl15"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl31"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl19"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl33"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl19"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl28"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl19"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl19"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl25"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl21"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl19"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl22"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl19"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl19"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl32"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl29"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl19"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl19"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl18"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl19"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl17"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl19"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl30"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "Rear end"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = True
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "beamDeform"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "19000"
+                                                                                    , nvValue = 19000.0
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r48"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r51"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r48"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r54"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r45"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r48"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r48"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r50"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r48"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r42"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r48"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r47"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r49"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r48"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r35"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r48"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r48"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r43"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r44"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r48"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r53"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r48"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r52"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r48"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r40"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r48"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r48"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r38"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r41"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r48"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r4"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r46"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "Front crush"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = True
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "beamDeform"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "8500"
+                                                                                    , nvValue = 8500.0
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl17"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f9"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl15"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f8"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ]
+                                                }
+                                            )
+                                        )
+                                    , True
+                                    )
+                                ,
+                                    ( Comment
+                                        ( InternalComment
+                                            { cText = "--Collision Triangles--"
+                                            , cMultiline = False
+                                            , cAssociationDirection = NextNode
+                                            , cHadNewlineBefore = False
+                                            }
+                                        )
+                                    , False
+                                    )
+                                ,
+                                    ( ObjectKey
+                                        ( String "triangles"
+                                        , Array
+                                            ( ArrayValue
+                                                { avElements =
+                                                    [
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "id1:"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "id2:"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "id3:"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f5"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f3"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f2"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f0"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f2"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f3"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f5"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f2"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f4"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f1"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f4"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f2"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f4"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f1"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f7"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f4"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f7"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f9"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f7"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f13"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f9"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f12"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f9"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f13"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f12"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f13"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl18"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl18"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl17"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f12"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f3"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f6"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f0"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f3"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f8"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f6"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f10"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f11"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f8"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f6"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f8"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f11"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_f10"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl16"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f11"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl16"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_f10"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl15"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl15"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl20"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl16"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl21"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl16"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl20"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl30"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl21"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl20"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl31"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl21"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl30"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl17"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl18"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl28"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl29"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl28"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl18"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl32"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl28"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl29"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl33"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl32"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl29"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl32"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl33"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r39"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r39"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl33"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r36"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r36"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r41"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r39"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r43"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r41"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r36"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r45"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r41"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r43"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r47"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r45"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r43"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r53"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r45"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r47"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r54"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r53"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r47"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r54"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r51"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r53"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r51"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r54"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r52"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r52"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r50"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r51"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r50"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r49"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r51"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r46"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r44"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r49"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r50"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r46"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r49"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r46"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r42"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r44"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r44"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r42"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r40"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r34"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r37"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r40"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r42"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r34"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r40"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r34"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r35"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r37"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r35"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r38"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r37"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r35"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r39"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r38"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r39"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r35"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r36"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl30"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r37"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl31"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl_r37"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl_r34"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl31"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl16"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl15"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl22"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl16"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl22"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl23"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl23"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl22"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl21"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl21"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl22"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl20"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl27"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl29"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl26"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl29"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl28"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl26"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl18"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl26"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl17"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl27"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl26"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl18"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl24"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl22"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl23"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl27"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl26"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl24"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl24"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl25"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl27"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl24"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl23"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl25"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl30"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl23"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl22"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl30"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl31"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl23"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl26"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl27"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl32"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl33"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl32"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl27"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ]
+                                                }
+                                            )
+                                        )
+                                    , True
+                                    )
+                                ,
+                                    ( ObjectKey
+                                        ( String "flexbodies"
+                                        , Array
+                                            ( ArrayValue
+                                                { avElements =
+                                                    [
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "mesh"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "[group]:"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "nonFlexMaterials"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rails"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Array
+                                                                            ( ArrayValue
+                                                                                { avElements =
+                                                                                    [
+                                                                                        ( String "chassis_rails"
+                                                                                        , False
+                                                                                        )
+                                                                                    ]
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ]
+                                                }
+                                            )
+                                        )
+                                    , True
+                                    )
+                                ,
+                                    ( ObjectKey
+                                        ( String "glowMap"
+                                        , Object
+                                            ( ObjectValue
+                                                { ovElements =
+                                                    [
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "main lights"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = False
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( ObjectKey
+                                                            ( String "chassis_headlight_L"
+                                                            , Object
+                                                                ( ObjectValue
+                                                                    { ovElements =
+                                                                        [
+                                                                            ( ObjectKey
+                                                                                ( String "simpleFunction"
+                                                                                , String "lowhighbeam_filament"
+                                                                                )
+                                                                            , True
+                                                                            )
+                                                                        ,
+                                                                            ( ObjectKey
+                                                                                ( String "off"
+                                                                                , String "chassis_headlight"
+                                                                                )
+                                                                            , True
+                                                                            )
+                                                                        ,
+                                                                            ( ObjectKey
+                                                                                ( String "on"
+                                                                                , String "chassis_headlight_on"
+                                                                                )
+                                                                            , True
+                                                                            )
+                                                                        ,
+                                                                            ( ObjectKey
+                                                                                ( String "materialEmissiveScaling"
+                                                                                , Object
+                                                                                    ( ObjectValue
+                                                                                        { ovElements =
+                                                                                            [
+                                                                                                ( ObjectKey
+                                                                                                    ( String "on_max"
+                                                                                                    , Number
+                                                                                                        ( NumberValue
+                                                                                                            { nvText = "1"
+                                                                                                            , nvValue = 1.0
+                                                                                                            }
+                                                                                                        )
+                                                                                                    )
+                                                                                                , False
+                                                                                                )
+                                                                                            ]
+                                                                                        }
+                                                                                    )
+                                                                                )
+                                                                            , False
+                                                                            )
+                                                                        ]
+                                                                    }
+                                                                )
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( ObjectKey
+                                                            ( String "chassis_headlight_R"
+                                                            , Object
+                                                                ( ObjectValue
+                                                                    { ovElements =
+                                                                        [
+                                                                            ( ObjectKey
+                                                                                ( String "simpleFunction"
+                                                                                , String "lowhighbeam_filament"
+                                                                                )
+                                                                            , True
+                                                                            )
+                                                                        ,
+                                                                            ( ObjectKey
+                                                                                ( String "off"
+                                                                                , String "chassis_headlight"
+                                                                                )
+                                                                            , True
+                                                                            )
+                                                                        ,
+                                                                            ( ObjectKey
+                                                                                ( String "on"
+                                                                                , String "chassis_headlight_on"
+                                                                                )
+                                                                            , True
+                                                                            )
+                                                                        ,
+                                                                            ( ObjectKey
+                                                                                ( String "materialEmissiveScaling"
+                                                                                , Object
+                                                                                    ( ObjectValue
+                                                                                        { ovElements =
+                                                                                            [
+                                                                                                ( ObjectKey
+                                                                                                    ( String "on_max"
+                                                                                                    , Number
+                                                                                                        ( NumberValue
+                                                                                                            { nvText = "1"
+                                                                                                            , nvValue = 1.0
+                                                                                                            }
+                                                                                                        )
+                                                                                                    )
+                                                                                                , False
+                                                                                                )
+                                                                                            ]
+                                                                                        }
+                                                                                    )
+                                                                                )
+                                                                            , False
+                                                                            )
+                                                                        ]
+                                                                    }
+                                                                )
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( ObjectKey
+                                                            ( String "chassis_signal_L"
+                                                            , Object
+                                                                ( ObjectValue
+                                                                    { ovElements =
+                                                                        [
+                                                                            ( ObjectKey
+                                                                                ( String "simpleFunction"
+                                                                                , String "signal_L_filament"
+                                                                                )
+                                                                            , True
+                                                                            )
+                                                                        ,
+                                                                            ( ObjectKey
+                                                                                ( String "off"
+                                                                                , String "chassis_signal_amber"
+                                                                                )
+                                                                            , True
+                                                                            )
+                                                                        ,
+                                                                            ( ObjectKey
+                                                                                ( String "on"
+                                                                                , String "chassis_signal_amber_on"
+                                                                                )
+                                                                            , True
+                                                                            )
+                                                                        ,
+                                                                            ( ObjectKey
+                                                                                ( String "materialEmissiveScaling"
+                                                                                , Object
+                                                                                    ( ObjectValue
+                                                                                        { ovElements =
+                                                                                            [
+                                                                                                ( ObjectKey
+                                                                                                    ( String "on_max"
+                                                                                                    , Number
+                                                                                                        ( NumberValue
+                                                                                                            { nvText = "1"
+                                                                                                            , nvValue = 1.0
+                                                                                                            }
+                                                                                                        )
+                                                                                                    )
+                                                                                                , False
+                                                                                                )
+                                                                                            ]
+                                                                                        }
+                                                                                    )
+                                                                                )
+                                                                            , False
+                                                                            )
+                                                                        ]
+                                                                    }
+                                                                )
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( ObjectKey
+                                                            ( String "chassis_signal_R"
+                                                            , Object
+                                                                ( ObjectValue
+                                                                    { ovElements =
+                                                                        [
+                                                                            ( ObjectKey
+                                                                                ( String "simpleFunction"
+                                                                                , String "signal_R_filament"
+                                                                                )
+                                                                            , True
+                                                                            )
+                                                                        ,
+                                                                            ( ObjectKey
+                                                                                ( String "off"
+                                                                                , String "chassis_signal_amber"
+                                                                                )
+                                                                            , True
+                                                                            )
+                                                                        ,
+                                                                            ( ObjectKey
+                                                                                ( String "on"
+                                                                                , String "chassis_signal_amber_on"
+                                                                                )
+                                                                            , True
+                                                                            )
+                                                                        ,
+                                                                            ( ObjectKey
+                                                                                ( String "materialEmissiveScaling"
+                                                                                , Object
+                                                                                    ( ObjectValue
+                                                                                        { ovElements =
+                                                                                            [
+                                                                                                ( ObjectKey
+                                                                                                    ( String "on_max"
+                                                                                                    , Number
+                                                                                                        ( NumberValue
+                                                                                                            { nvText = "1"
+                                                                                                            , nvValue = 1.0
+                                                                                                            }
+                                                                                                        )
+                                                                                                    )
+                                                                                                , False
+                                                                                                )
+                                                                                            ]
+                                                                                        }
+                                                                                    )
+                                                                                )
+                                                                            , False
+                                                                            )
+                                                                        ]
+                                                                    }
+                                                                )
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( ObjectKey
+                                                            ( String "chassis_reverselight"
+                                                            , Object
+                                                                ( ObjectValue
+                                                                    { ovElements =
+                                                                        [
+                                                                            ( ObjectKey
+                                                                                ( String "simpleFunction"
+                                                                                , String "reverselight_filament"
+                                                                                )
+                                                                            , True
+                                                                            )
+                                                                        ,
+                                                                            ( ObjectKey
+                                                                                ( String "off"
+                                                                                , String "chassis_reverselight"
+                                                                                )
+                                                                            , True
+                                                                            )
+                                                                        ,
+                                                                            ( ObjectKey
+                                                                                ( String "on"
+                                                                                , String "chassis_reverselight_on"
+                                                                                )
+                                                                            , True
+                                                                            )
+                                                                        ,
+                                                                            ( ObjectKey
+                                                                                ( String "materialEmissiveScaling"
+                                                                                , Object
+                                                                                    ( ObjectValue
+                                                                                        { ovElements =
+                                                                                            [
+                                                                                                ( ObjectKey
+                                                                                                    ( String "on_max"
+                                                                                                    , Number
+                                                                                                        ( NumberValue
+                                                                                                            { nvText = "1"
+                                                                                                            , nvValue = 1.0
+                                                                                                            }
+                                                                                                        )
+                                                                                                    )
+                                                                                                , False
+                                                                                                )
+                                                                                            ]
+                                                                                        }
+                                                                                    )
+                                                                                )
+                                                                            , False
+                                                                            )
+                                                                        ]
+                                                                    }
+                                                                )
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( ObjectKey
+                                                            ( String "chassis_brakelight_L"
+                                                            , Object
+                                                                ( ObjectValue
+                                                                    { ovElements =
+                                                                        [
+                                                                            ( ObjectKey
+                                                                                ( String "simpleFunction"
+                                                                                , String "brakelight_filament"
+                                                                                )
+                                                                            , True
+                                                                            )
+                                                                        ,
+                                                                            ( ObjectKey
+                                                                                ( String "off"
+                                                                                , String "chassis_taillight"
+                                                                                )
+                                                                            , True
+                                                                            )
+                                                                        ,
+                                                                            ( ObjectKey
+                                                                                ( String "on"
+                                                                                , String "chassis_taillight_on"
+                                                                                )
+                                                                            , True
+                                                                            )
+                                                                        ,
+                                                                            ( ObjectKey
+                                                                                ( String "materialEmissiveScaling"
+                                                                                , Object
+                                                                                    ( ObjectValue
+                                                                                        { ovElements =
+                                                                                            [
+                                                                                                ( ObjectKey
+                                                                                                    ( String "on_max"
+                                                                                                    , Number
+                                                                                                        ( NumberValue
+                                                                                                            { nvText = "1"
+                                                                                                            , nvValue = 1.0
+                                                                                                            }
+                                                                                                        )
+                                                                                                    )
+                                                                                                , False
+                                                                                                )
+                                                                                            ]
+                                                                                        }
+                                                                                    )
+                                                                                )
+                                                                            , False
+                                                                            )
+                                                                        ]
+                                                                    }
+                                                                )
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( ObjectKey
+                                                            ( String "chassis_brakelight_R"
+                                                            , Object
+                                                                ( ObjectValue
+                                                                    { ovElements =
+                                                                        [
+                                                                            ( ObjectKey
+                                                                                ( String "simpleFunction"
+                                                                                , String "brakelight_filament"
+                                                                                )
+                                                                            , True
+                                                                            )
+                                                                        ,
+                                                                            ( ObjectKey
+                                                                                ( String "off"
+                                                                                , String "chassis_taillight"
+                                                                                )
+                                                                            , True
+                                                                            )
+                                                                        ,
+                                                                            ( ObjectKey
+                                                                                ( String "on"
+                                                                                , String "chassis_taillight_on"
+                                                                                )
+                                                                            , True
+                                                                            )
+                                                                        ,
+                                                                            ( ObjectKey
+                                                                                ( String "materialEmissiveScaling"
+                                                                                , Object
+                                                                                    ( ObjectValue
+                                                                                        { ovElements =
+                                                                                            [
+                                                                                                ( ObjectKey
+                                                                                                    ( String "on_max"
+                                                                                                    , Number
+                                                                                                        ( NumberValue
+                                                                                                            { nvText = "1"
+                                                                                                            , nvValue = 1.0
+                                                                                                            }
+                                                                                                        )
+                                                                                                    )
+                                                                                                , False
+                                                                                                )
+                                                                                            ]
+                                                                                        }
+                                                                                    )
+                                                                                )
+                                                                            , False
+                                                                            )
+                                                                        ]
+                                                                    }
+                                                                )
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "gauge lights"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = False
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "(turn signals, battery, parking brake, highbeam)"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = True
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( ObjectKey
+                                                            ( String "chassis_gaugelight_highbeam"
+                                                            , Object
+                                                                ( ObjectValue
+                                                                    { ovElements =
+                                                                        [
+                                                                            ( ObjectKey
+                                                                                ( String "simpleFunction"
+                                                                                , String "highbeam"
+                                                                                )
+                                                                            , True
+                                                                            )
+                                                                        ,
+                                                                            ( ObjectKey
+                                                                                ( String "off"
+                                                                                , String "chassis_gauges"
+                                                                                )
+                                                                            , True
+                                                                            )
+                                                                        ,
+                                                                            ( ObjectKey
+                                                                                ( String "on"
+                                                                                , String "chassis_gauges_on"
+                                                                                )
+                                                                            , False
+                                                                            )
+                                                                        ]
+                                                                    }
+                                                                )
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( ObjectKey
+                                                            ( String "chassis_gaugelight_signal_L"
+                                                            , Object
+                                                                ( ObjectValue
+                                                                    { ovElements =
+                                                                        [
+                                                                            ( ObjectKey
+                                                                                ( String "simpleFunction"
+                                                                                , String "signal_L"
+                                                                                )
+                                                                            , True
+                                                                            )
+                                                                        ,
+                                                                            ( ObjectKey
+                                                                                ( String "off"
+                                                                                , String "chassis_gauges"
+                                                                                )
+                                                                            , True
+                                                                            )
+                                                                        ,
+                                                                            ( ObjectKey
+                                                                                ( String "on"
+                                                                                , String "chassis_gauges_on"
+                                                                                )
+                                                                            , False
+                                                                            )
+                                                                        ]
+                                                                    }
+                                                                )
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( ObjectKey
+                                                            ( String "chassis_gaugelight_signal_R"
+                                                            , Object
+                                                                ( ObjectValue
+                                                                    { ovElements =
+                                                                        [
+                                                                            ( ObjectKey
+                                                                                ( String "simpleFunction"
+                                                                                , String "signal_R"
+                                                                                )
+                                                                            , True
+                                                                            )
+                                                                        ,
+                                                                            ( ObjectKey
+                                                                                ( String "off"
+                                                                                , String "chassis_gauges"
+                                                                                )
+                                                                            , True
+                                                                            )
+                                                                        ,
+                                                                            ( ObjectKey
+                                                                                ( String "on"
+                                                                                , String "chassis_gauges_on"
+                                                                                )
+                                                                            , False
+                                                                            )
+                                                                        ]
+                                                                    }
+                                                                )
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( ObjectKey
+                                                            ( String "chassis_gaugelight_battery"
+                                                            , Object
+                                                                ( ObjectValue
+                                                                    { ovElements =
+                                                                        [
+                                                                            ( ObjectKey
+                                                                                ( String "simpleFunction"
+                                                                                , String "battery"
+                                                                                )
+                                                                            , True
+                                                                            )
+                                                                        ,
+                                                                            ( ObjectKey
+                                                                                ( String "off"
+                                                                                , String "chassis_gauges"
+                                                                                )
+                                                                            , True
+                                                                            )
+                                                                        ,
+                                                                            ( ObjectKey
+                                                                                ( String "on"
+                                                                                , String "chassis_gauges_on"
+                                                                                )
+                                                                            , False
+                                                                            )
+                                                                        ]
+                                                                    }
+                                                                )
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( ObjectKey
+                                                            ( String "chassis_gaugelight_parkbrake"
+                                                            , Object
+                                                                ( ObjectValue
+                                                                    { ovElements =
+                                                                        [
+                                                                            ( ObjectKey
+                                                                                ( String "simpleFunction"
+                                                                                , String "parkingbrakelight"
+                                                                                )
+                                                                            , True
+                                                                            )
+                                                                        ,
+                                                                            ( ObjectKey
+                                                                                ( String "off"
+                                                                                , String "chassis_gauges"
+                                                                                )
+                                                                            , True
+                                                                            )
+                                                                        ,
+                                                                            ( ObjectKey
+                                                                                ( String "on"
+                                                                                , String "chassis_gauges_on"
+                                                                                )
+                                                                            , False
+                                                                            )
+                                                                        ]
+                                                                    }
+                                                                )
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "multi-condition warning light"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = True
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( ObjectKey
+                                                            ( String "chassis_gaugelight_warning"
+                                                            , Object
+                                                                ( ObjectValue
+                                                                    { ovElements =
+                                                                        [
+                                                                            ( ObjectKey
+                                                                                ( String "simpleFunction"
+                                                                                , Object
+                                                                                    ( ObjectValue
+                                                                                        { ovElements =
+                                                                                            [
+                                                                                                ( ObjectKey
+                                                                                                    ( String "checkengine"
+                                                                                                    , Number
+                                                                                                        ( NumberValue
+                                                                                                            { nvText = "1"
+                                                                                                            , nvValue = 1.0
+                                                                                                            }
+                                                                                                        )
+                                                                                                    )
+                                                                                                , True
+                                                                                                )
+                                                                                            ,
+                                                                                                ( ObjectKey
+                                                                                                    ( String "battery"
+                                                                                                    , Number
+                                                                                                        ( NumberValue
+                                                                                                            { nvText = "1"
+                                                                                                            , nvValue = 1.0
+                                                                                                            }
+                                                                                                        )
+                                                                                                    )
+                                                                                                , True
+                                                                                                )
+                                                                                            ,
+                                                                                                ( ObjectKey
+                                                                                                    ( String "lowpressure"
+                                                                                                    , Number
+                                                                                                        ( NumberValue
+                                                                                                            { nvText = "1"
+                                                                                                            , nvValue = 1.0
+                                                                                                            }
+                                                                                                        )
+                                                                                                    )
+                                                                                                , False
+                                                                                                )
+                                                                                            ]
+                                                                                        }
+                                                                                    )
+                                                                                )
+                                                                            , True
+                                                                            )
+                                                                        ,
+                                                                            ( ObjectKey
+                                                                                ( String "off"
+                                                                                , String "chassis_gauges"
+                                                                                )
+                                                                            , True
+                                                                            )
+                                                                        ,
+                                                                            ( ObjectKey
+                                                                                ( String "on"
+                                                                                , String "chassis_gauges_on"
+                                                                                )
+                                                                            , False
+                                                                            )
+                                                                        ]
+                                                                    }
+                                                                )
+                                                            )
+                                                        , False
+                                                        )
+                                                    ]
+                                                }
+                                            )
+                                        )
+                                    , False
+                                    )
+                                ]
+                            }
+                        )
                     )
+                , False
                 )
             ]
-        , ovTrailingComma = False
         }
     )

--- a/examples/ast/jbeam/suspension.hs
+++ b/examples/ast/jbeam/suspension.hs
@@ -1,4520 +1,7874 @@
 Object
     ( ObjectValue
         { ovElements =
-            [ ObjectKey
-                ( String "chassis_rails"
-                , Object
-                    ( ObjectValue
-                        { ovElements =
-                            [ ObjectKey
-                                ( String "information"
-                                , Object
-                                    ( ObjectValue
-                                        { ovElements =
-                                            [ ObjectKey
-                                                ( String "authors"
-                                                , String "gittarrgy01"
-                                                )
-                                            , ObjectKey
-                                                ( String "name"
-                                                , String ""
-                                                )
-                                            ]
-                                        , ovTrailingComma = True
-                                        }
-                                    )
-                                )
-                            , ObjectKey
-                                ( String "slotType"
-                                , String "main"
-                                )
-                            , Comment
-                                ( InternalComment
-                                    { cText = "The purpose of this file is prove that moving metadata along with vertices when\nmoving vertices works as intended.\nSee issue for #69 explanation on the transformation part of the codebase."
-                                    , cMultiline = True
-                                    , cAssociationDirection = NextNode
-                                    , cHadNewlineBefore = False
-                                    }
-                                )
-                            , Comment
-                                ( InternalComment
-                                    { cText = "--Nodes--"
-                                    , cMultiline = False
-                                    , cAssociationDirection = NextNode
-                                    , cHadNewlineBefore = False
-                                    }
-                                )
-                            , ObjectKey
-                                ( String "nodes"
-                                , Array
-                                    ( ArrayValue
-                                        { avElements =
-                                            [ Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "id"
-                                                        , String "posX"
-                                                        , String "posY"
-                                                        , String "posZ"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "group"
-                                                            , String "chassis_rails"
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "selfCollision"
-                                                            , Bool False
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "nodeWeight"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "3.8"
-                                                                    , nvValue = 3.8
-                                                                    }
-                                                                )
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl0"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.523"
-                                                                , nvValue = 0.523
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-2.098"
-                                                                , nvValue = -2.098
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.319"
-                                                                , nvValue = 0.319
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl1"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.417"
-                                                                , nvValue = -0.417
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-2.098"
-                                                                , nvValue = -2.098
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.319"
-                                                                , nvValue = 0.319
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl2"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.053"
-                                                                , nvValue = 5.3e-2
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-2.095"
-                                                                , nvValue = -2.095
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.319"
-                                                                , nvValue = 0.319
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl3"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.523"
-                                                                , nvValue = 0.523
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-2.093"
-                                                                , nvValue = -2.093
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.268"
-                                                                , nvValue = 0.268
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl4"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.417"
-                                                                , nvValue = -0.417
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-2.093"
-                                                                , nvValue = -2.093
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.268"
-                                                                , nvValue = 0.268
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl5"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.053"
-                                                                , nvValue = 5.3e-2
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-2.09"
-                                                                , nvValue = -2.09
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.269"
-                                                                , nvValue = 0.269
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "ref node front"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = PreviousNode
-                                                    , cHadNewlineBefore = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl6"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.531"
-                                                                , nvValue = 0.531
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-1.724"
-                                                                , nvValue = -1.724
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.341"
-                                                                , nvValue = 0.341
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl7"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.424"
-                                                                , nvValue = -0.424
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-1.724"
-                                                                , nvValue = -1.724
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.341"
-                                                                , nvValue = 0.341
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl8"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.531"
-                                                                , nvValue = 0.531
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-1.721"
-                                                                , nvValue = -1.721
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.289"
-                                                                , nvValue = 0.289
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl9"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.424"
-                                                                , nvValue = -0.424
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-1.721"
-                                                                , nvValue = -1.721
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.289"
-                                                                , nvValue = 0.289
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl10"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.547"
-                                                                , nvValue = 0.547
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-1.35"
-                                                                , nvValue = -1.35
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.31"
-                                                                , nvValue = 0.31
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl11"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.547"
-                                                                , nvValue = 0.547
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-1.35"
-                                                                , nvValue = -1.35
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.364"
-                                                                , nvValue = 0.364
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl12"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.44"
-                                                                , nvValue = -0.44
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-1.35"
-                                                                , nvValue = -1.35
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.31"
-                                                                , nvValue = 0.31
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl13"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.44"
-                                                                , nvValue = -0.44
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-1.35"
-                                                                , nvValue = -1.35
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.364"
-                                                                , nvValue = 0.364
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl14"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.053"
-                                                                , nvValue = 5.3e-2
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-1.314"
-                                                                , nvValue = -1.314
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.382"
-                                                                , nvValue = 0.382
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "support"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = PreviousNode
-                                                    , cHadNewlineBefore = False
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "selfCollision"
-                                                            , Bool True
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "nodeWeight"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "3.5"
-                                                                    , nvValue = 3.5
-                                                                    }
-                                                                )
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl15"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.79"
-                                                                , nvValue = 0.79
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.919"
-                                                                , nvValue = -0.919
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.182"
-                                                                , nvValue = 0.182
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl16"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.79"
-                                                                , nvValue = 0.79
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.919"
-                                                                , nvValue = -0.919
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.233"
-                                                                , nvValue = 0.233
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl17"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.683"
-                                                                , nvValue = -0.683
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.919"
-                                                                , nvValue = -0.919
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.182"
-                                                                , nvValue = 0.182
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl18"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.683"
-                                                                , nvValue = -0.683
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.919"
-                                                                , nvValue = -0.919
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.233"
-                                                                , nvValue = 0.233
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl19"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.053"
-                                                                , nvValue = 5.3e-2
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.024"
-                                                                , nvValue = -2.4e-2
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.578"
-                                                                , nvValue = 0.578
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "support"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = PreviousNode
-                                                    , cHadNewlineBefore = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl20"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.837"
-                                                                , nvValue = 0.837
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.002"
-                                                                , nvValue = 2.0e-3
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.182"
-                                                                , nvValue = 0.182
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "ref node left"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = PreviousNode
-                                                    , cHadNewlineBefore = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl21"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.837"
-                                                                , nvValue = 0.837
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.002"
-                                                                , nvValue = 2.0e-3
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.233"
-                                                                , nvValue = 0.233
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl22"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.415"
-                                                                , nvValue = 0.415
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.002"
-                                                                , nvValue = 2.0e-3
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.182"
-                                                                , nvValue = 0.182
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl23"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.415"
-                                                                , nvValue = 0.415
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.002"
-                                                                , nvValue = 2.0e-3
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.233"
-                                                                , nvValue = 0.233
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl24"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.053"
-                                                                , nvValue = 5.3e-2
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.002"
-                                                                , nvValue = 2.0e-3
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.182"
-                                                                , nvValue = 0.182
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl25"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.053"
-                                                                , nvValue = 5.3e-2
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.002"
-                                                                , nvValue = 2.0e-3
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.233"
-                                                                , nvValue = 0.233
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl26"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.308"
-                                                                , nvValue = -0.308
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.002"
-                                                                , nvValue = 2.0e-3
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.182"
-                                                                , nvValue = 0.182
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl27"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.308"
-                                                                , nvValue = -0.308
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.002"
-                                                                , nvValue = 2.0e-3
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.233"
-                                                                , nvValue = 0.233
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl28"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.73"
-                                                                , nvValue = -0.73
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.002"
-                                                                , nvValue = 2.0e-3
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.182"
-                                                                , nvValue = 0.182
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "ref node right"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = PreviousNode
-                                                    , cHadNewlineBefore = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl29"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.73"
-                                                                , nvValue = -0.73
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.002"
-                                                                , nvValue = 2.0e-3
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.233"
-                                                                , nvValue = 0.233
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl30"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.822"
-                                                                , nvValue = 0.822
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.791"
-                                                                , nvValue = 0.791
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.182"
-                                                                , nvValue = 0.182
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl31"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.822"
-                                                                , nvValue = 0.822
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.791"
-                                                                , nvValue = 0.791
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.233"
-                                                                , nvValue = 0.233
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl32"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.715"
-                                                                , nvValue = -0.715
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.791"
-                                                                , nvValue = 0.791
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.182"
-                                                                , nvValue = 0.182
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl33"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.715"
-                                                                , nvValue = -0.715
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.791"
-                                                                , nvValue = 0.791
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.233"
-                                                                , nvValue = 0.233
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "selfCollision"
-                                                            , Bool False
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl34"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.651"
-                                                                , nvValue = 0.651
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "1.121"
-                                                                , nvValue = 1.121
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.628"
-                                                                , nvValue = 0.628
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl35"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.053"
-                                                                , nvValue = 5.3e-2
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "1.121"
-                                                                , nvValue = 1.121
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.628"
-                                                                , nvValue = 0.628
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl36"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.544"
-                                                                , nvValue = -0.544
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "1.121"
-                                                                , nvValue = 1.121
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.628"
-                                                                , nvValue = 0.628
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl37"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.651"
-                                                                , nvValue = 0.651
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "1.152"
-                                                                , nvValue = 1.152
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.565"
-                                                                , nvValue = 0.565
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl38"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.053"
-                                                                , nvValue = 5.3e-2
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "1.152"
-                                                                , nvValue = 1.152
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.565"
-                                                                , nvValue = 0.565
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl39"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.544"
-                                                                , nvValue = -0.544
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "1.152"
-                                                                , nvValue = 1.152
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.565"
-                                                                , nvValue = 0.565
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl40"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.602"
-                                                                , nvValue = 0.602
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "1.514"
-                                                                , nvValue = 1.514
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.566"
-                                                                , nvValue = 0.566
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl41"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.495"
-                                                                , nvValue = -0.495
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "1.514"
-                                                                , nvValue = 1.514
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.566"
-                                                                , nvValue = 0.566
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl42"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.602"
-                                                                , nvValue = 0.602
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "1.532"
-                                                                , nvValue = 1.532
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.623"
-                                                                , nvValue = 0.623
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl43"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.495"
-                                                                , nvValue = -0.495
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "1.532"
-                                                                , nvValue = 1.532
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.623"
-                                                                , nvValue = 0.623
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl44"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.553"
-                                                                , nvValue = 0.553
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "1.654"
-                                                                , nvValue = 1.654
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.359"
-                                                                , nvValue = 0.359
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl45"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.446"
-                                                                , nvValue = -0.446
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "1.654"
-                                                                , nvValue = 1.654
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.359"
-                                                                , nvValue = 0.359
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl46"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.553"
-                                                                , nvValue = 0.553
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "1.679"
-                                                                , nvValue = 1.679
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.448"
-                                                                , nvValue = 0.448
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl47"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.446"
-                                                                , nvValue = -0.446
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "1.679"
-                                                                , nvValue = 1.679
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.448"
-                                                                , nvValue = 0.448
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl48"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.053"
-                                                                , nvValue = 5.3e-2
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "1.71"
-                                                                , nvValue = 1.71
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.565"
-                                                                , nvValue = 0.565
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "support"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = PreviousNode
-                                                    , cHadNewlineBefore = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl49"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.558"
-                                                                , nvValue = 0.558
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "2.284"
-                                                                , nvValue = 2.284
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.364"
-                                                                , nvValue = 0.364
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl50"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.558"
-                                                                , nvValue = 0.558
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "2.284"
-                                                                , nvValue = 2.284
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.447"
-                                                                , nvValue = 0.447
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl51"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.053"
-                                                                , nvValue = 5.3e-2
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "2.284"
-                                                                , nvValue = 2.284
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.37"
-                                                                , nvValue = 0.37
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl52"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.053"
-                                                                , nvValue = 5.3e-2
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "2.284"
-                                                                , nvValue = 2.284
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.441"
-                                                                , nvValue = 0.441
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl53"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.451"
-                                                                , nvValue = -0.451
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "2.284"
-                                                                , nvValue = 2.284
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.364"
-                                                                , nvValue = 0.364
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl54"
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "-0.451"
-                                                                , nvValue = -0.451
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "2.284"
-                                                                , nvValue = 2.284
-                                                                }
-                                                            )
-                                                        , Number
-                                                            ( NumberValue
-                                                                { nvText = "0.447"
-                                                                , nvValue = 0.447
-                                                                }
-                                                            )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "group"
+            [
+                ( ObjectKey
+                    ( String "chassis_rails"
+                    , Object
+                        ( ObjectValue
+                            { ovElements =
+                                [
+                                    ( ObjectKey
+                                        ( String "information"
+                                        , Object
+                                            ( ObjectValue
+                                                { ovElements =
+                                                    [
+                                                        ( ObjectKey
+                                                            ( String "authors"
+                                                            , String "gittarrgy01"
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( ObjectKey
+                                                            ( String "name"
                                                             , String ""
                                                             )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            ]
-                                        , avTrailingComma = True
-                                        }
+                                                        , True
+                                                        )
+                                                    ]
+                                                }
+                                            )
+                                        )
+                                    , True
                                     )
-                                )
-                            , Comment
-                                ( InternalComment
-                                    { cText = "--Beams--"
-                                    , cMultiline = False
-                                    , cAssociationDirection = NextNode
-                                    , cHadNewlineBefore = False
-                                    }
-                                )
-                            , ObjectKey
-                                ( String "beams"
-                                , Array
-                                    ( ArrayValue
-                                        { avElements =
-                                            [ Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "id1:"
-                                                        , String "id2:"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "Structural beams"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = True
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "beamStrength"
-                                                            , String "FLT_MAX"
-                                                            )
-                                                        , ObjectKey
-                                                            ( String "beamSpring"
-                                                            , String "3800000"
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "beamDamp"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "130"
-                                                                    , nvValue = 130.0
-                                                                    }
-                                                                )
-                                                            )
-                                                        , ObjectKey
-                                                            ( String "deformLimit"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "1.1"
-                                                                    , nvValue = 1.1
-                                                                    }
-                                                                )
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "Front end"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = True
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "beamDeform"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "20600"
-                                                                    , nvValue = 20600.0
-                                                                    }
-                                                                )
-                                                            )
-                                                        , ObjectKey
-                                                            ( String "deformLimit"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "1.1"
-                                                                    , nvValue = 1.1
-                                                                    }
-                                                                )
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl3"
-                                                        , String "rl5"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl0"
-                                                        , String "rl3"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl8"
-                                                        , String "rl3"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl15"
-                                                        , String "rl10"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl8"
-                                                        , String "rl6"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl11"
-                                                        , String "rl10"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl10"
-                                                        , String "rl8"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl9"
-                                                        , String "rl7"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl17"
-                                                        , String "rl12"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl6"
-                                                        , String "rl11"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl11"
-                                                        , String "rl16"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl13"
-                                                        , String "rl18"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl13"
-                                                        , String "rl12"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl1"
-                                                        , String "rl4"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl2"
-                                                        , String "rl1"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl2"
-                                                        , String "rl5"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl12"
-                                                        , String "rl9"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl7"
-                                                        , String "rl13"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl0"
-                                                        , String "rl6"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl9"
-                                                        , String "rl4"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl2"
-                                                        , String "rl0"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl4"
-                                                        , String "rl5"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl1"
-                                                        , String "rl7"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "Middle"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = True
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "beamDeform"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "27000"
-                                                                    , nvValue = 27000.0
-                                                                    }
-                                                                )
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl16"
-                                                        , String "rl15"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl20"
-                                                        , String "rl30"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl16"
-                                                        , String "rl23"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl18"
-                                                        , String "rl17"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl17"
-                                                        , String "rl28"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl26"
-                                                        , String "rl17"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl18"
-                                                        , String "rl27"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl26"
-                                                        , String "rl24"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl25"
-                                                        , String "rl24"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl25"
-                                                        , String "rl27"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl21"
-                                                        , String "rl16"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl22"
-                                                        , String "rl15"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl15"
-                                                        , String "rl20"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl29"
-                                                        , String "rl27"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl28"
-                                                        , String "rl32"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl29"
-                                                        , String "rl18"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl22"
-                                                        , String "rl24"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl31"
-                                                        , String "rl21"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl28"
-                                                        , String "rl29"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl32"
-                                                        , String "rl33"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl30"
-                                                        , String "rl31"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl33"
-                                                        , String "rl29"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl30"
-                                                        , String "rl22"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl25"
-                                                        , String "rl23"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl32"
-                                                        , String "rl26"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl20"
-                                                        , String "rl21"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl31"
-                                                        , String "rl23"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl20"
-                                                        , String "rl22"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl21"
-                                                        , String "rl23"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl33"
-                                                        , String "rl27"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl23"
-                                                        , String "rl22"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl28"
-                                                        , String "rl26"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl27"
-                                                        , String "rl26"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "Rear end"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = True
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "beamDeform"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "22000"
-                                                                    , nvValue = 22000.0
-                                                                    }
-                                                                )
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl37"
-                                                        , String "rl34"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl39"
-                                                        , String "rl41"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl44"
-                                                        , String "rl46"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl33"
-                                                        , String "rl36"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl46"
-                                                        , String "rl42"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl31"
-                                                        , String "rl34"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl37"
-                                                        , String "rl30"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl49"
-                                                        , String "rl51"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl52"
-                                                        , String "rl50"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl50"
-                                                        , String "rl46"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl49"
-                                                        , String "rl50"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl42"
-                                                        , String "rl34"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl40"
-                                                        , String "rl44"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl40"
-                                                        , String "rl42"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl41"
-                                                        , String "rl45"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl39"
-                                                        , String "rl36"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl36"
-                                                        , String "rl35"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl38"
-                                                        , String "rl35"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl53"
-                                                        , String "rl54"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl52"
-                                                        , String "rl54"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl51"
-                                                        , String "rl52"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl45"
-                                                        , String "rl53"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl54"
-                                                        , String "rl47"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl43"
-                                                        , String "rl36"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl53"
-                                                        , String "rl51"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl34"
-                                                        , String "rl35"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl38"
-                                                        , String "rl37"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl45"
-                                                        , String "rl47"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl41"
-                                                        , String "rl43"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl38"
-                                                        , String "rl39"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl39"
-                                                        , String "rl32"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl47"
-                                                        , String "rl43"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl44"
-                                                        , String "rl49"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl37"
-                                                        , String "rl40"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "Crossing beams"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = True
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "Front end"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = True
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "beamDeform"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "16000"
-                                                                    , nvValue = 16000.0
-                                                                    }
-                                                                )
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl4"
-                                                        , String "rl2"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl0"
-                                                        , String "rl8"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl16"
-                                                        , String "rl10"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl15"
-                                                        , String "rl11"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl10"
-                                                        , String "rl6"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl11"
-                                                        , String "rl8"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl1"
-                                                        , String "rl5"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl4"
-                                                        , String "rl7"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl1"
-                                                        , String "rl9"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl12"
-                                                        , String "rl7"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl3"
-                                                        , String "rl6"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl0"
-                                                        , String "rl5"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl3"
-                                                        , String "rl2"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl13"
-                                                        , String "rl9"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl17"
-                                                        , String "rl13"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl18"
-                                                        , String "rl12"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "Middle"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = True
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "beamDeform"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "6500"
-                                                                    , nvValue = 6500.0
-                                                                    }
-                                                                )
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl16"
-                                                        , String "rl20"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl15"
-                                                        , String "rl23"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl18"
-                                                        , String "rl28"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl18"
-                                                        , String "rl26"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl17"
-                                                        , String "rl27"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl27"
-                                                        , String "rl24"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl26"
-                                                        , String "rl25"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl31"
-                                                        , String "rl20"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl15"
-                                                        , String "rl21"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl16"
-                                                        , String "rl22"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl32"
-                                                        , String "rl29"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl30"
-                                                        , String "rl21"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl23"
-                                                        , String "rl24"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl32"
-                                                        , String "rl27"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl17"
-                                                        , String "rl29"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl33"
-                                                        , String "rl28"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl29"
-                                                        , String "rl26"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl30"
-                                                        , String "rl23"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl33"
-                                                        , String "rl26"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl22"
-                                                        , String "rl25"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl20"
-                                                        , String "rl23"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl28"
-                                                        , String "rl27"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl31"
-                                                        , String "rl22"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl21"
-                                                        , String "rl22"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "Rear end"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = True
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "beamDeform"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "16000"
-                                                                    , nvValue = 16000.0
-                                                                    }
-                                                                )
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl54"
-                                                        , String "rl45"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl32"
-                                                        , String "rl36"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl36"
-                                                        , String "rl41"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl50"
-                                                        , String "rl51"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl31"
-                                                        , String "rl37"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl30"
-                                                        , String "rl34"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl46"
-                                                        , String "rl40"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl53"
-                                                        , String "rl47"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl50"
-                                                        , String "rl44"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl49"
-                                                        , String "rl46"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl37"
-                                                        , String "rl42"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl34"
-                                                        , String "rl40"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl34"
-                                                        , String "rl38"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl33"
-                                                        , String "rl39"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl39"
-                                                        , String "rl35"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl36"
-                                                        , String "rl38"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl53"
-                                                        , String "rl52"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl54"
-                                                        , String "rl51"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl45"
-                                                        , String "rl43"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl47"
-                                                        , String "rl41"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl39"
-                                                        , String "rl43"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl37"
-                                                        , String "rl35"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl49"
-                                                        , String "rl52"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl44"
-                                                        , String "rl42"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "Support beams"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = True
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "Front end"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = True
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "beamDeform"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "19000"
-                                                                    , nvValue = 19000.0
-                                                                    }
-                                                                )
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl8"
-                                                        , String "rl14"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl9"
-                                                        , String "rl14"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl14"
-                                                        , String "rl3"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl10"
-                                                        , String "rl14"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl14"
-                                                        , String "rl13"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl1"
-                                                        , String "rl14"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl0"
-                                                        , String "rl14"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl12"
-                                                        , String "rl14"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl5"
-                                                        , String "rl14"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl14"
-                                                        , String "rl4"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl14"
-                                                        , String "rl6"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl14"
-                                                        , String "rl7"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl14"
-                                                        , String "rl2"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl14"
-                                                        , String "rl11"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "Middle"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = True
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "beamDeform"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "11000"
-                                                                    , nvValue = 11000.0
-                                                                    }
-                                                                )
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl27"
-                                                        , String "rl19"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl26"
-                                                        , String "rl19"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl24"
-                                                        , String "rl19"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl23"
-                                                        , String "rl19"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl20"
-                                                        , String "rl19"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl19"
-                                                        , String "rl16"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl19"
-                                                        , String "rl15"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl31"
-                                                        , String "rl19"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl33"
-                                                        , String "rl19"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl28"
-                                                        , String "rl19"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl19"
-                                                        , String "rl25"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl21"
-                                                        , String "rl19"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl22"
-                                                        , String "rl19"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl19"
-                                                        , String "rl32"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl29"
-                                                        , String "rl19"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl19"
-                                                        , String "rl18"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl19"
-                                                        , String "rl17"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl19"
-                                                        , String "rl30"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "Rear end"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = True
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "beamDeform"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "19000"
-                                                                    , nvValue = 19000.0
-                                                                    }
-                                                                )
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl48"
-                                                        , String "rl51"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl48"
-                                                        , String "rl54"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl45"
-                                                        , String "rl48"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl48"
-                                                        , String "rl50"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl48"
-                                                        , String "rl42"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl48"
-                                                        , String "rl47"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl49"
-                                                        , String "rl48"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl35"
-                                                        , String "rl48"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl48"
-                                                        , String "rl43"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl44"
-                                                        , String "rl48"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl53"
-                                                        , String "rl48"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl52"
-                                                        , String "rl48"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl40"
-                                                        , String "rl48"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl48"
-                                                        , String "rl38"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl41"
-                                                        , String "rl48"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl48"
-                                                        , String "rl46"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Comment
-                                                ( InternalComment
-                                                    { cText = "Front crush"
-                                                    , cMultiline = False
-                                                    , cAssociationDirection = NextNode
-                                                    , cHadNewlineBefore = True
-                                                    }
-                                                )
-                                            , Object
-                                                ( ObjectValue
-                                                    { ovElements =
-                                                        [ ObjectKey
-                                                            ( String "beamDeform"
-                                                            , Number
-                                                                ( NumberValue
-                                                                    { nvText = "8500"
-                                                                    , nvValue = 8500.0
-                                                                    }
-                                                                )
-                                                            )
-                                                        ]
-                                                    , ovTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl17"
-                                                        , String "rl9"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl15"
-                                                        , String "rl8"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            ]
-                                        , avTrailingComma = True
-                                        }
+                                ,
+                                    ( ObjectKey
+                                        ( String "slotType"
+                                        , String "main"
+                                        )
+                                    , True
                                     )
-                                )
-                            , Comment
-                                ( InternalComment
-                                    { cText = "--Collision Triangles--"
-                                    , cMultiline = False
-                                    , cAssociationDirection = NextNode
-                                    , cHadNewlineBefore = False
-                                    }
-                                )
-                            , ObjectKey
-                                ( String "triangles"
-                                , Array
-                                    ( ArrayValue
-                                        { avElements =
-                                            [ Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "id1:"
-                                                        , String "id2:"
-                                                        , String "id3:"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl5"
-                                                        , String "rl3"
-                                                        , String "rl2"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl0"
-                                                        , String "rl2"
-                                                        , String "rl3"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl5"
-                                                        , String "rl2"
-                                                        , String "rl4"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl1"
-                                                        , String "rl4"
-                                                        , String "rl2"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl4"
-                                                        , String "rl1"
-                                                        , String "rl7"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl4"
-                                                        , String "rl7"
-                                                        , String "rl9"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl7"
-                                                        , String "rl13"
-                                                        , String "rl9"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl12"
-                                                        , String "rl9"
-                                                        , String "rl13"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl12"
-                                                        , String "rl13"
-                                                        , String "rl18"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl18"
-                                                        , String "rl17"
-                                                        , String "rl12"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl3"
-                                                        , String "rl6"
-                                                        , String "rl0"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl3"
-                                                        , String "rl8"
-                                                        , String "rl6"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl10"
-                                                        , String "rl11"
-                                                        , String "rl8"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl6"
-                                                        , String "rl8"
-                                                        , String "rl11"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl10"
-                                                        , String "rl16"
-                                                        , String "rl11"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl16"
-                                                        , String "rl10"
-                                                        , String "rl15"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl15"
-                                                        , String "rl20"
-                                                        , String "rl16"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl21"
-                                                        , String "rl16"
-                                                        , String "rl20"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl30"
-                                                        , String "rl21"
-                                                        , String "rl20"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl31"
-                                                        , String "rl21"
-                                                        , String "rl30"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl17"
-                                                        , String "rl18"
-                                                        , String "rl28"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl29"
-                                                        , String "rl28"
-                                                        , String "rl18"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl32"
-                                                        , String "rl28"
-                                                        , String "rl29"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl33"
-                                                        , String "rl32"
-                                                        , String "rl29"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl32"
-                                                        , String "rl33"
-                                                        , String "rl39"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl39"
-                                                        , String "rl33"
-                                                        , String "rl36"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl36"
-                                                        , String "rl41"
-                                                        , String "rl39"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl43"
-                                                        , String "rl41"
-                                                        , String "rl36"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl45"
-                                                        , String "rl41"
-                                                        , String "rl43"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl47"
-                                                        , String "rl45"
-                                                        , String "rl43"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl53"
-                                                        , String "rl45"
-                                                        , String "rl47"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl54"
-                                                        , String "rl53"
-                                                        , String "rl47"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl54"
-                                                        , String "rl51"
-                                                        , String "rl53"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl51"
-                                                        , String "rl54"
-                                                        , String "rl52"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl52"
-                                                        , String "rl50"
-                                                        , String "rl51"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl50"
-                                                        , String "rl49"
-                                                        , String "rl51"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl46"
-                                                        , String "rl44"
-                                                        , String "rl49"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl50"
-                                                        , String "rl46"
-                                                        , String "rl49"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl46"
-                                                        , String "rl42"
-                                                        , String "rl44"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl44"
-                                                        , String "rl42"
-                                                        , String "rl40"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl34"
-                                                        , String "rl37"
-                                                        , String "rl40"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl42"
-                                                        , String "rl34"
-                                                        , String "rl40"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl34"
-                                                        , String "rl35"
-                                                        , String "rl37"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl35"
-                                                        , String "rl38"
-                                                        , String "rl37"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl35"
-                                                        , String "rl39"
-                                                        , String "rl38"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl39"
-                                                        , String "rl35"
-                                                        , String "rl36"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl30"
-                                                        , String "rl37"
-                                                        , String "rl31"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl37"
-                                                        , String "rl34"
-                                                        , String "rl31"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl16"
-                                                        , String "rl15"
-                                                        , String "rl22"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl16"
-                                                        , String "rl22"
-                                                        , String "rl23"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl23"
-                                                        , String "rl22"
-                                                        , String "rl21"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl21"
-                                                        , String "rl22"
-                                                        , String "rl20"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl27"
-                                                        , String "rl29"
-                                                        , String "rl26"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl29"
-                                                        , String "rl28"
-                                                        , String "rl26"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl18"
-                                                        , String "rl26"
-                                                        , String "rl17"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl27"
-                                                        , String "rl26"
-                                                        , String "rl18"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl24"
-                                                        , String "rl22"
-                                                        , String "rl23"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl27"
-                                                        , String "rl26"
-                                                        , String "rl24"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl24"
-                                                        , String "rl25"
-                                                        , String "rl27"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl24"
-                                                        , String "rl23"
-                                                        , String "rl25"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl30"
-                                                        , String "rl23"
-                                                        , String "rl22"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl30"
-                                                        , String "rl31"
-                                                        , String "rl23"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl26"
-                                                        , String "rl27"
-                                                        , String "rl32"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rl33"
-                                                        , String "rl32"
-                                                        , String "rl27"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            ]
-                                        , avTrailingComma = True
-                                        }
+                                ,
+                                    ( Comment
+                                        ( InternalComment
+                                            { cText = "The purpose of this file is prove that moving metadata along with vertices when\nmoving vertices works as intended.\nSee issue for #69 explanation on the transformation part of the codebase."
+                                            , cMultiline = True
+                                            , cAssociationDirection = NextNode
+                                            , cHadNewlineBefore = False
+                                            }
+                                        )
+                                    , False
                                     )
-                                )
-                            , ObjectKey
-                                ( String "flexbodies"
-                                , Array
-                                    ( ArrayValue
-                                        { avElements =
-                                            [ Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "mesh"
-                                                        , String "[group]:"
-                                                        , String "nonFlexMaterials"
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            , Array
-                                                ( ArrayValue
-                                                    { avElements =
-                                                        [ String "rails"
-                                                        , Array
+                                ,
+                                    ( Comment
+                                        ( InternalComment
+                                            { cText = "--Nodes--"
+                                            , cMultiline = False
+                                            , cAssociationDirection = NextNode
+                                            , cHadNewlineBefore = False
+                                            }
+                                        )
+                                    , False
+                                    )
+                                ,
+                                    ( ObjectKey
+                                        ( String "nodes"
+                                        , Array
+                                            ( ArrayValue
+                                                { avElements =
+                                                    [
+                                                        ( Array
                                                             ( ArrayValue
                                                                 { avElements =
-                                                                    [ String "chassis_rails" ]
-                                                                , avTrailingComma = False
+                                                                    [
+                                                                        ( String "id"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "posX"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "posY"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "posZ"
+                                                                        , False
+                                                                        )
+                                                                    ]
                                                                 }
                                                             )
-                                                        ]
-                                                    , avTrailingComma = False
-                                                    }
-                                                )
-                                            ]
-                                        , avTrailingComma = True
-                                        }
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "group"
+                                                                            , String "chassis_rails"
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "selfCollision"
+                                                                            , Bool False
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "nodeWeight"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "3.8"
+                                                                                    , nvValue = 3.8
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl0"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.523"
+                                                                                , nvValue = 0.523
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-2.098"
+                                                                                , nvValue = -2.098
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.319"
+                                                                                , nvValue = 0.319
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl1"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.417"
+                                                                                , nvValue = -0.417
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-2.098"
+                                                                                , nvValue = -2.098
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.319"
+                                                                                , nvValue = 0.319
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl2"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.053"
+                                                                                , nvValue = 5.3e-2
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-2.095"
+                                                                                , nvValue = -2.095
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.319"
+                                                                                , nvValue = 0.319
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl3"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.523"
+                                                                                , nvValue = 0.523
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-2.093"
+                                                                                , nvValue = -2.093
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.268"
+                                                                                , nvValue = 0.268
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl4"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.417"
+                                                                                , nvValue = -0.417
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-2.093"
+                                                                                , nvValue = -2.093
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.268"
+                                                                                , nvValue = 0.268
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl5"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.053"
+                                                                                , nvValue = 5.3e-2
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-2.09"
+                                                                                , nvValue = -2.09
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.269"
+                                                                                , nvValue = 0.269
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "ref node front"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = PreviousNode
+                                                                , cHadNewlineBefore = False
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl6"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.531"
+                                                                                , nvValue = 0.531
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-1.724"
+                                                                                , nvValue = -1.724
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.341"
+                                                                                , nvValue = 0.341
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl7"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.424"
+                                                                                , nvValue = -0.424
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-1.724"
+                                                                                , nvValue = -1.724
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.341"
+                                                                                , nvValue = 0.341
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl8"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.531"
+                                                                                , nvValue = 0.531
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-1.721"
+                                                                                , nvValue = -1.721
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.289"
+                                                                                , nvValue = 0.289
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl9"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.424"
+                                                                                , nvValue = -0.424
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-1.721"
+                                                                                , nvValue = -1.721
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.289"
+                                                                                , nvValue = 0.289
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl10"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.547"
+                                                                                , nvValue = 0.547
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-1.35"
+                                                                                , nvValue = -1.35
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.31"
+                                                                                , nvValue = 0.31
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl11"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.547"
+                                                                                , nvValue = 0.547
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-1.35"
+                                                                                , nvValue = -1.35
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.364"
+                                                                                , nvValue = 0.364
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl12"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.44"
+                                                                                , nvValue = -0.44
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-1.35"
+                                                                                , nvValue = -1.35
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.31"
+                                                                                , nvValue = 0.31
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl13"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.44"
+                                                                                , nvValue = -0.44
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-1.35"
+                                                                                , nvValue = -1.35
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.364"
+                                                                                , nvValue = 0.364
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl14"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.053"
+                                                                                , nvValue = 5.3e-2
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-1.314"
+                                                                                , nvValue = -1.314
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.382"
+                                                                                , nvValue = 0.382
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "support"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = PreviousNode
+                                                                , cHadNewlineBefore = False
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "selfCollision"
+                                                                            , Bool True
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "nodeWeight"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "3.5"
+                                                                                    , nvValue = 3.5
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl15"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.79"
+                                                                                , nvValue = 0.79
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.919"
+                                                                                , nvValue = -0.919
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.182"
+                                                                                , nvValue = 0.182
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl16"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.79"
+                                                                                , nvValue = 0.79
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.919"
+                                                                                , nvValue = -0.919
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.233"
+                                                                                , nvValue = 0.233
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl17"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.683"
+                                                                                , nvValue = -0.683
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.919"
+                                                                                , nvValue = -0.919
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.182"
+                                                                                , nvValue = 0.182
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl18"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.683"
+                                                                                , nvValue = -0.683
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.919"
+                                                                                , nvValue = -0.919
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.233"
+                                                                                , nvValue = 0.233
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl19"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.053"
+                                                                                , nvValue = 5.3e-2
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.024"
+                                                                                , nvValue = -2.4e-2
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.578"
+                                                                                , nvValue = 0.578
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "support"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = PreviousNode
+                                                                , cHadNewlineBefore = False
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl20"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.837"
+                                                                                , nvValue = 0.837
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.002"
+                                                                                , nvValue = 2.0e-3
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.182"
+                                                                                , nvValue = 0.182
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "ref node left"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = PreviousNode
+                                                                , cHadNewlineBefore = False
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl21"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.837"
+                                                                                , nvValue = 0.837
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.002"
+                                                                                , nvValue = 2.0e-3
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.233"
+                                                                                , nvValue = 0.233
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl22"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.415"
+                                                                                , nvValue = 0.415
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.002"
+                                                                                , nvValue = 2.0e-3
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.182"
+                                                                                , nvValue = 0.182
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl23"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.415"
+                                                                                , nvValue = 0.415
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.002"
+                                                                                , nvValue = 2.0e-3
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.233"
+                                                                                , nvValue = 0.233
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl24"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.053"
+                                                                                , nvValue = 5.3e-2
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.002"
+                                                                                , nvValue = 2.0e-3
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.182"
+                                                                                , nvValue = 0.182
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl25"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.053"
+                                                                                , nvValue = 5.3e-2
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.002"
+                                                                                , nvValue = 2.0e-3
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.233"
+                                                                                , nvValue = 0.233
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl26"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.308"
+                                                                                , nvValue = -0.308
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.002"
+                                                                                , nvValue = 2.0e-3
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.182"
+                                                                                , nvValue = 0.182
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl27"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.308"
+                                                                                , nvValue = -0.308
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.002"
+                                                                                , nvValue = 2.0e-3
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.233"
+                                                                                , nvValue = 0.233
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl28"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.73"
+                                                                                , nvValue = -0.73
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.002"
+                                                                                , nvValue = 2.0e-3
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.182"
+                                                                                , nvValue = 0.182
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "ref node right"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = PreviousNode
+                                                                , cHadNewlineBefore = False
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl29"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.73"
+                                                                                , nvValue = -0.73
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.002"
+                                                                                , nvValue = 2.0e-3
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.233"
+                                                                                , nvValue = 0.233
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl30"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.822"
+                                                                                , nvValue = 0.822
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.791"
+                                                                                , nvValue = 0.791
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.182"
+                                                                                , nvValue = 0.182
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl31"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.822"
+                                                                                , nvValue = 0.822
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.791"
+                                                                                , nvValue = 0.791
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.233"
+                                                                                , nvValue = 0.233
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl32"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.715"
+                                                                                , nvValue = -0.715
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.791"
+                                                                                , nvValue = 0.791
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.182"
+                                                                                , nvValue = 0.182
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl33"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.715"
+                                                                                , nvValue = -0.715
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.791"
+                                                                                , nvValue = 0.791
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.233"
+                                                                                , nvValue = 0.233
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "selfCollision"
+                                                                            , Bool False
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl34"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.651"
+                                                                                , nvValue = 0.651
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "1.121"
+                                                                                , nvValue = 1.121
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.628"
+                                                                                , nvValue = 0.628
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl35"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.053"
+                                                                                , nvValue = 5.3e-2
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "1.121"
+                                                                                , nvValue = 1.121
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.628"
+                                                                                , nvValue = 0.628
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl36"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.544"
+                                                                                , nvValue = -0.544
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "1.121"
+                                                                                , nvValue = 1.121
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.628"
+                                                                                , nvValue = 0.628
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl37"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.651"
+                                                                                , nvValue = 0.651
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "1.152"
+                                                                                , nvValue = 1.152
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.565"
+                                                                                , nvValue = 0.565
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl38"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.053"
+                                                                                , nvValue = 5.3e-2
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "1.152"
+                                                                                , nvValue = 1.152
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.565"
+                                                                                , nvValue = 0.565
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl39"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.544"
+                                                                                , nvValue = -0.544
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "1.152"
+                                                                                , nvValue = 1.152
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.565"
+                                                                                , nvValue = 0.565
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl40"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.602"
+                                                                                , nvValue = 0.602
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "1.514"
+                                                                                , nvValue = 1.514
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.566"
+                                                                                , nvValue = 0.566
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl41"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.495"
+                                                                                , nvValue = -0.495
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "1.514"
+                                                                                , nvValue = 1.514
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.566"
+                                                                                , nvValue = 0.566
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl42"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.602"
+                                                                                , nvValue = 0.602
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "1.532"
+                                                                                , nvValue = 1.532
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.623"
+                                                                                , nvValue = 0.623
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl43"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.495"
+                                                                                , nvValue = -0.495
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "1.532"
+                                                                                , nvValue = 1.532
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.623"
+                                                                                , nvValue = 0.623
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl44"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.553"
+                                                                                , nvValue = 0.553
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "1.654"
+                                                                                , nvValue = 1.654
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.359"
+                                                                                , nvValue = 0.359
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl45"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.446"
+                                                                                , nvValue = -0.446
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "1.654"
+                                                                                , nvValue = 1.654
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.359"
+                                                                                , nvValue = 0.359
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl46"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.553"
+                                                                                , nvValue = 0.553
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "1.679"
+                                                                                , nvValue = 1.679
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.448"
+                                                                                , nvValue = 0.448
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl47"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.446"
+                                                                                , nvValue = -0.446
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "1.679"
+                                                                                , nvValue = 1.679
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.448"
+                                                                                , nvValue = 0.448
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl48"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.053"
+                                                                                , nvValue = 5.3e-2
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "1.71"
+                                                                                , nvValue = 1.71
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.565"
+                                                                                , nvValue = 0.565
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "support"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = PreviousNode
+                                                                , cHadNewlineBefore = False
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl49"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.558"
+                                                                                , nvValue = 0.558
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "2.284"
+                                                                                , nvValue = 2.284
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.364"
+                                                                                , nvValue = 0.364
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl50"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.558"
+                                                                                , nvValue = 0.558
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "2.284"
+                                                                                , nvValue = 2.284
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.447"
+                                                                                , nvValue = 0.447
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl51"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.053"
+                                                                                , nvValue = 5.3e-2
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "2.284"
+                                                                                , nvValue = 2.284
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.37"
+                                                                                , nvValue = 0.37
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl52"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.053"
+                                                                                , nvValue = 5.3e-2
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "2.284"
+                                                                                , nvValue = 2.284
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.441"
+                                                                                , nvValue = 0.441
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl53"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.451"
+                                                                                , nvValue = -0.451
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "2.284"
+                                                                                , nvValue = 2.284
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.364"
+                                                                                , nvValue = 0.364
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl54"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "-0.451"
+                                                                                , nvValue = -0.451
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "2.284"
+                                                                                , nvValue = 2.284
+                                                                                }
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Number
+                                                                            ( NumberValue
+                                                                                { nvText = "0.447"
+                                                                                , nvValue = 0.447
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "group"
+                                                                            , String ""
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ]
+                                                }
+                                            )
+                                        )
+                                    , True
                                     )
-                                )
-                            ]
-                        , ovTrailingComma = True
-                        }
+                                ,
+                                    ( Comment
+                                        ( InternalComment
+                                            { cText = "--Beams--"
+                                            , cMultiline = False
+                                            , cAssociationDirection = NextNode
+                                            , cHadNewlineBefore = False
+                                            }
+                                        )
+                                    , False
+                                    )
+                                ,
+                                    ( ObjectKey
+                                        ( String "beams"
+                                        , Array
+                                            ( ArrayValue
+                                                { avElements =
+                                                    [
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "id1:"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "id2:"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "Structural beams"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = True
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "beamStrength"
+                                                                            , String "FLT_MAX"
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( ObjectKey
+                                                                            ( String "beamSpring"
+                                                                            , String "3800000"
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "beamDamp"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "130"
+                                                                                    , nvValue = 130.0
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( ObjectKey
+                                                                            ( String "deformLimit"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "1.1"
+                                                                                    , nvValue = 1.1
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "Front end"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = True
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "beamDeform"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "20600"
+                                                                                    , nvValue = 20600.0
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( ObjectKey
+                                                                            ( String "deformLimit"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "1.1"
+                                                                                    , nvValue = 1.1
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl3"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl5"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl0"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl3"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl8"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl3"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl15"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl10"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl8"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl6"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl11"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl10"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl10"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl8"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl9"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl7"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl17"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl12"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl6"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl11"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl11"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl16"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl13"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl18"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl13"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl12"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl1"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl4"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl2"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl1"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl2"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl5"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl12"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl9"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl7"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl13"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl0"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl6"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl9"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl4"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl2"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl0"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl4"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl5"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl1"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl7"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "Middle"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = True
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "beamDeform"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "27000"
+                                                                                    , nvValue = 27000.0
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl16"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl15"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl20"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl30"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl16"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl23"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl18"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl17"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl17"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl28"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl26"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl17"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl18"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl27"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl26"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl24"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl25"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl24"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl25"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl27"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl21"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl16"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl22"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl15"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl15"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl20"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl29"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl27"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl28"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl32"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl29"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl18"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl22"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl24"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl31"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl21"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl28"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl29"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl32"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl33"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl30"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl31"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl33"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl29"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl30"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl22"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl25"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl23"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl32"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl26"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl20"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl21"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl31"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl23"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl20"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl22"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl21"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl23"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl33"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl27"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl23"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl22"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl28"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl26"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl27"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl26"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "Rear end"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = True
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "beamDeform"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "22000"
+                                                                                    , nvValue = 22000.0
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl37"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl34"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl39"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl41"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl44"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl46"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl33"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl36"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl46"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl42"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl31"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl34"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl37"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl30"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl49"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl51"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl52"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl50"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl50"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl46"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl49"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl50"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl42"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl34"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl40"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl44"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl40"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl42"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl41"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl45"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl39"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl36"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl36"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl35"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl38"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl35"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl53"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl54"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl52"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl54"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl51"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl52"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl45"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl53"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl54"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl47"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl43"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl36"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl53"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl51"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl34"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl35"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl38"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl37"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl45"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl47"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl41"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl43"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl38"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl39"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl39"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl32"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl47"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl43"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl44"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl49"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl37"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl40"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "Crossing beams"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = True
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "Front end"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = True
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "beamDeform"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "16000"
+                                                                                    , nvValue = 16000.0
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl4"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl2"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl0"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl8"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl16"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl10"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl15"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl11"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl10"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl6"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl11"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl8"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl1"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl5"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl4"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl7"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl1"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl9"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl12"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl7"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl3"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl6"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl0"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl5"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl3"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl2"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl13"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl9"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl17"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl13"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl18"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl12"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "Middle"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = True
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "beamDeform"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "6500"
+                                                                                    , nvValue = 6500.0
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl16"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl20"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl15"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl23"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl18"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl28"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl18"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl26"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl17"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl27"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl27"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl24"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl26"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl25"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl31"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl20"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl15"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl21"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl16"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl22"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl32"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl29"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl30"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl21"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl23"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl24"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl32"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl27"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl17"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl29"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl33"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl28"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl29"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl26"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl30"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl23"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl33"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl26"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl22"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl25"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl20"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl23"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl28"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl27"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl31"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl22"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl21"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl22"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "Rear end"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = True
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "beamDeform"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "16000"
+                                                                                    , nvValue = 16000.0
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl54"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl45"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl32"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl36"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl36"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl41"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl50"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl51"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl31"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl37"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl30"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl34"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl46"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl40"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl53"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl47"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl50"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl44"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl49"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl46"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl37"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl42"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl34"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl40"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl34"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl38"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl33"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl39"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl39"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl35"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl36"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl38"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl53"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl52"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl54"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl51"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl45"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl43"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl47"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl41"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl39"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl43"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl37"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl35"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl49"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl52"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl44"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl42"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "Support beams"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = True
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "Front end"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = True
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "beamDeform"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "19000"
+                                                                                    , nvValue = 19000.0
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl8"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl14"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl9"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl14"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl14"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl3"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl10"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl14"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl14"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl13"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl1"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl14"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl0"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl14"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl12"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl14"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl5"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl14"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl14"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl4"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl14"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl6"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl14"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl7"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl14"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl2"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl14"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl11"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "Middle"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = True
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "beamDeform"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "11000"
+                                                                                    , nvValue = 11000.0
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl27"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl19"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl26"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl19"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl24"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl19"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl23"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl19"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl20"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl19"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl19"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl16"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl19"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl15"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl31"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl19"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl33"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl19"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl28"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl19"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl19"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl25"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl21"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl19"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl22"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl19"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl19"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl32"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl29"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl19"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl19"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl18"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl19"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl17"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl19"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl30"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "Rear end"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = True
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "beamDeform"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "19000"
+                                                                                    , nvValue = 19000.0
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl48"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl51"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl48"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl54"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl45"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl48"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl48"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl50"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl48"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl42"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl48"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl47"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl49"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl48"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl35"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl48"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl48"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl43"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl44"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl48"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl53"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl48"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl52"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl48"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl40"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl48"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl48"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl38"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl41"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl48"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl48"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl46"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Comment
+                                                            ( InternalComment
+                                                                { cText = "Front crush"
+                                                                , cMultiline = False
+                                                                , cAssociationDirection = NextNode
+                                                                , cHadNewlineBefore = True
+                                                                }
+                                                            )
+                                                        , False
+                                                        )
+                                                    ,
+                                                        ( Object
+                                                            ( ObjectValue
+                                                                { ovElements =
+                                                                    [
+                                                                        ( ObjectKey
+                                                                            ( String "beamDeform"
+                                                                            , Number
+                                                                                ( NumberValue
+                                                                                    { nvText = "8500"
+                                                                                    , nvValue = 8500.0
+                                                                                    }
+                                                                                )
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl17"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl9"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl15"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl8"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ]
+                                                }
+                                            )
+                                        )
+                                    , True
+                                    )
+                                ,
+                                    ( Comment
+                                        ( InternalComment
+                                            { cText = "--Collision Triangles--"
+                                            , cMultiline = False
+                                            , cAssociationDirection = NextNode
+                                            , cHadNewlineBefore = False
+                                            }
+                                        )
+                                    , False
+                                    )
+                                ,
+                                    ( ObjectKey
+                                        ( String "triangles"
+                                        , Array
+                                            ( ArrayValue
+                                                { avElements =
+                                                    [
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "id1:"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "id2:"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "id3:"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl5"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl3"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl2"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl0"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl2"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl3"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl5"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl2"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl4"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl1"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl4"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl2"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl4"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl1"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl7"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl4"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl7"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl9"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl7"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl13"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl9"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl12"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl9"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl13"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl12"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl13"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl18"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl18"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl17"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl12"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl3"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl6"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl0"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl3"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl8"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl6"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl10"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl11"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl8"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl6"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl8"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl11"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl10"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl16"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl11"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl16"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl10"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl15"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl15"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl20"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl16"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl21"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl16"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl20"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl30"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl21"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl20"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl31"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl21"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl30"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl17"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl18"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl28"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl29"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl28"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl18"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl32"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl28"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl29"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl33"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl32"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl29"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl32"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl33"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl39"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl39"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl33"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl36"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl36"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl41"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl39"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl43"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl41"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl36"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl45"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl41"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl43"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl47"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl45"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl43"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl53"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl45"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl47"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl54"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl53"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl47"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl54"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl51"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl53"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl51"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl54"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl52"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl52"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl50"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl51"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl50"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl49"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl51"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl46"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl44"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl49"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl50"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl46"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl49"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl46"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl42"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl44"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl44"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl42"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl40"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl34"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl37"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl40"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl42"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl34"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl40"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl34"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl35"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl37"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl35"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl38"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl37"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl35"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl39"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl38"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl39"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl35"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl36"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl30"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl37"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl31"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl37"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl34"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl31"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl16"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl15"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl22"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl16"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl22"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl23"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl23"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl22"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl21"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl21"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl22"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl20"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl27"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl29"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl26"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl29"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl28"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl26"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl18"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl26"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl17"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl27"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl26"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl18"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl24"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl22"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl23"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl27"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl26"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl24"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl24"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl25"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl27"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl24"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl23"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl25"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl30"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl23"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl22"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl30"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl31"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl23"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl26"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl27"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl32"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rl33"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl32"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "rl27"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ]
+                                                }
+                                            )
+                                        )
+                                    , True
+                                    )
+                                ,
+                                    ( ObjectKey
+                                        ( String "flexbodies"
+                                        , Array
+                                            ( ArrayValue
+                                                { avElements =
+                                                    [
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "mesh"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "[group]:"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( String "nonFlexMaterials"
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ,
+                                                        ( Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [
+                                                                        ( String "rails"
+                                                                        , True
+                                                                        )
+                                                                    ,
+                                                                        ( Array
+                                                                            ( ArrayValue
+                                                                                { avElements =
+                                                                                    [
+                                                                                        ( String "chassis_rails"
+                                                                                        , False
+                                                                                        )
+                                                                                    ]
+                                                                                }
+                                                                            )
+                                                                        , False
+                                                                        )
+                                                                    ]
+                                                                }
+                                                            )
+                                                        , True
+                                                        )
+                                                    ]
+                                                }
+                                            )
+                                        )
+                                    , True
+                                    )
+                                ]
+                            }
+                        )
                     )
+                , True
                 )
             ]
-        , ovTrailingComma = True
         }
     )

--- a/examples/ast/jbeam/suspension.hs
+++ b/examples/ast/jbeam/suspension.hs
@@ -1,2745 +1,4520 @@
 Object
-    [ ObjectKey
-        ( String "chassis_rails"
-        , Object
+    ( ObjectValue
+        { ovElements =
             [ ObjectKey
-                ( String "information"
+                ( String "chassis_rails"
                 , Object
-                    [ ObjectKey
-                        ( String "authors"
-                        , String "gittarrgy01"
-                        )
-                    , ObjectKey
-                        ( String "name"
-                        , String ""
-                        )
-                    ]
-                )
-            , ObjectKey
-                ( String "slotType"
-                , String "main"
-                )
-            , Comment
-                ( InternalComment
-                    { cText = "The purpose of this file is prove that moving metadata along with vertices when\nmoving vertices works as intended.\nSee issue for #69 explanation on the transformation part of the codebase."
-                    , cMultiline = True
-                    , cAssociationDirection = NextNode
-                    , cHadNewlineBefore = False
-                    }
-                )
-            , Comment
-                ( InternalComment
-                    { cText = "--Nodes--"
-                    , cMultiline = False
-                    , cAssociationDirection = NextNode
-                    , cHadNewlineBefore = False
-                    }
-                )
-            , ObjectKey
-                ( String "nodes"
-                , Array
-                    [ Array
-                        [ String "id"
-                        , String "posX"
-                        , String "posY"
-                        , String "posZ"
-                        ]
-                    , Object
-                        [ ObjectKey
-                            ( String "group"
-                            , String "chassis_rails"
-                            )
-                        ]
-                    , Object
-                        [ ObjectKey
-                            ( String "selfCollision"
-                            , Bool False
-                            )
-                        ]
-                    , Object
-                        [ ObjectKey
-                            ( String "nodeWeight"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "3.8"
-                                    , nvValue = 3.8
+                    ( ObjectValue
+                        { ovElements =
+                            [ ObjectKey
+                                ( String "information"
+                                , Object
+                                    ( ObjectValue
+                                        { ovElements =
+                                            [ ObjectKey
+                                                ( String "authors"
+                                                , String "gittarrgy01"
+                                                )
+                                            , ObjectKey
+                                                ( String "name"
+                                                , String ""
+                                                )
+                                            ]
+                                        , ovTrailingComma = True
+                                        }
+                                    )
+                                )
+                            , ObjectKey
+                                ( String "slotType"
+                                , String "main"
+                                )
+                            , Comment
+                                ( InternalComment
+                                    { cText = "The purpose of this file is prove that moving metadata along with vertices when\nmoving vertices works as intended.\nSee issue for #69 explanation on the transformation part of the codebase."
+                                    , cMultiline = True
+                                    , cAssociationDirection = NextNode
+                                    , cHadNewlineBefore = False
                                     }
                                 )
-                            )
-                        ]
-                    , Array
-                        [ String "rl0"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.523"
-                                , nvValue = 0.523
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-2.098"
-                                , nvValue = -2.098
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.319"
-                                , nvValue = 0.319
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl1"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.417"
-                                , nvValue = -0.417
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-2.098"
-                                , nvValue = -2.098
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.319"
-                                , nvValue = 0.319
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl2"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.053"
-                                , nvValue = 5.3e-2
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-2.095"
-                                , nvValue = -2.095
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.319"
-                                , nvValue = 0.319
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl3"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.523"
-                                , nvValue = 0.523
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-2.093"
-                                , nvValue = -2.093
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.268"
-                                , nvValue = 0.268
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl4"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.417"
-                                , nvValue = -0.417
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-2.093"
-                                , nvValue = -2.093
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.268"
-                                , nvValue = 0.268
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl5"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.053"
-                                , nvValue = 5.3e-2
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-2.09"
-                                , nvValue = -2.09
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.269"
-                                , nvValue = 0.269
-                                }
-                            )
-                        ]
-                    , Comment
-                        ( InternalComment
-                            { cText = "ref node front"
-                            , cMultiline = False
-                            , cAssociationDirection = PreviousNode
-                            , cHadNewlineBefore = False
-                            }
-                        )
-                    , Array
-                        [ String "rl6"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.531"
-                                , nvValue = 0.531
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-1.724"
-                                , nvValue = -1.724
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.341"
-                                , nvValue = 0.341
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl7"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.424"
-                                , nvValue = -0.424
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-1.724"
-                                , nvValue = -1.724
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.341"
-                                , nvValue = 0.341
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl8"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.531"
-                                , nvValue = 0.531
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-1.721"
-                                , nvValue = -1.721
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.289"
-                                , nvValue = 0.289
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl9"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.424"
-                                , nvValue = -0.424
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-1.721"
-                                , nvValue = -1.721
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.289"
-                                , nvValue = 0.289
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl10"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.547"
-                                , nvValue = 0.547
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-1.35"
-                                , nvValue = -1.35
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.31"
-                                , nvValue = 0.31
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl11"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.547"
-                                , nvValue = 0.547
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-1.35"
-                                , nvValue = -1.35
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.364"
-                                , nvValue = 0.364
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl12"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.44"
-                                , nvValue = -0.44
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-1.35"
-                                , nvValue = -1.35
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.31"
-                                , nvValue = 0.31
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl13"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.44"
-                                , nvValue = -0.44
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-1.35"
-                                , nvValue = -1.35
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.364"
-                                , nvValue = 0.364
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl14"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.053"
-                                , nvValue = 5.3e-2
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-1.314"
-                                , nvValue = -1.314
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.382"
-                                , nvValue = 0.382
-                                }
-                            )
-                        ]
-                    , Comment
-                        ( InternalComment
-                            { cText = "support"
-                            , cMultiline = False
-                            , cAssociationDirection = PreviousNode
-                            , cHadNewlineBefore = False
-                            }
-                        )
-                    , Object
-                        [ ObjectKey
-                            ( String "selfCollision"
-                            , Bool True
-                            )
-                        ]
-                    , Object
-                        [ ObjectKey
-                            ( String "nodeWeight"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "3.5"
-                                    , nvValue = 3.5
+                            , Comment
+                                ( InternalComment
+                                    { cText = "--Nodes--"
+                                    , cMultiline = False
+                                    , cAssociationDirection = NextNode
+                                    , cHadNewlineBefore = False
                                     }
                                 )
-                            )
-                        ]
-                    , Array
-                        [ String "rl15"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.79"
-                                , nvValue = 0.79
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.919"
-                                , nvValue = -0.919
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.182"
-                                , nvValue = 0.182
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl16"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.79"
-                                , nvValue = 0.79
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.919"
-                                , nvValue = -0.919
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.233"
-                                , nvValue = 0.233
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl17"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.683"
-                                , nvValue = -0.683
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.919"
-                                , nvValue = -0.919
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.182"
-                                , nvValue = 0.182
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl18"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.683"
-                                , nvValue = -0.683
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.919"
-                                , nvValue = -0.919
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.233"
-                                , nvValue = 0.233
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl19"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.053"
-                                , nvValue = 5.3e-2
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.024"
-                                , nvValue = -2.4e-2
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.578"
-                                , nvValue = 0.578
-                                }
-                            )
-                        ]
-                    , Comment
-                        ( InternalComment
-                            { cText = "support"
-                            , cMultiline = False
-                            , cAssociationDirection = PreviousNode
-                            , cHadNewlineBefore = False
-                            }
-                        )
-                    , Array
-                        [ String "rl20"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.837"
-                                , nvValue = 0.837
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.002"
-                                , nvValue = 2.0e-3
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.182"
-                                , nvValue = 0.182
-                                }
-                            )
-                        ]
-                    , Comment
-                        ( InternalComment
-                            { cText = "ref node left"
-                            , cMultiline = False
-                            , cAssociationDirection = PreviousNode
-                            , cHadNewlineBefore = False
-                            }
-                        )
-                    , Array
-                        [ String "rl21"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.837"
-                                , nvValue = 0.837
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.002"
-                                , nvValue = 2.0e-3
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.233"
-                                , nvValue = 0.233
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl22"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.415"
-                                , nvValue = 0.415
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.002"
-                                , nvValue = 2.0e-3
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.182"
-                                , nvValue = 0.182
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl23"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.415"
-                                , nvValue = 0.415
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.002"
-                                , nvValue = 2.0e-3
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.233"
-                                , nvValue = 0.233
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl24"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.053"
-                                , nvValue = 5.3e-2
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.002"
-                                , nvValue = 2.0e-3
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.182"
-                                , nvValue = 0.182
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl25"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.053"
-                                , nvValue = 5.3e-2
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.002"
-                                , nvValue = 2.0e-3
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.233"
-                                , nvValue = 0.233
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl26"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.308"
-                                , nvValue = -0.308
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.002"
-                                , nvValue = 2.0e-3
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.182"
-                                , nvValue = 0.182
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl27"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.308"
-                                , nvValue = -0.308
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.002"
-                                , nvValue = 2.0e-3
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.233"
-                                , nvValue = 0.233
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl28"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.73"
-                                , nvValue = -0.73
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.002"
-                                , nvValue = 2.0e-3
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.182"
-                                , nvValue = 0.182
-                                }
-                            )
-                        ]
-                    , Comment
-                        ( InternalComment
-                            { cText = "ref node right"
-                            , cMultiline = False
-                            , cAssociationDirection = PreviousNode
-                            , cHadNewlineBefore = False
-                            }
-                        )
-                    , Array
-                        [ String "rl29"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.73"
-                                , nvValue = -0.73
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.002"
-                                , nvValue = 2.0e-3
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.233"
-                                , nvValue = 0.233
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl30"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.822"
-                                , nvValue = 0.822
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.791"
-                                , nvValue = 0.791
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.182"
-                                , nvValue = 0.182
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl31"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.822"
-                                , nvValue = 0.822
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.791"
-                                , nvValue = 0.791
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.233"
-                                , nvValue = 0.233
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl32"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.715"
-                                , nvValue = -0.715
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.791"
-                                , nvValue = 0.791
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.182"
-                                , nvValue = 0.182
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl33"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.715"
-                                , nvValue = -0.715
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.791"
-                                , nvValue = 0.791
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.233"
-                                , nvValue = 0.233
-                                }
-                            )
-                        ]
-                    , Object
-                        [ ObjectKey
-                            ( String "selfCollision"
-                            , Bool False
-                            )
-                        ]
-                    , Array
-                        [ String "rl34"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.651"
-                                , nvValue = 0.651
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "1.121"
-                                , nvValue = 1.121
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.628"
-                                , nvValue = 0.628
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl35"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.053"
-                                , nvValue = 5.3e-2
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "1.121"
-                                , nvValue = 1.121
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.628"
-                                , nvValue = 0.628
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl36"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.544"
-                                , nvValue = -0.544
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "1.121"
-                                , nvValue = 1.121
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.628"
-                                , nvValue = 0.628
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl37"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.651"
-                                , nvValue = 0.651
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "1.152"
-                                , nvValue = 1.152
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.565"
-                                , nvValue = 0.565
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl38"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.053"
-                                , nvValue = 5.3e-2
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "1.152"
-                                , nvValue = 1.152
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.565"
-                                , nvValue = 0.565
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl39"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.544"
-                                , nvValue = -0.544
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "1.152"
-                                , nvValue = 1.152
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.565"
-                                , nvValue = 0.565
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl40"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.602"
-                                , nvValue = 0.602
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "1.514"
-                                , nvValue = 1.514
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.566"
-                                , nvValue = 0.566
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl41"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.495"
-                                , nvValue = -0.495
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "1.514"
-                                , nvValue = 1.514
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.566"
-                                , nvValue = 0.566
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl42"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.602"
-                                , nvValue = 0.602
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "1.532"
-                                , nvValue = 1.532
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.623"
-                                , nvValue = 0.623
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl43"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.495"
-                                , nvValue = -0.495
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "1.532"
-                                , nvValue = 1.532
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.623"
-                                , nvValue = 0.623
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl44"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.553"
-                                , nvValue = 0.553
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "1.654"
-                                , nvValue = 1.654
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.359"
-                                , nvValue = 0.359
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl45"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.446"
-                                , nvValue = -0.446
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "1.654"
-                                , nvValue = 1.654
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.359"
-                                , nvValue = 0.359
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl46"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.553"
-                                , nvValue = 0.553
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "1.679"
-                                , nvValue = 1.679
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.448"
-                                , nvValue = 0.448
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl47"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.446"
-                                , nvValue = -0.446
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "1.679"
-                                , nvValue = 1.679
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.448"
-                                , nvValue = 0.448
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl48"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.053"
-                                , nvValue = 5.3e-2
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "1.71"
-                                , nvValue = 1.71
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.565"
-                                , nvValue = 0.565
-                                }
-                            )
-                        ]
-                    , Comment
-                        ( InternalComment
-                            { cText = "support"
-                            , cMultiline = False
-                            , cAssociationDirection = PreviousNode
-                            , cHadNewlineBefore = False
-                            }
-                        )
-                    , Array
-                        [ String "rl49"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.558"
-                                , nvValue = 0.558
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "2.284"
-                                , nvValue = 2.284
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.364"
-                                , nvValue = 0.364
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl50"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.558"
-                                , nvValue = 0.558
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "2.284"
-                                , nvValue = 2.284
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.447"
-                                , nvValue = 0.447
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl51"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.053"
-                                , nvValue = 5.3e-2
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "2.284"
-                                , nvValue = 2.284
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.37"
-                                , nvValue = 0.37
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl52"
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.053"
-                                , nvValue = 5.3e-2
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "2.284"
-                                , nvValue = 2.284
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.441"
-                                , nvValue = 0.441
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl53"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.451"
-                                , nvValue = -0.451
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "2.284"
-                                , nvValue = 2.284
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.364"
-                                , nvValue = 0.364
-                                }
-                            )
-                        ]
-                    , Array
-                        [ String "rl54"
-                        , Number
-                            ( NumberValue
-                                { nvText = "-0.451"
-                                , nvValue = -0.451
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "2.284"
-                                , nvValue = 2.284
-                                }
-                            )
-                        , Number
-                            ( NumberValue
-                                { nvText = "0.447"
-                                , nvValue = 0.447
-                                }
-                            )
-                        ]
-                    , Object
-                        [ ObjectKey
-                            ( String "group"
-                            , String ""
-                            )
-                        ]
-                    ]
-                )
-            , Comment
-                ( InternalComment
-                    { cText = "--Beams--"
-                    , cMultiline = False
-                    , cAssociationDirection = NextNode
-                    , cHadNewlineBefore = False
-                    }
-                )
-            , ObjectKey
-                ( String "beams"
-                , Array
-                    [ Array
-                        [ String "id1:"
-                        , String "id2:"
-                        ]
-                    , Comment
-                        ( InternalComment
-                            { cText = "Structural beams"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = True
-                            }
-                        )
-                    , Object
-                        [ ObjectKey
-                            ( String "beamStrength"
-                            , String "FLT_MAX"
-                            )
-                        , ObjectKey
-                            ( String "beamSpring"
-                            , String "3800000"
-                            )
-                        ]
-                    , Object
-                        [ ObjectKey
-                            ( String "beamDamp"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "130"
-                                    , nvValue = 130.0
+                            , ObjectKey
+                                ( String "nodes"
+                                , Array
+                                    ( ArrayValue
+                                        { avElements =
+                                            [ Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "id"
+                                                        , String "posX"
+                                                        , String "posY"
+                                                        , String "posZ"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "group"
+                                                            , String "chassis_rails"
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "selfCollision"
+                                                            , Bool False
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "nodeWeight"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "3.8"
+                                                                    , nvValue = 3.8
+                                                                    }
+                                                                )
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl0"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.523"
+                                                                , nvValue = 0.523
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-2.098"
+                                                                , nvValue = -2.098
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.319"
+                                                                , nvValue = 0.319
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl1"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.417"
+                                                                , nvValue = -0.417
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-2.098"
+                                                                , nvValue = -2.098
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.319"
+                                                                , nvValue = 0.319
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl2"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.053"
+                                                                , nvValue = 5.3e-2
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-2.095"
+                                                                , nvValue = -2.095
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.319"
+                                                                , nvValue = 0.319
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl3"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.523"
+                                                                , nvValue = 0.523
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-2.093"
+                                                                , nvValue = -2.093
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.268"
+                                                                , nvValue = 0.268
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl4"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.417"
+                                                                , nvValue = -0.417
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-2.093"
+                                                                , nvValue = -2.093
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.268"
+                                                                , nvValue = 0.268
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl5"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.053"
+                                                                , nvValue = 5.3e-2
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-2.09"
+                                                                , nvValue = -2.09
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.269"
+                                                                , nvValue = 0.269
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "ref node front"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = PreviousNode
+                                                    , cHadNewlineBefore = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl6"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.531"
+                                                                , nvValue = 0.531
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-1.724"
+                                                                , nvValue = -1.724
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.341"
+                                                                , nvValue = 0.341
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl7"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.424"
+                                                                , nvValue = -0.424
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-1.724"
+                                                                , nvValue = -1.724
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.341"
+                                                                , nvValue = 0.341
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl8"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.531"
+                                                                , nvValue = 0.531
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-1.721"
+                                                                , nvValue = -1.721
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.289"
+                                                                , nvValue = 0.289
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl9"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.424"
+                                                                , nvValue = -0.424
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-1.721"
+                                                                , nvValue = -1.721
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.289"
+                                                                , nvValue = 0.289
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl10"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.547"
+                                                                , nvValue = 0.547
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-1.35"
+                                                                , nvValue = -1.35
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.31"
+                                                                , nvValue = 0.31
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl11"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.547"
+                                                                , nvValue = 0.547
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-1.35"
+                                                                , nvValue = -1.35
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.364"
+                                                                , nvValue = 0.364
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl12"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.44"
+                                                                , nvValue = -0.44
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-1.35"
+                                                                , nvValue = -1.35
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.31"
+                                                                , nvValue = 0.31
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl13"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.44"
+                                                                , nvValue = -0.44
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-1.35"
+                                                                , nvValue = -1.35
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.364"
+                                                                , nvValue = 0.364
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl14"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.053"
+                                                                , nvValue = 5.3e-2
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-1.314"
+                                                                , nvValue = -1.314
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.382"
+                                                                , nvValue = 0.382
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "support"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = PreviousNode
+                                                    , cHadNewlineBefore = False
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "selfCollision"
+                                                            , Bool True
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "nodeWeight"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "3.5"
+                                                                    , nvValue = 3.5
+                                                                    }
+                                                                )
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl15"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.79"
+                                                                , nvValue = 0.79
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.919"
+                                                                , nvValue = -0.919
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.182"
+                                                                , nvValue = 0.182
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl16"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.79"
+                                                                , nvValue = 0.79
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.919"
+                                                                , nvValue = -0.919
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.233"
+                                                                , nvValue = 0.233
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl17"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.683"
+                                                                , nvValue = -0.683
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.919"
+                                                                , nvValue = -0.919
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.182"
+                                                                , nvValue = 0.182
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl18"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.683"
+                                                                , nvValue = -0.683
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.919"
+                                                                , nvValue = -0.919
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.233"
+                                                                , nvValue = 0.233
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl19"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.053"
+                                                                , nvValue = 5.3e-2
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.024"
+                                                                , nvValue = -2.4e-2
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.578"
+                                                                , nvValue = 0.578
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "support"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = PreviousNode
+                                                    , cHadNewlineBefore = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl20"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.837"
+                                                                , nvValue = 0.837
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.002"
+                                                                , nvValue = 2.0e-3
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.182"
+                                                                , nvValue = 0.182
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "ref node left"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = PreviousNode
+                                                    , cHadNewlineBefore = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl21"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.837"
+                                                                , nvValue = 0.837
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.002"
+                                                                , nvValue = 2.0e-3
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.233"
+                                                                , nvValue = 0.233
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl22"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.415"
+                                                                , nvValue = 0.415
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.002"
+                                                                , nvValue = 2.0e-3
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.182"
+                                                                , nvValue = 0.182
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl23"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.415"
+                                                                , nvValue = 0.415
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.002"
+                                                                , nvValue = 2.0e-3
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.233"
+                                                                , nvValue = 0.233
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl24"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.053"
+                                                                , nvValue = 5.3e-2
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.002"
+                                                                , nvValue = 2.0e-3
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.182"
+                                                                , nvValue = 0.182
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl25"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.053"
+                                                                , nvValue = 5.3e-2
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.002"
+                                                                , nvValue = 2.0e-3
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.233"
+                                                                , nvValue = 0.233
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl26"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.308"
+                                                                , nvValue = -0.308
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.002"
+                                                                , nvValue = 2.0e-3
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.182"
+                                                                , nvValue = 0.182
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl27"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.308"
+                                                                , nvValue = -0.308
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.002"
+                                                                , nvValue = 2.0e-3
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.233"
+                                                                , nvValue = 0.233
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl28"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.73"
+                                                                , nvValue = -0.73
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.002"
+                                                                , nvValue = 2.0e-3
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.182"
+                                                                , nvValue = 0.182
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "ref node right"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = PreviousNode
+                                                    , cHadNewlineBefore = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl29"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.73"
+                                                                , nvValue = -0.73
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.002"
+                                                                , nvValue = 2.0e-3
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.233"
+                                                                , nvValue = 0.233
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl30"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.822"
+                                                                , nvValue = 0.822
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.791"
+                                                                , nvValue = 0.791
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.182"
+                                                                , nvValue = 0.182
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl31"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.822"
+                                                                , nvValue = 0.822
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.791"
+                                                                , nvValue = 0.791
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.233"
+                                                                , nvValue = 0.233
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl32"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.715"
+                                                                , nvValue = -0.715
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.791"
+                                                                , nvValue = 0.791
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.182"
+                                                                , nvValue = 0.182
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl33"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.715"
+                                                                , nvValue = -0.715
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.791"
+                                                                , nvValue = 0.791
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.233"
+                                                                , nvValue = 0.233
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "selfCollision"
+                                                            , Bool False
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl34"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.651"
+                                                                , nvValue = 0.651
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "1.121"
+                                                                , nvValue = 1.121
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.628"
+                                                                , nvValue = 0.628
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl35"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.053"
+                                                                , nvValue = 5.3e-2
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "1.121"
+                                                                , nvValue = 1.121
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.628"
+                                                                , nvValue = 0.628
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl36"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.544"
+                                                                , nvValue = -0.544
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "1.121"
+                                                                , nvValue = 1.121
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.628"
+                                                                , nvValue = 0.628
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl37"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.651"
+                                                                , nvValue = 0.651
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "1.152"
+                                                                , nvValue = 1.152
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.565"
+                                                                , nvValue = 0.565
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl38"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.053"
+                                                                , nvValue = 5.3e-2
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "1.152"
+                                                                , nvValue = 1.152
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.565"
+                                                                , nvValue = 0.565
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl39"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.544"
+                                                                , nvValue = -0.544
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "1.152"
+                                                                , nvValue = 1.152
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.565"
+                                                                , nvValue = 0.565
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl40"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.602"
+                                                                , nvValue = 0.602
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "1.514"
+                                                                , nvValue = 1.514
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.566"
+                                                                , nvValue = 0.566
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl41"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.495"
+                                                                , nvValue = -0.495
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "1.514"
+                                                                , nvValue = 1.514
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.566"
+                                                                , nvValue = 0.566
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl42"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.602"
+                                                                , nvValue = 0.602
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "1.532"
+                                                                , nvValue = 1.532
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.623"
+                                                                , nvValue = 0.623
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl43"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.495"
+                                                                , nvValue = -0.495
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "1.532"
+                                                                , nvValue = 1.532
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.623"
+                                                                , nvValue = 0.623
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl44"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.553"
+                                                                , nvValue = 0.553
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "1.654"
+                                                                , nvValue = 1.654
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.359"
+                                                                , nvValue = 0.359
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl45"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.446"
+                                                                , nvValue = -0.446
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "1.654"
+                                                                , nvValue = 1.654
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.359"
+                                                                , nvValue = 0.359
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl46"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.553"
+                                                                , nvValue = 0.553
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "1.679"
+                                                                , nvValue = 1.679
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.448"
+                                                                , nvValue = 0.448
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl47"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.446"
+                                                                , nvValue = -0.446
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "1.679"
+                                                                , nvValue = 1.679
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.448"
+                                                                , nvValue = 0.448
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl48"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.053"
+                                                                , nvValue = 5.3e-2
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "1.71"
+                                                                , nvValue = 1.71
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.565"
+                                                                , nvValue = 0.565
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "support"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = PreviousNode
+                                                    , cHadNewlineBefore = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl49"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.558"
+                                                                , nvValue = 0.558
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "2.284"
+                                                                , nvValue = 2.284
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.364"
+                                                                , nvValue = 0.364
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl50"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.558"
+                                                                , nvValue = 0.558
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "2.284"
+                                                                , nvValue = 2.284
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.447"
+                                                                , nvValue = 0.447
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl51"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.053"
+                                                                , nvValue = 5.3e-2
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "2.284"
+                                                                , nvValue = 2.284
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.37"
+                                                                , nvValue = 0.37
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl52"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.053"
+                                                                , nvValue = 5.3e-2
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "2.284"
+                                                                , nvValue = 2.284
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.441"
+                                                                , nvValue = 0.441
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl53"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.451"
+                                                                , nvValue = -0.451
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "2.284"
+                                                                , nvValue = 2.284
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.364"
+                                                                , nvValue = 0.364
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl54"
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "-0.451"
+                                                                , nvValue = -0.451
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "2.284"
+                                                                , nvValue = 2.284
+                                                                }
+                                                            )
+                                                        , Number
+                                                            ( NumberValue
+                                                                { nvText = "0.447"
+                                                                , nvValue = 0.447
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "group"
+                                                            , String ""
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            ]
+                                        , avTrailingComma = True
+                                        }
+                                    )
+                                )
+                            , Comment
+                                ( InternalComment
+                                    { cText = "--Beams--"
+                                    , cMultiline = False
+                                    , cAssociationDirection = NextNode
+                                    , cHadNewlineBefore = False
                                     }
                                 )
-                            )
-                        , ObjectKey
-                            ( String "deformLimit"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "1.1"
-                                    , nvValue = 1.1
+                            , ObjectKey
+                                ( String "beams"
+                                , Array
+                                    ( ArrayValue
+                                        { avElements =
+                                            [ Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "id1:"
+                                                        , String "id2:"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "Structural beams"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = True
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "beamStrength"
+                                                            , String "FLT_MAX"
+                                                            )
+                                                        , ObjectKey
+                                                            ( String "beamSpring"
+                                                            , String "3800000"
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "beamDamp"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "130"
+                                                                    , nvValue = 130.0
+                                                                    }
+                                                                )
+                                                            )
+                                                        , ObjectKey
+                                                            ( String "deformLimit"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "1.1"
+                                                                    , nvValue = 1.1
+                                                                    }
+                                                                )
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "Front end"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = True
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "beamDeform"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "20600"
+                                                                    , nvValue = 20600.0
+                                                                    }
+                                                                )
+                                                            )
+                                                        , ObjectKey
+                                                            ( String "deformLimit"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "1.1"
+                                                                    , nvValue = 1.1
+                                                                    }
+                                                                )
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl3"
+                                                        , String "rl5"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl0"
+                                                        , String "rl3"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl8"
+                                                        , String "rl3"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl15"
+                                                        , String "rl10"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl8"
+                                                        , String "rl6"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl11"
+                                                        , String "rl10"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl10"
+                                                        , String "rl8"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl9"
+                                                        , String "rl7"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl17"
+                                                        , String "rl12"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl6"
+                                                        , String "rl11"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl11"
+                                                        , String "rl16"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl13"
+                                                        , String "rl18"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl13"
+                                                        , String "rl12"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl1"
+                                                        , String "rl4"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl2"
+                                                        , String "rl1"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl2"
+                                                        , String "rl5"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl12"
+                                                        , String "rl9"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl7"
+                                                        , String "rl13"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl0"
+                                                        , String "rl6"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl9"
+                                                        , String "rl4"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl2"
+                                                        , String "rl0"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl4"
+                                                        , String "rl5"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl1"
+                                                        , String "rl7"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "Middle"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = True
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "beamDeform"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "27000"
+                                                                    , nvValue = 27000.0
+                                                                    }
+                                                                )
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl16"
+                                                        , String "rl15"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl20"
+                                                        , String "rl30"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl16"
+                                                        , String "rl23"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl18"
+                                                        , String "rl17"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl17"
+                                                        , String "rl28"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl26"
+                                                        , String "rl17"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl18"
+                                                        , String "rl27"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl26"
+                                                        , String "rl24"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl25"
+                                                        , String "rl24"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl25"
+                                                        , String "rl27"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl21"
+                                                        , String "rl16"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl22"
+                                                        , String "rl15"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl15"
+                                                        , String "rl20"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl29"
+                                                        , String "rl27"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl28"
+                                                        , String "rl32"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl29"
+                                                        , String "rl18"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl22"
+                                                        , String "rl24"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl31"
+                                                        , String "rl21"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl28"
+                                                        , String "rl29"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl32"
+                                                        , String "rl33"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl30"
+                                                        , String "rl31"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl33"
+                                                        , String "rl29"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl30"
+                                                        , String "rl22"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl25"
+                                                        , String "rl23"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl32"
+                                                        , String "rl26"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl20"
+                                                        , String "rl21"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl31"
+                                                        , String "rl23"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl20"
+                                                        , String "rl22"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl21"
+                                                        , String "rl23"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl33"
+                                                        , String "rl27"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl23"
+                                                        , String "rl22"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl28"
+                                                        , String "rl26"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl27"
+                                                        , String "rl26"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "Rear end"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = True
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "beamDeform"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "22000"
+                                                                    , nvValue = 22000.0
+                                                                    }
+                                                                )
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl37"
+                                                        , String "rl34"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl39"
+                                                        , String "rl41"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl44"
+                                                        , String "rl46"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl33"
+                                                        , String "rl36"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl46"
+                                                        , String "rl42"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl31"
+                                                        , String "rl34"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl37"
+                                                        , String "rl30"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl49"
+                                                        , String "rl51"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl52"
+                                                        , String "rl50"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl50"
+                                                        , String "rl46"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl49"
+                                                        , String "rl50"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl42"
+                                                        , String "rl34"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl40"
+                                                        , String "rl44"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl40"
+                                                        , String "rl42"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl41"
+                                                        , String "rl45"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl39"
+                                                        , String "rl36"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl36"
+                                                        , String "rl35"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl38"
+                                                        , String "rl35"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl53"
+                                                        , String "rl54"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl52"
+                                                        , String "rl54"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl51"
+                                                        , String "rl52"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl45"
+                                                        , String "rl53"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl54"
+                                                        , String "rl47"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl43"
+                                                        , String "rl36"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl53"
+                                                        , String "rl51"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl34"
+                                                        , String "rl35"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl38"
+                                                        , String "rl37"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl45"
+                                                        , String "rl47"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl41"
+                                                        , String "rl43"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl38"
+                                                        , String "rl39"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl39"
+                                                        , String "rl32"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl47"
+                                                        , String "rl43"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl44"
+                                                        , String "rl49"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl37"
+                                                        , String "rl40"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "Crossing beams"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = True
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "Front end"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = True
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "beamDeform"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "16000"
+                                                                    , nvValue = 16000.0
+                                                                    }
+                                                                )
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl4"
+                                                        , String "rl2"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl0"
+                                                        , String "rl8"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl16"
+                                                        , String "rl10"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl15"
+                                                        , String "rl11"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl10"
+                                                        , String "rl6"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl11"
+                                                        , String "rl8"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl1"
+                                                        , String "rl5"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl4"
+                                                        , String "rl7"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl1"
+                                                        , String "rl9"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl12"
+                                                        , String "rl7"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl3"
+                                                        , String "rl6"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl0"
+                                                        , String "rl5"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl3"
+                                                        , String "rl2"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl13"
+                                                        , String "rl9"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl17"
+                                                        , String "rl13"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl18"
+                                                        , String "rl12"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "Middle"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = True
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "beamDeform"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "6500"
+                                                                    , nvValue = 6500.0
+                                                                    }
+                                                                )
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl16"
+                                                        , String "rl20"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl15"
+                                                        , String "rl23"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl18"
+                                                        , String "rl28"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl18"
+                                                        , String "rl26"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl17"
+                                                        , String "rl27"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl27"
+                                                        , String "rl24"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl26"
+                                                        , String "rl25"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl31"
+                                                        , String "rl20"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl15"
+                                                        , String "rl21"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl16"
+                                                        , String "rl22"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl32"
+                                                        , String "rl29"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl30"
+                                                        , String "rl21"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl23"
+                                                        , String "rl24"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl32"
+                                                        , String "rl27"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl17"
+                                                        , String "rl29"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl33"
+                                                        , String "rl28"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl29"
+                                                        , String "rl26"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl30"
+                                                        , String "rl23"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl33"
+                                                        , String "rl26"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl22"
+                                                        , String "rl25"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl20"
+                                                        , String "rl23"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl28"
+                                                        , String "rl27"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl31"
+                                                        , String "rl22"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl21"
+                                                        , String "rl22"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "Rear end"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = True
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "beamDeform"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "16000"
+                                                                    , nvValue = 16000.0
+                                                                    }
+                                                                )
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl54"
+                                                        , String "rl45"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl32"
+                                                        , String "rl36"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl36"
+                                                        , String "rl41"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl50"
+                                                        , String "rl51"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl31"
+                                                        , String "rl37"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl30"
+                                                        , String "rl34"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl46"
+                                                        , String "rl40"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl53"
+                                                        , String "rl47"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl50"
+                                                        , String "rl44"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl49"
+                                                        , String "rl46"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl37"
+                                                        , String "rl42"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl34"
+                                                        , String "rl40"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl34"
+                                                        , String "rl38"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl33"
+                                                        , String "rl39"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl39"
+                                                        , String "rl35"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl36"
+                                                        , String "rl38"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl53"
+                                                        , String "rl52"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl54"
+                                                        , String "rl51"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl45"
+                                                        , String "rl43"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl47"
+                                                        , String "rl41"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl39"
+                                                        , String "rl43"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl37"
+                                                        , String "rl35"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl49"
+                                                        , String "rl52"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl44"
+                                                        , String "rl42"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "Support beams"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = True
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "Front end"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = True
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "beamDeform"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "19000"
+                                                                    , nvValue = 19000.0
+                                                                    }
+                                                                )
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl8"
+                                                        , String "rl14"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl9"
+                                                        , String "rl14"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl14"
+                                                        , String "rl3"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl10"
+                                                        , String "rl14"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl14"
+                                                        , String "rl13"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl1"
+                                                        , String "rl14"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl0"
+                                                        , String "rl14"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl12"
+                                                        , String "rl14"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl5"
+                                                        , String "rl14"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl14"
+                                                        , String "rl4"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl14"
+                                                        , String "rl6"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl14"
+                                                        , String "rl7"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl14"
+                                                        , String "rl2"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl14"
+                                                        , String "rl11"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "Middle"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = True
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "beamDeform"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "11000"
+                                                                    , nvValue = 11000.0
+                                                                    }
+                                                                )
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl27"
+                                                        , String "rl19"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl26"
+                                                        , String "rl19"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl24"
+                                                        , String "rl19"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl23"
+                                                        , String "rl19"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl20"
+                                                        , String "rl19"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl19"
+                                                        , String "rl16"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl19"
+                                                        , String "rl15"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl31"
+                                                        , String "rl19"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl33"
+                                                        , String "rl19"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl28"
+                                                        , String "rl19"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl19"
+                                                        , String "rl25"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl21"
+                                                        , String "rl19"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl22"
+                                                        , String "rl19"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl19"
+                                                        , String "rl32"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl29"
+                                                        , String "rl19"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl19"
+                                                        , String "rl18"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl19"
+                                                        , String "rl17"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl19"
+                                                        , String "rl30"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "Rear end"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = True
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "beamDeform"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "19000"
+                                                                    , nvValue = 19000.0
+                                                                    }
+                                                                )
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl48"
+                                                        , String "rl51"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl48"
+                                                        , String "rl54"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl45"
+                                                        , String "rl48"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl48"
+                                                        , String "rl50"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl48"
+                                                        , String "rl42"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl48"
+                                                        , String "rl47"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl49"
+                                                        , String "rl48"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl35"
+                                                        , String "rl48"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl48"
+                                                        , String "rl43"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl44"
+                                                        , String "rl48"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl53"
+                                                        , String "rl48"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl52"
+                                                        , String "rl48"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl40"
+                                                        , String "rl48"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl48"
+                                                        , String "rl38"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl41"
+                                                        , String "rl48"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl48"
+                                                        , String "rl46"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Comment
+                                                ( InternalComment
+                                                    { cText = "Front crush"
+                                                    , cMultiline = False
+                                                    , cAssociationDirection = NextNode
+                                                    , cHadNewlineBefore = True
+                                                    }
+                                                )
+                                            , Object
+                                                ( ObjectValue
+                                                    { ovElements =
+                                                        [ ObjectKey
+                                                            ( String "beamDeform"
+                                                            , Number
+                                                                ( NumberValue
+                                                                    { nvText = "8500"
+                                                                    , nvValue = 8500.0
+                                                                    }
+                                                                )
+                                                            )
+                                                        ]
+                                                    , ovTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl17"
+                                                        , String "rl9"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl15"
+                                                        , String "rl8"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            ]
+                                        , avTrailingComma = True
+                                        }
+                                    )
+                                )
+                            , Comment
+                                ( InternalComment
+                                    { cText = "--Collision Triangles--"
+                                    , cMultiline = False
+                                    , cAssociationDirection = NextNode
+                                    , cHadNewlineBefore = False
                                     }
                                 )
-                            )
-                        ]
-                    , Comment
-                        ( InternalComment
-                            { cText = "Front end"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = True
-                            }
-                        )
-                    , Object
-                        [ ObjectKey
-                            ( String "beamDeform"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "20600"
-                                    , nvValue = 20600.0
-                                    }
+                            , ObjectKey
+                                ( String "triangles"
+                                , Array
+                                    ( ArrayValue
+                                        { avElements =
+                                            [ Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "id1:"
+                                                        , String "id2:"
+                                                        , String "id3:"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl5"
+                                                        , String "rl3"
+                                                        , String "rl2"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl0"
+                                                        , String "rl2"
+                                                        , String "rl3"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl5"
+                                                        , String "rl2"
+                                                        , String "rl4"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl1"
+                                                        , String "rl4"
+                                                        , String "rl2"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl4"
+                                                        , String "rl1"
+                                                        , String "rl7"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl4"
+                                                        , String "rl7"
+                                                        , String "rl9"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl7"
+                                                        , String "rl13"
+                                                        , String "rl9"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl12"
+                                                        , String "rl9"
+                                                        , String "rl13"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl12"
+                                                        , String "rl13"
+                                                        , String "rl18"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl18"
+                                                        , String "rl17"
+                                                        , String "rl12"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl3"
+                                                        , String "rl6"
+                                                        , String "rl0"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl3"
+                                                        , String "rl8"
+                                                        , String "rl6"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl10"
+                                                        , String "rl11"
+                                                        , String "rl8"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl6"
+                                                        , String "rl8"
+                                                        , String "rl11"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl10"
+                                                        , String "rl16"
+                                                        , String "rl11"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl16"
+                                                        , String "rl10"
+                                                        , String "rl15"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl15"
+                                                        , String "rl20"
+                                                        , String "rl16"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl21"
+                                                        , String "rl16"
+                                                        , String "rl20"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl30"
+                                                        , String "rl21"
+                                                        , String "rl20"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl31"
+                                                        , String "rl21"
+                                                        , String "rl30"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl17"
+                                                        , String "rl18"
+                                                        , String "rl28"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl29"
+                                                        , String "rl28"
+                                                        , String "rl18"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl32"
+                                                        , String "rl28"
+                                                        , String "rl29"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl33"
+                                                        , String "rl32"
+                                                        , String "rl29"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl32"
+                                                        , String "rl33"
+                                                        , String "rl39"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl39"
+                                                        , String "rl33"
+                                                        , String "rl36"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl36"
+                                                        , String "rl41"
+                                                        , String "rl39"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl43"
+                                                        , String "rl41"
+                                                        , String "rl36"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl45"
+                                                        , String "rl41"
+                                                        , String "rl43"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl47"
+                                                        , String "rl45"
+                                                        , String "rl43"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl53"
+                                                        , String "rl45"
+                                                        , String "rl47"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl54"
+                                                        , String "rl53"
+                                                        , String "rl47"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl54"
+                                                        , String "rl51"
+                                                        , String "rl53"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl51"
+                                                        , String "rl54"
+                                                        , String "rl52"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl52"
+                                                        , String "rl50"
+                                                        , String "rl51"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl50"
+                                                        , String "rl49"
+                                                        , String "rl51"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl46"
+                                                        , String "rl44"
+                                                        , String "rl49"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl50"
+                                                        , String "rl46"
+                                                        , String "rl49"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl46"
+                                                        , String "rl42"
+                                                        , String "rl44"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl44"
+                                                        , String "rl42"
+                                                        , String "rl40"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl34"
+                                                        , String "rl37"
+                                                        , String "rl40"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl42"
+                                                        , String "rl34"
+                                                        , String "rl40"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl34"
+                                                        , String "rl35"
+                                                        , String "rl37"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl35"
+                                                        , String "rl38"
+                                                        , String "rl37"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl35"
+                                                        , String "rl39"
+                                                        , String "rl38"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl39"
+                                                        , String "rl35"
+                                                        , String "rl36"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl30"
+                                                        , String "rl37"
+                                                        , String "rl31"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl37"
+                                                        , String "rl34"
+                                                        , String "rl31"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl16"
+                                                        , String "rl15"
+                                                        , String "rl22"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl16"
+                                                        , String "rl22"
+                                                        , String "rl23"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl23"
+                                                        , String "rl22"
+                                                        , String "rl21"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl21"
+                                                        , String "rl22"
+                                                        , String "rl20"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl27"
+                                                        , String "rl29"
+                                                        , String "rl26"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl29"
+                                                        , String "rl28"
+                                                        , String "rl26"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl18"
+                                                        , String "rl26"
+                                                        , String "rl17"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl27"
+                                                        , String "rl26"
+                                                        , String "rl18"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl24"
+                                                        , String "rl22"
+                                                        , String "rl23"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl27"
+                                                        , String "rl26"
+                                                        , String "rl24"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl24"
+                                                        , String "rl25"
+                                                        , String "rl27"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl24"
+                                                        , String "rl23"
+                                                        , String "rl25"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl30"
+                                                        , String "rl23"
+                                                        , String "rl22"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl30"
+                                                        , String "rl31"
+                                                        , String "rl23"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl26"
+                                                        , String "rl27"
+                                                        , String "rl32"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rl33"
+                                                        , String "rl32"
+                                                        , String "rl27"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            ]
+                                        , avTrailingComma = True
+                                        }
+                                    )
                                 )
-                            )
-                        , ObjectKey
-                            ( String "deformLimit"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "1.1"
-                                    , nvValue = 1.1
-                                    }
+                            , ObjectKey
+                                ( String "flexbodies"
+                                , Array
+                                    ( ArrayValue
+                                        { avElements =
+                                            [ Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "mesh"
+                                                        , String "[group]:"
+                                                        , String "nonFlexMaterials"
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            , Array
+                                                ( ArrayValue
+                                                    { avElements =
+                                                        [ String "rails"
+                                                        , Array
+                                                            ( ArrayValue
+                                                                { avElements =
+                                                                    [ String "chassis_rails" ]
+                                                                , avTrailingComma = False
+                                                                }
+                                                            )
+                                                        ]
+                                                    , avTrailingComma = False
+                                                    }
+                                                )
+                                            ]
+                                        , avTrailingComma = True
+                                        }
+                                    )
                                 )
-                            )
-                        ]
-                    , Array
-                        [ String "rl3"
-                        , String "rl5"
-                        ]
-                    , Array
-                        [ String "rl0"
-                        , String "rl3"
-                        ]
-                    , Array
-                        [ String "rl8"
-                        , String "rl3"
-                        ]
-                    , Array
-                        [ String "rl15"
-                        , String "rl10"
-                        ]
-                    , Array
-                        [ String "rl8"
-                        , String "rl6"
-                        ]
-                    , Array
-                        [ String "rl11"
-                        , String "rl10"
-                        ]
-                    , Array
-                        [ String "rl10"
-                        , String "rl8"
-                        ]
-                    , Array
-                        [ String "rl9"
-                        , String "rl7"
-                        ]
-                    , Array
-                        [ String "rl17"
-                        , String "rl12"
-                        ]
-                    , Array
-                        [ String "rl6"
-                        , String "rl11"
-                        ]
-                    , Array
-                        [ String "rl11"
-                        , String "rl16"
-                        ]
-                    , Array
-                        [ String "rl13"
-                        , String "rl18"
-                        ]
-                    , Array
-                        [ String "rl13"
-                        , String "rl12"
-                        ]
-                    , Array
-                        [ String "rl1"
-                        , String "rl4"
-                        ]
-                    , Array
-                        [ String "rl2"
-                        , String "rl1"
-                        ]
-                    , Array
-                        [ String "rl2"
-                        , String "rl5"
-                        ]
-                    , Array
-                        [ String "rl12"
-                        , String "rl9"
-                        ]
-                    , Array
-                        [ String "rl7"
-                        , String "rl13"
-                        ]
-                    , Array
-                        [ String "rl0"
-                        , String "rl6"
-                        ]
-                    , Array
-                        [ String "rl9"
-                        , String "rl4"
-                        ]
-                    , Array
-                        [ String "rl2"
-                        , String "rl0"
-                        ]
-                    , Array
-                        [ String "rl4"
-                        , String "rl5"
-                        ]
-                    , Array
-                        [ String "rl1"
-                        , String "rl7"
-                        ]
-                    , Comment
-                        ( InternalComment
-                            { cText = "Middle"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = True
-                            }
-                        )
-                    , Object
-                        [ ObjectKey
-                            ( String "beamDeform"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "27000"
-                                    , nvValue = 27000.0
-                                    }
-                                )
-                            )
-                        ]
-                    , Array
-                        [ String "rl16"
-                        , String "rl15"
-                        ]
-                    , Array
-                        [ String "rl20"
-                        , String "rl30"
-                        ]
-                    , Array
-                        [ String "rl16"
-                        , String "rl23"
-                        ]
-                    , Array
-                        [ String "rl18"
-                        , String "rl17"
-                        ]
-                    , Array
-                        [ String "rl17"
-                        , String "rl28"
-                        ]
-                    , Array
-                        [ String "rl26"
-                        , String "rl17"
-                        ]
-                    , Array
-                        [ String "rl18"
-                        , String "rl27"
-                        ]
-                    , Array
-                        [ String "rl26"
-                        , String "rl24"
-                        ]
-                    , Array
-                        [ String "rl25"
-                        , String "rl24"
-                        ]
-                    , Array
-                        [ String "rl25"
-                        , String "rl27"
-                        ]
-                    , Array
-                        [ String "rl21"
-                        , String "rl16"
-                        ]
-                    , Array
-                        [ String "rl22"
-                        , String "rl15"
-                        ]
-                    , Array
-                        [ String "rl15"
-                        , String "rl20"
-                        ]
-                    , Array
-                        [ String "rl29"
-                        , String "rl27"
-                        ]
-                    , Array
-                        [ String "rl28"
-                        , String "rl32"
-                        ]
-                    , Array
-                        [ String "rl29"
-                        , String "rl18"
-                        ]
-                    , Array
-                        [ String "rl22"
-                        , String "rl24"
-                        ]
-                    , Array
-                        [ String "rl31"
-                        , String "rl21"
-                        ]
-                    , Array
-                        [ String "rl28"
-                        , String "rl29"
-                        ]
-                    , Array
-                        [ String "rl32"
-                        , String "rl33"
-                        ]
-                    , Array
-                        [ String "rl30"
-                        , String "rl31"
-                        ]
-                    , Array
-                        [ String "rl33"
-                        , String "rl29"
-                        ]
-                    , Array
-                        [ String "rl30"
-                        , String "rl22"
-                        ]
-                    , Array
-                        [ String "rl25"
-                        , String "rl23"
-                        ]
-                    , Array
-                        [ String "rl32"
-                        , String "rl26"
-                        ]
-                    , Array
-                        [ String "rl20"
-                        , String "rl21"
-                        ]
-                    , Array
-                        [ String "rl31"
-                        , String "rl23"
-                        ]
-                    , Array
-                        [ String "rl20"
-                        , String "rl22"
-                        ]
-                    , Array
-                        [ String "rl21"
-                        , String "rl23"
-                        ]
-                    , Array
-                        [ String "rl33"
-                        , String "rl27"
-                        ]
-                    , Array
-                        [ String "rl23"
-                        , String "rl22"
-                        ]
-                    , Array
-                        [ String "rl28"
-                        , String "rl26"
-                        ]
-                    , Array
-                        [ String "rl27"
-                        , String "rl26"
-                        ]
-                    , Comment
-                        ( InternalComment
-                            { cText = "Rear end"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = True
-                            }
-                        )
-                    , Object
-                        [ ObjectKey
-                            ( String "beamDeform"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "22000"
-                                    , nvValue = 22000.0
-                                    }
-                                )
-                            )
-                        ]
-                    , Array
-                        [ String "rl37"
-                        , String "rl34"
-                        ]
-                    , Array
-                        [ String "rl39"
-                        , String "rl41"
-                        ]
-                    , Array
-                        [ String "rl44"
-                        , String "rl46"
-                        ]
-                    , Array
-                        [ String "rl33"
-                        , String "rl36"
-                        ]
-                    , Array
-                        [ String "rl46"
-                        , String "rl42"
-                        ]
-                    , Array
-                        [ String "rl31"
-                        , String "rl34"
-                        ]
-                    , Array
-                        [ String "rl37"
-                        , String "rl30"
-                        ]
-                    , Array
-                        [ String "rl49"
-                        , String "rl51"
-                        ]
-                    , Array
-                        [ String "rl52"
-                        , String "rl50"
-                        ]
-                    , Array
-                        [ String "rl50"
-                        , String "rl46"
-                        ]
-                    , Array
-                        [ String "rl49"
-                        , String "rl50"
-                        ]
-                    , Array
-                        [ String "rl42"
-                        , String "rl34"
-                        ]
-                    , Array
-                        [ String "rl40"
-                        , String "rl44"
-                        ]
-                    , Array
-                        [ String "rl40"
-                        , String "rl42"
-                        ]
-                    , Array
-                        [ String "rl41"
-                        , String "rl45"
-                        ]
-                    , Array
-                        [ String "rl39"
-                        , String "rl36"
-                        ]
-                    , Array
-                        [ String "rl36"
-                        , String "rl35"
-                        ]
-                    , Array
-                        [ String "rl38"
-                        , String "rl35"
-                        ]
-                    , Array
-                        [ String "rl53"
-                        , String "rl54"
-                        ]
-                    , Array
-                        [ String "rl52"
-                        , String "rl54"
-                        ]
-                    , Array
-                        [ String "rl51"
-                        , String "rl52"
-                        ]
-                    , Array
-                        [ String "rl45"
-                        , String "rl53"
-                        ]
-                    , Array
-                        [ String "rl54"
-                        , String "rl47"
-                        ]
-                    , Array
-                        [ String "rl43"
-                        , String "rl36"
-                        ]
-                    , Array
-                        [ String "rl53"
-                        , String "rl51"
-                        ]
-                    , Array
-                        [ String "rl34"
-                        , String "rl35"
-                        ]
-                    , Array
-                        [ String "rl38"
-                        , String "rl37"
-                        ]
-                    , Array
-                        [ String "rl45"
-                        , String "rl47"
-                        ]
-                    , Array
-                        [ String "rl41"
-                        , String "rl43"
-                        ]
-                    , Array
-                        [ String "rl38"
-                        , String "rl39"
-                        ]
-                    , Array
-                        [ String "rl39"
-                        , String "rl32"
-                        ]
-                    , Array
-                        [ String "rl47"
-                        , String "rl43"
-                        ]
-                    , Array
-                        [ String "rl44"
-                        , String "rl49"
-                        ]
-                    , Array
-                        [ String "rl37"
-                        , String "rl40"
-                        ]
-                    , Comment
-                        ( InternalComment
-                            { cText = "Crossing beams"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = True
-                            }
-                        )
-                    , Comment
-                        ( InternalComment
-                            { cText = "Front end"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = True
-                            }
-                        )
-                    , Object
-                        [ ObjectKey
-                            ( String "beamDeform"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "16000"
-                                    , nvValue = 16000.0
-                                    }
-                                )
-                            )
-                        ]
-                    , Array
-                        [ String "rl4"
-                        , String "rl2"
-                        ]
-                    , Array
-                        [ String "rl0"
-                        , String "rl8"
-                        ]
-                    , Array
-                        [ String "rl16"
-                        , String "rl10"
-                        ]
-                    , Array
-                        [ String "rl15"
-                        , String "rl11"
-                        ]
-                    , Array
-                        [ String "rl10"
-                        , String "rl6"
-                        ]
-                    , Array
-                        [ String "rl11"
-                        , String "rl8"
-                        ]
-                    , Array
-                        [ String "rl1"
-                        , String "rl5"
-                        ]
-                    , Array
-                        [ String "rl4"
-                        , String "rl7"
-                        ]
-                    , Array
-                        [ String "rl1"
-                        , String "rl9"
-                        ]
-                    , Array
-                        [ String "rl12"
-                        , String "rl7"
-                        ]
-                    , Array
-                        [ String "rl3"
-                        , String "rl6"
-                        ]
-                    , Array
-                        [ String "rl0"
-                        , String "rl5"
-                        ]
-                    , Array
-                        [ String "rl3"
-                        , String "rl2"
-                        ]
-                    , Array
-                        [ String "rl13"
-                        , String "rl9"
-                        ]
-                    , Array
-                        [ String "rl17"
-                        , String "rl13"
-                        ]
-                    , Array
-                        [ String "rl18"
-                        , String "rl12"
-                        ]
-                    , Comment
-                        ( InternalComment
-                            { cText = "Middle"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = True
-                            }
-                        )
-                    , Object
-                        [ ObjectKey
-                            ( String "beamDeform"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "6500"
-                                    , nvValue = 6500.0
-                                    }
-                                )
-                            )
-                        ]
-                    , Array
-                        [ String "rl16"
-                        , String "rl20"
-                        ]
-                    , Array
-                        [ String "rl15"
-                        , String "rl23"
-                        ]
-                    , Array
-                        [ String "rl18"
-                        , String "rl28"
-                        ]
-                    , Array
-                        [ String "rl18"
-                        , String "rl26"
-                        ]
-                    , Array
-                        [ String "rl17"
-                        , String "rl27"
-                        ]
-                    , Array
-                        [ String "rl27"
-                        , String "rl24"
-                        ]
-                    , Array
-                        [ String "rl26"
-                        , String "rl25"
-                        ]
-                    , Array
-                        [ String "rl31"
-                        , String "rl20"
-                        ]
-                    , Array
-                        [ String "rl15"
-                        , String "rl21"
-                        ]
-                    , Array
-                        [ String "rl16"
-                        , String "rl22"
-                        ]
-                    , Array
-                        [ String "rl32"
-                        , String "rl29"
-                        ]
-                    , Array
-                        [ String "rl30"
-                        , String "rl21"
-                        ]
-                    , Array
-                        [ String "rl23"
-                        , String "rl24"
-                        ]
-                    , Array
-                        [ String "rl32"
-                        , String "rl27"
-                        ]
-                    , Array
-                        [ String "rl17"
-                        , String "rl29"
-                        ]
-                    , Array
-                        [ String "rl33"
-                        , String "rl28"
-                        ]
-                    , Array
-                        [ String "rl29"
-                        , String "rl26"
-                        ]
-                    , Array
-                        [ String "rl30"
-                        , String "rl23"
-                        ]
-                    , Array
-                        [ String "rl33"
-                        , String "rl26"
-                        ]
-                    , Array
-                        [ String "rl22"
-                        , String "rl25"
-                        ]
-                    , Array
-                        [ String "rl20"
-                        , String "rl23"
-                        ]
-                    , Array
-                        [ String "rl28"
-                        , String "rl27"
-                        ]
-                    , Array
-                        [ String "rl31"
-                        , String "rl22"
-                        ]
-                    , Array
-                        [ String "rl21"
-                        , String "rl22"
-                        ]
-                    , Comment
-                        ( InternalComment
-                            { cText = "Rear end"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = True
-                            }
-                        )
-                    , Object
-                        [ ObjectKey
-                            ( String "beamDeform"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "16000"
-                                    , nvValue = 16000.0
-                                    }
-                                )
-                            )
-                        ]
-                    , Array
-                        [ String "rl54"
-                        , String "rl45"
-                        ]
-                    , Array
-                        [ String "rl32"
-                        , String "rl36"
-                        ]
-                    , Array
-                        [ String "rl36"
-                        , String "rl41"
-                        ]
-                    , Array
-                        [ String "rl50"
-                        , String "rl51"
-                        ]
-                    , Array
-                        [ String "rl31"
-                        , String "rl37"
-                        ]
-                    , Array
-                        [ String "rl30"
-                        , String "rl34"
-                        ]
-                    , Array
-                        [ String "rl46"
-                        , String "rl40"
-                        ]
-                    , Array
-                        [ String "rl53"
-                        , String "rl47"
-                        ]
-                    , Array
-                        [ String "rl50"
-                        , String "rl44"
-                        ]
-                    , Array
-                        [ String "rl49"
-                        , String "rl46"
-                        ]
-                    , Array
-                        [ String "rl37"
-                        , String "rl42"
-                        ]
-                    , Array
-                        [ String "rl34"
-                        , String "rl40"
-                        ]
-                    , Array
-                        [ String "rl34"
-                        , String "rl38"
-                        ]
-                    , Array
-                        [ String "rl33"
-                        , String "rl39"
-                        ]
-                    , Array
-                        [ String "rl39"
-                        , String "rl35"
-                        ]
-                    , Array
-                        [ String "rl36"
-                        , String "rl38"
-                        ]
-                    , Array
-                        [ String "rl53"
-                        , String "rl52"
-                        ]
-                    , Array
-                        [ String "rl54"
-                        , String "rl51"
-                        ]
-                    , Array
-                        [ String "rl45"
-                        , String "rl43"
-                        ]
-                    , Array
-                        [ String "rl47"
-                        , String "rl41"
-                        ]
-                    , Array
-                        [ String "rl39"
-                        , String "rl43"
-                        ]
-                    , Array
-                        [ String "rl37"
-                        , String "rl35"
-                        ]
-                    , Array
-                        [ String "rl49"
-                        , String "rl52"
-                        ]
-                    , Array
-                        [ String "rl44"
-                        , String "rl42"
-                        ]
-                    , Comment
-                        ( InternalComment
-                            { cText = "Support beams"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = True
-                            }
-                        )
-                    , Comment
-                        ( InternalComment
-                            { cText = "Front end"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = True
-                            }
-                        )
-                    , Object
-                        [ ObjectKey
-                            ( String "beamDeform"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "19000"
-                                    , nvValue = 19000.0
-                                    }
-                                )
-                            )
-                        ]
-                    , Array
-                        [ String "rl8"
-                        , String "rl14"
-                        ]
-                    , Array
-                        [ String "rl9"
-                        , String "rl14"
-                        ]
-                    , Array
-                        [ String "rl14"
-                        , String "rl3"
-                        ]
-                    , Array
-                        [ String "rl10"
-                        , String "rl14"
-                        ]
-                    , Array
-                        [ String "rl14"
-                        , String "rl13"
-                        ]
-                    , Array
-                        [ String "rl1"
-                        , String "rl14"
-                        ]
-                    , Array
-                        [ String "rl0"
-                        , String "rl14"
-                        ]
-                    , Array
-                        [ String "rl12"
-                        , String "rl14"
-                        ]
-                    , Array
-                        [ String "rl5"
-                        , String "rl14"
-                        ]
-                    , Array
-                        [ String "rl14"
-                        , String "rl4"
-                        ]
-                    , Array
-                        [ String "rl14"
-                        , String "rl6"
-                        ]
-                    , Array
-                        [ String "rl14"
-                        , String "rl7"
-                        ]
-                    , Array
-                        [ String "rl14"
-                        , String "rl2"
-                        ]
-                    , Array
-                        [ String "rl14"
-                        , String "rl11"
-                        ]
-                    , Comment
-                        ( InternalComment
-                            { cText = "Middle"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = True
-                            }
-                        )
-                    , Object
-                        [ ObjectKey
-                            ( String "beamDeform"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "11000"
-                                    , nvValue = 11000.0
-                                    }
-                                )
-                            )
-                        ]
-                    , Array
-                        [ String "rl27"
-                        , String "rl19"
-                        ]
-                    , Array
-                        [ String "rl26"
-                        , String "rl19"
-                        ]
-                    , Array
-                        [ String "rl24"
-                        , String "rl19"
-                        ]
-                    , Array
-                        [ String "rl23"
-                        , String "rl19"
-                        ]
-                    , Array
-                        [ String "rl20"
-                        , String "rl19"
-                        ]
-                    , Array
-                        [ String "rl19"
-                        , String "rl16"
-                        ]
-                    , Array
-                        [ String "rl19"
-                        , String "rl15"
-                        ]
-                    , Array
-                        [ String "rl31"
-                        , String "rl19"
-                        ]
-                    , Array
-                        [ String "rl33"
-                        , String "rl19"
-                        ]
-                    , Array
-                        [ String "rl28"
-                        , String "rl19"
-                        ]
-                    , Array
-                        [ String "rl19"
-                        , String "rl25"
-                        ]
-                    , Array
-                        [ String "rl21"
-                        , String "rl19"
-                        ]
-                    , Array
-                        [ String "rl22"
-                        , String "rl19"
-                        ]
-                    , Array
-                        [ String "rl19"
-                        , String "rl32"
-                        ]
-                    , Array
-                        [ String "rl29"
-                        , String "rl19"
-                        ]
-                    , Array
-                        [ String "rl19"
-                        , String "rl18"
-                        ]
-                    , Array
-                        [ String "rl19"
-                        , String "rl17"
-                        ]
-                    , Array
-                        [ String "rl19"
-                        , String "rl30"
-                        ]
-                    , Comment
-                        ( InternalComment
-                            { cText = "Rear end"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = True
-                            }
-                        )
-                    , Object
-                        [ ObjectKey
-                            ( String "beamDeform"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "19000"
-                                    , nvValue = 19000.0
-                                    }
-                                )
-                            )
-                        ]
-                    , Array
-                        [ String "rl48"
-                        , String "rl51"
-                        ]
-                    , Array
-                        [ String "rl48"
-                        , String "rl54"
-                        ]
-                    , Array
-                        [ String "rl45"
-                        , String "rl48"
-                        ]
-                    , Array
-                        [ String "rl48"
-                        , String "rl50"
-                        ]
-                    , Array
-                        [ String "rl48"
-                        , String "rl42"
-                        ]
-                    , Array
-                        [ String "rl48"
-                        , String "rl47"
-                        ]
-                    , Array
-                        [ String "rl49"
-                        , String "rl48"
-                        ]
-                    , Array
-                        [ String "rl35"
-                        , String "rl48"
-                        ]
-                    , Array
-                        [ String "rl48"
-                        , String "rl43"
-                        ]
-                    , Array
-                        [ String "rl44"
-                        , String "rl48"
-                        ]
-                    , Array
-                        [ String "rl53"
-                        , String "rl48"
-                        ]
-                    , Array
-                        [ String "rl52"
-                        , String "rl48"
-                        ]
-                    , Array
-                        [ String "rl40"
-                        , String "rl48"
-                        ]
-                    , Array
-                        [ String "rl48"
-                        , String "rl38"
-                        ]
-                    , Array
-                        [ String "rl41"
-                        , String "rl48"
-                        ]
-                    , Array
-                        [ String "rl48"
-                        , String "rl46"
-                        ]
-                    , Comment
-                        ( InternalComment
-                            { cText = "Front crush"
-                            , cMultiline = False
-                            , cAssociationDirection = NextNode
-                            , cHadNewlineBefore = True
-                            }
-                        )
-                    , Object
-                        [ ObjectKey
-                            ( String "beamDeform"
-                            , Number
-                                ( NumberValue
-                                    { nvText = "8500"
-                                    , nvValue = 8500.0
-                                    }
-                                )
-                            )
-                        ]
-                    , Array
-                        [ String "rl17"
-                        , String "rl9"
-                        ]
-                    , Array
-                        [ String "rl15"
-                        , String "rl8"
-                        ]
-                    ]
-                )
-            , Comment
-                ( InternalComment
-                    { cText = "--Collision Triangles--"
-                    , cMultiline = False
-                    , cAssociationDirection = NextNode
-                    , cHadNewlineBefore = False
-                    }
-                )
-            , ObjectKey
-                ( String "triangles"
-                , Array
-                    [ Array
-                        [ String "id1:"
-                        , String "id2:"
-                        , String "id3:"
-                        ]
-                    , Array
-                        [ String "rl5"
-                        , String "rl3"
-                        , String "rl2"
-                        ]
-                    , Array
-                        [ String "rl0"
-                        , String "rl2"
-                        , String "rl3"
-                        ]
-                    , Array
-                        [ String "rl5"
-                        , String "rl2"
-                        , String "rl4"
-                        ]
-                    , Array
-                        [ String "rl1"
-                        , String "rl4"
-                        , String "rl2"
-                        ]
-                    , Array
-                        [ String "rl4"
-                        , String "rl1"
-                        , String "rl7"
-                        ]
-                    , Array
-                        [ String "rl4"
-                        , String "rl7"
-                        , String "rl9"
-                        ]
-                    , Array
-                        [ String "rl7"
-                        , String "rl13"
-                        , String "rl9"
-                        ]
-                    , Array
-                        [ String "rl12"
-                        , String "rl9"
-                        , String "rl13"
-                        ]
-                    , Array
-                        [ String "rl12"
-                        , String "rl13"
-                        , String "rl18"
-                        ]
-                    , Array
-                        [ String "rl18"
-                        , String "rl17"
-                        , String "rl12"
-                        ]
-                    , Array
-                        [ String "rl3"
-                        , String "rl6"
-                        , String "rl0"
-                        ]
-                    , Array
-                        [ String "rl3"
-                        , String "rl8"
-                        , String "rl6"
-                        ]
-                    , Array
-                        [ String "rl10"
-                        , String "rl11"
-                        , String "rl8"
-                        ]
-                    , Array
-                        [ String "rl6"
-                        , String "rl8"
-                        , String "rl11"
-                        ]
-                    , Array
-                        [ String "rl10"
-                        , String "rl16"
-                        , String "rl11"
-                        ]
-                    , Array
-                        [ String "rl16"
-                        , String "rl10"
-                        , String "rl15"
-                        ]
-                    , Array
-                        [ String "rl15"
-                        , String "rl20"
-                        , String "rl16"
-                        ]
-                    , Array
-                        [ String "rl21"
-                        , String "rl16"
-                        , String "rl20"
-                        ]
-                    , Array
-                        [ String "rl30"
-                        , String "rl21"
-                        , String "rl20"
-                        ]
-                    , Array
-                        [ String "rl31"
-                        , String "rl21"
-                        , String "rl30"
-                        ]
-                    , Array
-                        [ String "rl17"
-                        , String "rl18"
-                        , String "rl28"
-                        ]
-                    , Array
-                        [ String "rl29"
-                        , String "rl28"
-                        , String "rl18"
-                        ]
-                    , Array
-                        [ String "rl32"
-                        , String "rl28"
-                        , String "rl29"
-                        ]
-                    , Array
-                        [ String "rl33"
-                        , String "rl32"
-                        , String "rl29"
-                        ]
-                    , Array
-                        [ String "rl32"
-                        , String "rl33"
-                        , String "rl39"
-                        ]
-                    , Array
-                        [ String "rl39"
-                        , String "rl33"
-                        , String "rl36"
-                        ]
-                    , Array
-                        [ String "rl36"
-                        , String "rl41"
-                        , String "rl39"
-                        ]
-                    , Array
-                        [ String "rl43"
-                        , String "rl41"
-                        , String "rl36"
-                        ]
-                    , Array
-                        [ String "rl45"
-                        , String "rl41"
-                        , String "rl43"
-                        ]
-                    , Array
-                        [ String "rl47"
-                        , String "rl45"
-                        , String "rl43"
-                        ]
-                    , Array
-                        [ String "rl53"
-                        , String "rl45"
-                        , String "rl47"
-                        ]
-                    , Array
-                        [ String "rl54"
-                        , String "rl53"
-                        , String "rl47"
-                        ]
-                    , Array
-                        [ String "rl54"
-                        , String "rl51"
-                        , String "rl53"
-                        ]
-                    , Array
-                        [ String "rl51"
-                        , String "rl54"
-                        , String "rl52"
-                        ]
-                    , Array
-                        [ String "rl52"
-                        , String "rl50"
-                        , String "rl51"
-                        ]
-                    , Array
-                        [ String "rl50"
-                        , String "rl49"
-                        , String "rl51"
-                        ]
-                    , Array
-                        [ String "rl46"
-                        , String "rl44"
-                        , String "rl49"
-                        ]
-                    , Array
-                        [ String "rl50"
-                        , String "rl46"
-                        , String "rl49"
-                        ]
-                    , Array
-                        [ String "rl46"
-                        , String "rl42"
-                        , String "rl44"
-                        ]
-                    , Array
-                        [ String "rl44"
-                        , String "rl42"
-                        , String "rl40"
-                        ]
-                    , Array
-                        [ String "rl34"
-                        , String "rl37"
-                        , String "rl40"
-                        ]
-                    , Array
-                        [ String "rl42"
-                        , String "rl34"
-                        , String "rl40"
-                        ]
-                    , Array
-                        [ String "rl34"
-                        , String "rl35"
-                        , String "rl37"
-                        ]
-                    , Array
-                        [ String "rl35"
-                        , String "rl38"
-                        , String "rl37"
-                        ]
-                    , Array
-                        [ String "rl35"
-                        , String "rl39"
-                        , String "rl38"
-                        ]
-                    , Array
-                        [ String "rl39"
-                        , String "rl35"
-                        , String "rl36"
-                        ]
-                    , Array
-                        [ String "rl30"
-                        , String "rl37"
-                        , String "rl31"
-                        ]
-                    , Array
-                        [ String "rl37"
-                        , String "rl34"
-                        , String "rl31"
-                        ]
-                    , Array
-                        [ String "rl16"
-                        , String "rl15"
-                        , String "rl22"
-                        ]
-                    , Array
-                        [ String "rl16"
-                        , String "rl22"
-                        , String "rl23"
-                        ]
-                    , Array
-                        [ String "rl23"
-                        , String "rl22"
-                        , String "rl21"
-                        ]
-                    , Array
-                        [ String "rl21"
-                        , String "rl22"
-                        , String "rl20"
-                        ]
-                    , Array
-                        [ String "rl27"
-                        , String "rl29"
-                        , String "rl26"
-                        ]
-                    , Array
-                        [ String "rl29"
-                        , String "rl28"
-                        , String "rl26"
-                        ]
-                    , Array
-                        [ String "rl18"
-                        , String "rl26"
-                        , String "rl17"
-                        ]
-                    , Array
-                        [ String "rl27"
-                        , String "rl26"
-                        , String "rl18"
-                        ]
-                    , Array
-                        [ String "rl24"
-                        , String "rl22"
-                        , String "rl23"
-                        ]
-                    , Array
-                        [ String "rl27"
-                        , String "rl26"
-                        , String "rl24"
-                        ]
-                    , Array
-                        [ String "rl24"
-                        , String "rl25"
-                        , String "rl27"
-                        ]
-                    , Array
-                        [ String "rl24"
-                        , String "rl23"
-                        , String "rl25"
-                        ]
-                    , Array
-                        [ String "rl30"
-                        , String "rl23"
-                        , String "rl22"
-                        ]
-                    , Array
-                        [ String "rl30"
-                        , String "rl31"
-                        , String "rl23"
-                        ]
-                    , Array
-                        [ String "rl26"
-                        , String "rl27"
-                        , String "rl32"
-                        ]
-                    , Array
-                        [ String "rl33"
-                        , String "rl32"
-                        , String "rl27"
-                        ]
-                    ]
-                )
-            , ObjectKey
-                ( String "flexbodies"
-                , Array
-                    [ Array
-                        [ String "mesh"
-                        , String "[group]:"
-                        , String "nonFlexMaterials"
-                        ]
-                    , Array
-                        [ String "rails"
-                        , Array
-                            [ String "chassis_rails" ]
-                        ]
-                    ]
+                            ]
+                        , ovTrailingComma = True
+                        }
+                    )
                 )
             ]
-        )
-    ]
+        , ovTrailingComma = True
+        }
+    )

--- a/examples/ast/jbfl/complex.hs
+++ b/examples/ast/jbfl/complex.hs
@@ -1062,5 +1062,15 @@ RuleSet
                     )
                 ]
             )
+        ,
+            ( NodePattern
+                ( fromList [ AnyObjectKey ] )
+            , fromList
+                [
+                    ( SomeKey TrailingComma
+                    , SomeProperty TrailingComma None
+                    )
+                ]
+            )
         ]
     )

--- a/examples/formatted_jbeam/fender-complex-jbfl.jbeam
+++ b/examples/formatted_jbeam/fender-complex-jbfl.jbeam
@@ -2,7 +2,7 @@
   "cot_fender" : {
     "information" : {
       "authors" : "gittarrgy01",
-      "name"    : "Fenders",
+      "name"    : "Fenders"
     },
     "sounds" : {
       "impactMetal"   : "event:>Destruction>Props>fender_metal",
@@ -55,7 +55,7 @@
       {"nodeWeight" : 1.2},
       {"group" : ""},
       ["bfsl",  0.684,  -1.079, 0.507],
-      ["bfsr",  -0.623, -1.064, 0.507],
+      ["bfsr",  -0.623, -1.064, 0.507]
     ],
     "beams" : [
       ["id1:",  "id2:"],
@@ -272,7 +272,7 @@
       ["bfr8",  "mbr0"],
       ["bfr9",  "mbr1"],
       ["bfr10", "mbr2"],
-      {"breakGroup" : "", "breakGroupType" : "", "beamType" : "|NORMAL"},
+      {"breakGroup" : "", "breakGroupType" : "", "beamType" : "|NORMAL"}
     ],
     "triangles" : [
       ["id1:",  "id2:",  "id3:"],
@@ -293,14 +293,14 @@
       ["bfr10", "bfr6",  "bfr7"],
       ["bfr9",  "bfr6",  "bfr10"],
       ["bfr9",  "bfr8",  "bfr6"],
-      ["bfr5",  "bfr6",  "bfr8"],
+      ["bfr5",  "bfr6",  "bfr8"]
     ],
     "flexbodies" : [
       ["mesh", "[group]:", "nonFlexMaterials"],
       ["impala_fender_l", ["cot_fender_l"]],
       ["impala_fender_inter_l", ["cot_fender_l"]],
       ["impala_fender_r", ["cot_fender_r"]],
-      ["impala_fender_inter_r", ["cot_fender_r"]],
-    ],
+      ["impala_fender_inter_r", ["cot_fender_r"]]
+    ]
   },
 }

--- a/examples/formatted_jbeam/fender-complex-jbfl.jbeam
+++ b/examples/formatted_jbeam/fender-complex-jbfl.jbeam
@@ -302,5 +302,5 @@
       ["impala_fender_r", ["cot_fender_r"]],
       ["impala_fender_inter_r", ["cot_fender_r"]]
     ]
-  },
+  }
 }

--- a/examples/formatted_jbeam/fender-complex-jbfl.jbeam
+++ b/examples/formatted_jbeam/fender-complex-jbfl.jbeam
@@ -2,7 +2,7 @@
   "cot_fender" : {
     "information" : {
       "authors" : "gittarrgy01",
-      "name"    : "Fenders"
+      "name"    : "Fenders",
     },
     "sounds" : {
       "impactMetal"   : "event:>Destruction>Props>fender_metal",
@@ -55,7 +55,7 @@
       {"nodeWeight" : 1.2},
       {"group" : ""},
       ["bfsl",  0.684,  -1.079, 0.507],
-      ["bfsr",  -0.623, -1.064, 0.507]
+      ["bfsr",  -0.623, -1.064, 0.507],
     ],
     "beams" : [
       ["id1:",  "id2:"],
@@ -272,7 +272,7 @@
       ["bfr8",  "mbr0"],
       ["bfr9",  "mbr1"],
       ["bfr10", "mbr2"],
-      {"breakGroup" : "", "breakGroupType" : "", "beamType" : "|NORMAL"}
+      {"breakGroup" : "", "breakGroupType" : "", "beamType" : "|NORMAL"},
     ],
     "triangles" : [
       ["id1:",  "id2:",  "id3:"],
@@ -293,14 +293,14 @@
       ["bfr10", "bfr6",  "bfr7"],
       ["bfr9",  "bfr6",  "bfr10"],
       ["bfr9",  "bfr8",  "bfr6"],
-      ["bfr5",  "bfr6",  "bfr8"]
+      ["bfr5",  "bfr6",  "bfr8"],
     ],
     "flexbodies" : [
       ["mesh", "[group]:", "nonFlexMaterials"],
       ["impala_fender_l", ["cot_fender_l"]],
       ["impala_fender_inter_l", ["cot_fender_l"]],
       ["impala_fender_r", ["cot_fender_r"]],
-      ["impala_fender_inter_r", ["cot_fender_r"]]
-    ]
-  }
+      ["impala_fender_inter_r", ["cot_fender_r"]],
+    ],
+  },
 }

--- a/examples/formatted_jbeam/fender-minimal-jbfl.jbeam
+++ b/examples/formatted_jbeam/fender-minimal-jbfl.jbeam
@@ -2,7 +2,7 @@
   "cot_fender" : {
     "information" : {
       "authors" : "gittarrgy01",
-      "name"    : "Fenders"
+      "name"    : "Fenders",
     },
     "sounds" : {
       "impactMetal"   : "event:>Destruction>Props>fender_metal",
@@ -55,7 +55,7 @@
       {"nodeWeight" : 1.2},
       {"group" : ""},
       ["bfsl",  0.684,  -1.079, 0.507],
-      ["bfsr",  -0.623, -1.064, 0.507]
+      ["bfsr",  -0.623, -1.064, 0.507],
     ],
     "beams" : [
       ["id1:",  "id2:"],
@@ -272,7 +272,7 @@
       ["bfr8",  "mbr0"],
       ["bfr9",  "mbr1"],
       ["bfr10", "mbr2"],
-      {"breakGroup" : "", "breakGroupType" : "", "beamType" : "|NORMAL"}
+      {"breakGroup" : "", "breakGroupType" : "", "beamType" : "|NORMAL"},
     ],
     "triangles" : [
       ["id1:",  "id2:",  "id3:"],
@@ -293,14 +293,14 @@
       ["bfr10", "bfr6",  "bfr7"],
       ["bfr9",  "bfr6",  "bfr10"],
       ["bfr9",  "bfr8",  "bfr6"],
-      ["bfr5",  "bfr6",  "bfr8"]
+      ["bfr5",  "bfr6",  "bfr8"],
     ],
     "flexbodies" : [
       ["mesh", "[group]:", "nonFlexMaterials"],
       ["impala_fender_l", ["cot_fender_l"]],
       ["impala_fender_inter_l", ["cot_fender_l"]],
       ["impala_fender_r", ["cot_fender_r"]],
-      ["impala_fender_inter_r", ["cot_fender_r"]]
-    ]
-  }
+      ["impala_fender_inter_r", ["cot_fender_r"]],
+    ],
+  },
 }

--- a/examples/formatted_jbeam/suspension-complex-jbfl.jbeam
+++ b/examples/formatted_jbeam/suspension-complex-jbfl.jbeam
@@ -2,7 +2,7 @@
   "chassis_rails" : {
     "information" : {
       "authors" : "gittarrgy01",
-      "name"    : ""
+      "name"    : "",
     },
     "slotType" : "main",
     /* The purpose of this file is prove that moving metadata along with vertices when
@@ -72,7 +72,7 @@
       ["rl52", 0.053,  2.284,  0.441],
       ["rl53", -0.451, 2.284,  0.364],
       ["rl54", -0.451, 2.284,  0.447],
-      {"group" : ""}
+      {"group" : ""},
     ],
     // --Beams--
     "beams" : [
@@ -318,7 +318,7 @@
       // Front crush
       {"beamDeform" : 8500},
       ["rl17", "rl9"],
-      ["rl15", "rl8"]
+      ["rl15", "rl8"],
     ],
     // --Collision Triangles--
     "triangles" : [
@@ -386,11 +386,11 @@
       ["rl30", "rl23", "rl22"],
       ["rl30", "rl31", "rl23"],
       ["rl26", "rl27", "rl32"],
-      ["rl33", "rl32", "rl27"]
+      ["rl33", "rl32", "rl27"],
     ],
     "flexbodies" : [
       ["mesh", "[group]:", "nonFlexMaterials"],
-      ["rails", ["chassis_rails"]]
-    ]
-  }
+      ["rails", ["chassis_rails"]],
+    ],
+  },
 }

--- a/examples/formatted_jbeam/suspension-complex-jbfl.jbeam
+++ b/examples/formatted_jbeam/suspension-complex-jbfl.jbeam
@@ -2,7 +2,7 @@
   "chassis_rails" : {
     "information" : {
       "authors" : "gittarrgy01",
-      "name"    : "",
+      "name"    : ""
     },
     "slotType" : "main",
     /* The purpose of this file is prove that moving metadata along with vertices when
@@ -72,7 +72,7 @@
       ["rl52", 0.053,  2.284,  0.441],
       ["rl53", -0.451, 2.284,  0.364],
       ["rl54", -0.451, 2.284,  0.447],
-      {"group" : ""},
+      {"group" : ""}
     ],
     // --Beams--
     "beams" : [
@@ -318,7 +318,7 @@
       // Front crush
       {"beamDeform" : 8500},
       ["rl17", "rl9"],
-      ["rl15", "rl8"],
+      ["rl15", "rl8"]
     ],
     // --Collision Triangles--
     "triangles" : [
@@ -386,11 +386,11 @@
       ["rl30", "rl23", "rl22"],
       ["rl30", "rl31", "rl23"],
       ["rl26", "rl27", "rl32"],
-      ["rl33", "rl32", "rl27"],
+      ["rl33", "rl32", "rl27"]
     ],
     "flexbodies" : [
       ["mesh", "[group]:", "nonFlexMaterials"],
-      ["rails", ["chassis_rails"]],
-    ],
+      ["rails", ["chassis_rails"]]
+    ]
   },
 }

--- a/examples/formatted_jbeam/suspension-complex-jbfl.jbeam
+++ b/examples/formatted_jbeam/suspension-complex-jbfl.jbeam
@@ -392,5 +392,5 @@
       ["mesh", "[group]:", "nonFlexMaterials"],
       ["rails", ["chassis_rails"]]
     ]
-  },
+  }
 }

--- a/examples/formatted_jbeam/suspension-minimal-jbfl.jbeam
+++ b/examples/formatted_jbeam/suspension-minimal-jbfl.jbeam
@@ -2,7 +2,7 @@
   "chassis_rails" : {
     "information" : {
       "authors" : "gittarrgy01",
-      "name"    : ""
+      "name"    : "",
     },
     "slotType" : "main",
     /* The purpose of this file is prove that moving metadata along with vertices when
@@ -72,7 +72,7 @@
       ["rl52", 0.053,  2.284,  0.441],
       ["rl53", -0.451, 2.284,  0.364],
       ["rl54", -0.451, 2.284,  0.447],
-      {"group" : ""}
+      {"group" : ""},
     ],
     // --Beams--
     "beams" : [
@@ -318,7 +318,7 @@
       // Front crush
       {"beamDeform" : 8500},
       ["rl17", "rl9"],
-      ["rl15", "rl8"]
+      ["rl15", "rl8"],
     ],
     // --Collision Triangles--
     "triangles" : [
@@ -386,11 +386,11 @@
       ["rl30", "rl23", "rl22"],
       ["rl30", "rl31", "rl23"],
       ["rl26", "rl27", "rl32"],
-      ["rl33", "rl32", "rl27"]
+      ["rl33", "rl32", "rl27"],
     ],
     "flexbodies" : [
       ["mesh", "[group]:", "nonFlexMaterials"],
-      ["rails", ["chassis_rails"]]
-    ]
-  }
+      ["rails", ["chassis_rails"]],
+    ],
+  },
 }

--- a/examples/jbfl/complex.jbfl
+++ b/examples/jbfl/complex.jbfl
@@ -1,3 +1,7 @@
+.* {
+    TrailingComma : None;
+}
+
 /* Default formatting for all numeric node values */
 .*.nodes[*][*] {
     PadDecimals: 3;  // Show 3 decimal places for uniformity

--- a/examples/transformed_jbeam/fender-after-frame-cfg-default.jbeam
+++ b/examples/transformed_jbeam/fender-after-frame-cfg-default.jbeam
@@ -2,7 +2,7 @@
   "cot_fender" : {
     "information" : {
       "authors" : "gittarrgy01",
-      "name"    : "Fenders"
+      "name"    : "Fenders",
     },
     "sounds" : {
       "impactMetal"   : "event:>Destruction>Props>fender_metal",
@@ -55,7 +55,7 @@
       {"nodeWeight" : 1.2},
       {"group" : ""},
       ["bfsl",  0.684,  -1.079, 0.507],
-      ["bfsr",  -0.623, -1.064, 0.507]
+      ["bfsr",  -0.623, -1.064, 0.507],
     ],
     "beams" : [
       ["id1:",  "id2:"],
@@ -272,7 +272,7 @@
       ["bfr8",  "mbr0"],
       ["bfr9",  "mbr1"],
       ["bfr10", "mbr2"],
-      {"breakGroup" : "", "breakGroupType" : "", "beamType" : "|NORMAL"}
+      {"breakGroup" : "", "breakGroupType" : "", "beamType" : "|NORMAL"},
     ],
     "triangles" : [
       ["id1:",  "id2:",  "id3:"],
@@ -293,14 +293,14 @@
       ["bfr10", "bfr6",  "bfr7"],
       ["bfr9",  "bfr6",  "bfr10"],
       ["bfr9",  "bfr8",  "bfr6"],
-      ["bfr5",  "bfr6",  "bfr8"]
+      ["bfr5",  "bfr6",  "bfr8"],
     ],
     "flexbodies" : [
       ["mesh", "[group]:", "nonFlexMaterials"],
       ["impala_fender_l", ["cot_fender_l"]],
       ["impala_fender_inter_l", ["cot_fender_l"]],
       ["impala_fender_r", ["cot_fender_r"]],
-      ["impala_fender_inter_r", ["cot_fender_r"]]
-    ]
-  }
+      ["impala_fender_inter_r", ["cot_fender_r"]],
+    ],
+  },
 }

--- a/examples/transformed_jbeam/fender-after-frame-cfg-example.jbeam
+++ b/examples/transformed_jbeam/fender-after-frame-cfg-example.jbeam
@@ -2,7 +2,7 @@
   "cot_fender" : {
     "information" : {
       "authors" : "gittarrgy01",
-      "name"    : "Fenders"
+      "name"    : "Fenders",
     },
     "sounds" : {
       "impactMetal"   : "event:>Destruction>Props>fender_metal",
@@ -55,7 +55,7 @@
       {"nodeWeight" : 1.2},
       {"group" : ""},
       ["bfsl",  0.684,  -1.079, 0.507],
-      ["bfsr",  -0.623, -1.064, 0.507]
+      ["bfsr",  -0.623, -1.064, 0.507],
     ],
     "beams" : [
       ["id1:",  "id2:"],
@@ -272,7 +272,7 @@
       ["bfr8",  "mbr0"],
       ["bfr9",  "mbr1"],
       ["bfr10", "mbr2"],
-      {"breakGroup" : "", "breakGroupType" : "", "beamType" : "|NORMAL"}
+      {"breakGroup" : "", "breakGroupType" : "", "beamType" : "|NORMAL"},
     ],
     "triangles" : [
       ["id1:",  "id2:",  "id3:"],
@@ -293,14 +293,14 @@
       ["bfr10", "bfr6",  "bfr7"],
       ["bfr9",  "bfr6",  "bfr10"],
       ["bfr9",  "bfr8",  "bfr6"],
-      ["bfr5",  "bfr6",  "bfr8"]
+      ["bfr5",  "bfr6",  "bfr8"],
     ],
     "flexbodies" : [
       ["mesh", "[group]:", "nonFlexMaterials"],
       ["impala_fender_l", ["cot_fender_l"]],
       ["impala_fender_inter_l", ["cot_fender_l"]],
       ["impala_fender_r", ["cot_fender_r"]],
-      ["impala_fender_inter_r", ["cot_fender_r"]]
-    ]
-  }
+      ["impala_fender_inter_r", ["cot_fender_r"]],
+    ],
+  },
 }

--- a/examples/transformed_jbeam/fender-cfg-default.jbeam
+++ b/examples/transformed_jbeam/fender-cfg-default.jbeam
@@ -2,7 +2,7 @@
   "cot_fender" : {
     "information" : {
       "authors" : "gittarrgy01",
-      "name"    : "Fenders"
+      "name"    : "Fenders",
     },
     "sounds" : {
       "impactMetal"   : "event:>Destruction>Props>fender_metal",
@@ -55,7 +55,7 @@
       {"nodeWeight" : 1.2},
       {"selfCollision" : false},
       ["bfsl",  0.684,  -1.079, 0.507],
-      ["bfsr",  -0.623, -1.064, 0.507]
+      ["bfsr",  -0.623, -1.064, 0.507],
     ],
     "beams" : [
       ["id1:",  "id2:"],
@@ -272,7 +272,7 @@
       ["bfr8",  "mbr0"],
       ["bfr9",  "mbr1"],
       ["bfr10", "mbr2"],
-      {"breakGroup" : "", "breakGroupType" : "", "beamType" : "|NORMAL"}
+      {"breakGroup" : "", "breakGroupType" : "", "beamType" : "|NORMAL"},
     ],
     "triangles" : [
       ["id1:",  "id2:",  "id3:"],
@@ -293,14 +293,14 @@
       ["bfr10", "bfr6",  "bfr7"],
       ["bfr9",  "bfr6",  "bfr10"],
       ["bfr9",  "bfr8",  "bfr6"],
-      ["bfr5",  "bfr6",  "bfr8"]
+      ["bfr5",  "bfr6",  "bfr8"],
     ],
     "flexbodies" : [
       ["mesh", "[group]:", "nonFlexMaterials"],
       ["impala_fender_l", ["cot_fender_l"]],
       ["impala_fender_inter_l", ["cot_fender_l"]],
       ["impala_fender_r", ["cot_fender_r"]],
-      ["impala_fender_inter_r", ["cot_fender_r"]]
-    ]
-  }
+      ["impala_fender_inter_r", ["cot_fender_r"]],
+    ],
+  },
 }

--- a/examples/transformed_jbeam/fender-cfg-example.jbeam
+++ b/examples/transformed_jbeam/fender-cfg-example.jbeam
@@ -2,7 +2,7 @@
   "cot_fender" : {
     "information" : {
       "authors" : "gittarrgy01",
-      "name"    : "Fenders"
+      "name"    : "Fenders",
     },
     "sounds" : {
       "impactMetal"   : "event:>Destruction>Props>fender_metal",
@@ -55,7 +55,7 @@
       {"nodeWeight" : 1.2},
       {"selfCollision" : false},
       ["bfsl",  0.684,  -1.079, 0.507],
-      ["bfsr",  -0.623, -1.064, 0.507]
+      ["bfsr",  -0.623, -1.064, 0.507],
     ],
     "beams" : [
       ["id1:",  "id2:"],
@@ -272,7 +272,7 @@
       ["bfr8",  "mbr0"],
       ["bfr9",  "mbr1"],
       ["bfr10", "mbr2"],
-      {"breakGroup" : "", "breakGroupType" : "", "beamType" : "|NORMAL"}
+      {"breakGroup" : "", "breakGroupType" : "", "beamType" : "|NORMAL"},
     ],
     "triangles" : [
       ["id1:",  "id2:",  "id3:"],
@@ -293,14 +293,14 @@
       ["bfr10", "bfr6",  "bfr7"],
       ["bfr9",  "bfr6",  "bfr10"],
       ["bfr9",  "bfr8",  "bfr6"],
-      ["bfr5",  "bfr6",  "bfr8"]
+      ["bfr5",  "bfr6",  "bfr8"],
     ],
     "flexbodies" : [
       ["mesh", "[group]:", "nonFlexMaterials"],
       ["impala_fender_l", ["cot_fender_l"]],
       ["impala_fender_inter_l", ["cot_fender_l"]],
       ["impala_fender_r", ["cot_fender_r"]],
-      ["impala_fender_inter_r", ["cot_fender_r"]]
-    ]
-  }
+      ["impala_fender_inter_r", ["cot_fender_r"]],
+    ],
+  },
 }

--- a/examples/transformed_jbeam/suspension-cfg-default.jbeam
+++ b/examples/transformed_jbeam/suspension-cfg-default.jbeam
@@ -2,7 +2,7 @@
   "chassis_rails" : {
     "information" : {
       "authors" : "gittarrgy01",
-      "name"    : ""
+      "name"    : "",
     },
     "slotType" : "main",
     /* The purpose of this file is prove that moving metadata along with vertices when
@@ -337,7 +337,7 @@
       // Front crush
       {"beamDeform" : 8500},
       ["rlr8",  "rlr18"],
-      ["rll8",  "rll18"]
+      ["rll8",  "rll18"],
     ],
     // --Collision Triangles--
     "triangles" : [
@@ -405,11 +405,11 @@
       ["rll14", "rll12", "rll10"],
       ["rll14", "rll15", "rll12"],
       ["rlr11", "rlr13", "rlr14"],
-      ["rlr15", "rlr14", "rlr13"]
+      ["rlr15", "rlr14", "rlr13"],
     ],
     "flexbodies" : [
       ["mesh", "[group]:", "nonFlexMaterials"],
-      ["rails", ["chassis_rails"]]
-    ]
-  }
+      ["rails", ["chassis_rails"]],
+    ],
+  },
 }

--- a/examples/transformed_jbeam/suspension-cfg-example.jbeam
+++ b/examples/transformed_jbeam/suspension-cfg-example.jbeam
@@ -2,7 +2,7 @@
   "chassis_rails" : {
     "information" : {
       "authors" : "gittarrgy01",
-      "name"    : ""
+      "name"    : "",
     },
     "slotType" : "main",
     /* The purpose of this file is prove that moving metadata along with vertices when
@@ -337,7 +337,7 @@
       // Front crush
       {"beamDeform" : 8500},
       ["rlr8",  "rlr18"],
-      ["rll8",  "rll18"]
+      ["rll8",  "rll18"],
     ],
     // --Collision Triangles--
     "triangles" : [
@@ -405,11 +405,11 @@
       ["rll14", "rll12", "rll10"],
       ["rll14", "rll15", "rll12"],
       ["rlr11", "rlr13", "rlr14"],
-      ["rlr15", "rlr14", "rlr13"]
+      ["rlr15", "rlr14", "rlr13"],
     ],
     "flexbodies" : [
       ["mesh", "[group]:", "nonFlexMaterials"],
-      ["rails", ["chassis_rails"]]
-    ]
-  }
+      ["rails", ["chassis_rails"]],
+    ],
+  },
 }

--- a/jbeam-edit.cabal
+++ b/jbeam-edit.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 
--- This file has been generated from package.yaml by hpack version 0.38.0.
+--- This file has been generated from package.yaml by hpack version 0.38.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -89,6 +89,7 @@ library
     default-language:   GHC2021
     default-extensions:
         OverloadedStrings ImportQualifiedPost DerivingStrategies
+        TupleSections
 
     ghc-options:
         -Wall -Wcompat -Widentities -Wincomplete-record-updates
@@ -141,6 +142,7 @@ library jbeam-edit-transformation
     default-language:   GHC2021
     default-extensions:
         OverloadedStrings ImportQualifiedPost DerivingStrategies
+        TupleSections
 
     ghc-options:
         -Wall -Wcompat -Widentities -Wincomplete-record-updates
@@ -187,8 +189,8 @@ library jbeam-language-server
     autogen-modules:    Paths_jbeam_edit
     default-language:   GHC2021
     default-extensions:
-        OverloadedStrings ImportQualifiedPost DerivingStrategies DataKinds
-        PolyKinds
+        OverloadedStrings ImportQualifiedPost DerivingStrategies
+        TupleSections DataKinds PolyKinds
 
     ghc-options:
         -Wall -Wcompat -Widentities -Wincomplete-record-updates
@@ -232,7 +234,8 @@ executable jbeam-edit
     autogen-modules:    Paths_jbeam_edit
     default-language:   GHC2021
     default-extensions:
-        OverloadedStrings ImportQualifiedPost DerivingStrategies CPP
+        OverloadedStrings ImportQualifiedPost DerivingStrategies
+        TupleSections CPP
 
     ghc-options:
         -Wall -Wcompat -Widentities -Wincomplete-record-updates
@@ -270,6 +273,7 @@ executable jbeam-edit-dump-ast
     default-language:   GHC2021
     default-extensions:
         OverloadedStrings ImportQualifiedPost DerivingStrategies
+        TupleSections
 
     ghc-options:
         -Wall -Wcompat -Widentities -Wincomplete-record-updates
@@ -314,6 +318,7 @@ executable jbeam-lsp-server
     default-language:   GHC2021
     default-extensions:
         OverloadedStrings ImportQualifiedPost DerivingStrategies
+        TupleSections
 
     ghc-options:
         -Wall -Wcompat -Widentities -Wincomplete-record-updates
@@ -365,6 +370,7 @@ test-suite jbeam-edit-test
     default-language:   GHC2021
     default-extensions:
         OverloadedStrings ImportQualifiedPost DerivingStrategies
+        TupleSections
 
     ghc-options:
         -Wall -Wcompat -Widentities -Wincomplete-record-updates
@@ -405,6 +411,7 @@ test-suite jbeam-edit-transformation-test
     default-language:   GHC2021
     default-extensions:
         OverloadedStrings ImportQualifiedPost DerivingStrategies
+        TupleSections
 
     ghc-options:
         -Wall -Wcompat -Widentities -Wincomplete-record-updates
@@ -454,6 +461,7 @@ test-suite jbeam-language-server-test
     default-language:   GHC2021
     default-extensions:
         OverloadedStrings ImportQualifiedPost DerivingStrategies
+        TupleSections
 
     ghc-options:
         -Wall -Wcompat -Widentities -Wincomplete-record-updates
@@ -499,6 +507,7 @@ benchmark jbeam-edit-bench
     default-language:   GHC2021
     default-extensions:
         OverloadedStrings ImportQualifiedPost DerivingStrategies
+        TupleSections
 
     ghc-options:
         -Wall -Wcompat -Widentities -Wincomplete-record-updates

--- a/jbeam-edit.cabal
+++ b/jbeam-edit.cabal
@@ -74,6 +74,8 @@ library
         JbeamEdit.Formatting
         JbeamEdit.Formatting.Config
         JbeamEdit.Formatting.Rules
+        JbeamEdit.Formatting.Rules.ComplexNewLine
+        JbeamEdit.Formatting.Rules.TrailingComma
         JbeamEdit.IOUtils
         JbeamEdit.Parsing.Common
         JbeamEdit.Parsing.Common.ErrorMessage

--- a/package.yaml
+++ b/package.yaml
@@ -42,6 +42,7 @@ default-extensions:
   - OverloadedStrings
   - ImportQualifiedPost
   - DerivingStrategies
+  - TupleSections
 
 ghc-options:
   - -Wall

--- a/src-extra/transformation/JbeamEdit/Transformation.hs
+++ b/src-extra/transformation/JbeamEdit/Transformation.hs
@@ -1,6 +1,7 @@
 module JbeamEdit.Transformation (findAndUpdateTextInNode, transform, updateOtherFiles, filterJbeamFiles) where
 
 import Control.Monad (foldM, when)
+import Data.Bifunctor (first)
 import Data.Bool (bool)
 import Data.Foldable.Extra (notNull)
 import Data.Function (on)
@@ -409,10 +410,12 @@ updateVerticesInNode (NP.NodePath Empty) g globals (Array av) =
   let globalsList = NE.toList globals
       initialMeta =
         M.unions (map metaMapFromObject globalsList)
-      newElems =
-        V.map
-          (,True)
-          (V.fromList globalsList <> vertexForestToNodeVector initialMeta g)
+      allNodes = V.fromList globalsList <> vertexForestToNodeVector initialMeta g
+      origTrailingComma = case V.unsnoc (avElements av) of
+        Just (_, (_, hc)) -> hc
+        Nothing -> False
+      lastIdx = V.length allNodes - 1
+      newElems = V.imap (\i n -> (n, i < lastIdx || origTrailingComma)) allNodes
    in Array av {avElements = newElems}
 updateVerticesInNode (NP.NodePath ((NP.ArrayIndex i) :<| qrest)) g globals (Array av) =
   let children = avElements av
@@ -445,9 +448,6 @@ isObjectKeyEqual :: NP.NodeSelector -> Node -> Bool
 isObjectKeyEqual (NP.ObjectKey a) (ObjectKey (String b, _)) = a == b
 isObjectKeyEqual _ _ = False
 
-updateNodeInPair :: (Node -> Node) -> (Node, Bool) -> (Node, Bool)
-updateNodeInPair f (n, hc) = (f n, hc)
-
 findAndUpdateTextInNode :: UpdateNamesMap -> NC.NodeCursor -> Node -> Node
 findAndUpdateTextInNode m cursor node =
   case node of
@@ -457,13 +457,13 @@ findAndUpdateTextInNode m cursor node =
           Array
             av
               { avElements =
-                  V.imap (updateNodeInPair . applyBreadcrumbAndUpdateText) (avElements av)
+                  V.imap (first . applyBreadcrumbAndUpdateText) (avElements av)
               }
     Object ov ->
       Object
         ov
           { ovElements =
-              V.imap (updateNodeInPair . applyBreadcrumbAndUpdateText) (ovElements ov)
+              V.imap (first . applyBreadcrumbAndUpdateText) (ovElements ov)
           }
     ObjectKey (key, value) ->
       ObjectKey

--- a/src-extra/transformation/JbeamEdit/Transformation.hs
+++ b/src-extra/transformation/JbeamEdit/Transformation.hs
@@ -281,7 +281,7 @@ annotatedVertexToNodesWithPrev prevMeta (AnnotatedVertex comments vertex meta) =
       newPrevMeta = M.union localsMeta prevMeta
 
       metaNodes =
-        [ Object (V.singleton (ObjectKey (String k, v)))
+        [ mkObject (V.singleton (ObjectKey (String k, v)))
         | (k, v) <- M.assocs localsMeta
         ]
 
@@ -293,8 +293,8 @@ annotatedVertexToNodesWithPrev prevMeta (AnnotatedVertex comments vertex meta) =
             x = Number (mkNumberValueNormalized (vX vertex))
             y = Number (mkNumberValueNormalized (vY vertex))
             z = Number (mkNumberValueNormalized (vZ vertex))
-            possiblyMeta = concatMap (pure . Object) (vMeta vertex)
-         in Array . V.fromList $ [name, x, y, z] ++ possiblyMeta
+            possiblyMeta = concatMap (pure . mkObject) (vMeta vertex)
+         in mkArray . V.fromList $ [name, x, y, z] ++ possiblyMeta
    in ( map Comment preComments
           ++ metaNodes
           ++ pure vertexArray
@@ -405,26 +405,36 @@ sortVertices treeType newNames tfCfg (VertexTree comments vertices) =
 
 updateVerticesInNode
   :: NP.NodePath -> VertexForest -> NE.NonEmpty Node -> Node -> Node
-updateVerticesInNode (NP.NodePath Empty) g globals (Array _) =
+updateVerticesInNode (NP.NodePath Empty) g globals (Array av) =
   let globalsList = NE.toList globals
       initialMeta =
         M.unions (map metaMapFromObject globalsList)
-   in Array (V.fromList globalsList <> vertexForestToNodeVector initialMeta g)
-updateVerticesInNode (NP.NodePath ((NP.ArrayIndex i) :<| qrest)) g globals (Array children) =
-  let updateInNode nodeToUpdate =
+   in Array
+        av
+          { avElements = V.fromList globalsList <> vertexForestToNodeVector initialMeta g
+          }
+updateVerticesInNode (NP.NodePath ((NP.ArrayIndex i) :<| qrest)) g globals (Array av) =
+  let children = avElements av
+      updateInNode nodeToUpdate =
         children
           // [(i, updateVerticesInNode (NP.NodePath qrest) g globals nodeToUpdate)]
-   in Array $ maybe children updateInNode (children !? i)
-updateVerticesInNode (NP.NodePath ((NP.ObjectIndex i) :<| qrest)) g globals (Object children) =
-  let updateInNode child =
+   in Array av {avElements = maybe children updateInNode (children !? i)}
+updateVerticesInNode (NP.NodePath ((NP.ObjectIndex i) :<| qrest)) g globals (Object ov) =
+  let children = ovElements ov
+      updateInNode child =
         children
           // [(i, updateVerticesInNode (NP.NodePath qrest) g globals child)]
-   in Object $ maybe children updateInNode (children !? i)
-updateVerticesInNode (NP.NodePath (k@(NP.ObjectKey _) :<| qrest)) g globals (Object children) =
-  let updateInNode i =
+   in Object ov {ovElements = maybe children updateInNode (children !? i)}
+updateVerticesInNode (NP.NodePath (k@(NP.ObjectKey _) :<| qrest)) g globals (Object ov) =
+  let children = ovElements ov
+      updateInNode i =
         children
           // [(i, updateVerticesInNode (NP.NodePath qrest) g globals (children ! i))]
-   in Object . maybe children updateInNode $ V.findIndex (isObjectKeyEqual k) children
+   in Object
+        ov
+          { ovElements =
+              maybe children updateInNode $ V.findIndex (isObjectKeyEqual k) children
+          }
 updateVerticesInNode query g globals (ObjectKey (k, v)) =
   ObjectKey (k, updateVerticesInNode query g globals v)
 updateVerticesInNode _ _ _ a = a
@@ -436,10 +446,11 @@ isObjectKeyEqual _ _ = False
 findAndUpdateTextInNode :: UpdateNamesMap -> NC.NodeCursor -> Node -> Node
 findAndUpdateTextInNode m cursor node =
   case node of
-    Array arr
-      | NC.comparePathAndCursor verticesQuery cursor -> Array arr
-      | otherwise -> Array $ V.imap applyBreadcrumbAndUpdateText arr
-    Object obj -> Object $ V.imap applyBreadcrumbAndUpdateText obj
+    Array av
+      | NC.comparePathAndCursor verticesQuery cursor -> Array av
+      | otherwise ->
+          Array av {avElements = V.imap applyBreadcrumbAndUpdateText (avElements av)}
+    Object ov -> Object ov {ovElements = V.imap applyBreadcrumbAndUpdateText (ovElements ov)}
     ObjectKey (key, value) ->
       ObjectKey
         (key, findAndUpdateTextInNode m cursor value)

--- a/src-extra/transformation/JbeamEdit/Transformation.hs
+++ b/src-extra/transformation/JbeamEdit/Transformation.hs
@@ -409,31 +409,33 @@ updateVerticesInNode (NP.NodePath Empty) g globals (Array av) =
   let globalsList = NE.toList globals
       initialMeta =
         M.unions (map metaMapFromObject globalsList)
-   in Array
-        av
-          { avElements = V.fromList globalsList <> vertexForestToNodeVector initialMeta g
-          }
+      newElems =
+        V.map
+          (,True)
+          (V.fromList globalsList <> vertexForestToNodeVector initialMeta g)
+   in Array av {avElements = newElems}
 updateVerticesInNode (NP.NodePath ((NP.ArrayIndex i) :<| qrest)) g globals (Array av) =
   let children = avElements av
-      updateInNode nodeToUpdate =
+      updateInNode (nodeToUpdate, hc) =
         children
-          // [(i, updateVerticesInNode (NP.NodePath qrest) g globals nodeToUpdate)]
+          // [(i, (updateVerticesInNode (NP.NodePath qrest) g globals nodeToUpdate, hc))]
    in Array av {avElements = maybe children updateInNode (children !? i)}
 updateVerticesInNode (NP.NodePath ((NP.ObjectIndex i) :<| qrest)) g globals (Object ov) =
   let children = ovElements ov
-      updateInNode child =
+      updateInNode (child, hc) =
         children
-          // [(i, updateVerticesInNode (NP.NodePath qrest) g globals child)]
+          // [(i, (updateVerticesInNode (NP.NodePath qrest) g globals child, hc))]
    in Object ov {ovElements = maybe children updateInNode (children !? i)}
 updateVerticesInNode (NP.NodePath (k@(NP.ObjectKey _) :<| qrest)) g globals (Object ov) =
   let children = ovElements ov
       updateInNode i =
-        children
-          // [(i, updateVerticesInNode (NP.NodePath qrest) g globals (children ! i))]
+        let (child, hc) = children ! i
+         in children
+              // [(i, (updateVerticesInNode (NP.NodePath qrest) g globals child, hc))]
    in Object
         ov
           { ovElements =
-              maybe children updateInNode $ V.findIndex (isObjectKeyEqual k) children
+              maybe children updateInNode $ V.findIndex (isObjectKeyEqual k . fst) children
           }
 updateVerticesInNode query g globals (ObjectKey (k, v)) =
   ObjectKey (k, updateVerticesInNode query g globals v)
@@ -443,14 +445,26 @@ isObjectKeyEqual :: NP.NodeSelector -> Node -> Bool
 isObjectKeyEqual (NP.ObjectKey a) (ObjectKey (String b, _)) = a == b
 isObjectKeyEqual _ _ = False
 
+updateNodeInPair :: (Node -> Node) -> (Node, Bool) -> (Node, Bool)
+updateNodeInPair f (n, hc) = (f n, hc)
+
 findAndUpdateTextInNode :: UpdateNamesMap -> NC.NodeCursor -> Node -> Node
 findAndUpdateTextInNode m cursor node =
   case node of
     Array av
       | NC.comparePathAndCursor verticesQuery cursor -> Array av
       | otherwise ->
-          Array av {avElements = V.imap applyBreadcrumbAndUpdateText (avElements av)}
-    Object ov -> Object ov {ovElements = V.imap applyBreadcrumbAndUpdateText (ovElements ov)}
+          Array
+            av
+              { avElements =
+                  V.imap (updateNodeInPair . applyBreadcrumbAndUpdateText) (avElements av)
+              }
+    Object ov ->
+      Object
+        ov
+          { ovElements =
+              V.imap (updateNodeInPair . applyBreadcrumbAndUpdateText) (ovElements ov)
+          }
     ObjectKey (key, value) ->
       ObjectKey
         (key, findAndUpdateTextInNode m cursor value)

--- a/src-extra/transformation/JbeamEdit/Transformation/BeamExtraction.hs
+++ b/src-extra/transformation/JbeamEdit/Transformation/BeamExtraction.hs
@@ -25,8 +25,8 @@ possiblyBeam :: MetaMap -> Node -> Either Node (Maybe Beam)
 possiblyBeam sectionMeta node
   | isCommentNode node || isObjectNode node = Right Nothing
   | otherwise = case node of
-      Array beamVec ->
-        Right (extractBeamFromArray sectionMeta beamVec)
+      Array av ->
+        Right (extractBeamFromArray sectionMeta (avElements av))
       _ -> Left node
 
 extractBeamFromArray :: MetaMap -> Vector Node -> Maybe Beam

--- a/src-extra/transformation/JbeamEdit/Transformation/BeamExtraction.hs
+++ b/src-extra/transformation/JbeamEdit/Transformation/BeamExtraction.hs
@@ -26,7 +26,7 @@ possiblyBeam sectionMeta node
   | isCommentNode node || isObjectNode node = Right Nothing
   | otherwise = case node of
       Array av ->
-        Right (extractBeamFromArray sectionMeta (avElements av))
+        Right (extractBeamFromArray sectionMeta (avNodes av))
       _ -> Left node
 
 extractBeamFromArray :: MetaMap -> Vector Node -> Maybe Beam

--- a/src-extra/transformation/JbeamEdit/Transformation/Types.hs
+++ b/src-extra/transformation/JbeamEdit/Transformation/Types.hs
@@ -19,6 +19,7 @@ import Data.Map (Map)
 import Data.Scientific (Scientific)
 import Data.Text (Text)
 import Data.Text qualified as T
+import Data.Vector (Vector)
 import Data.Yaml.Aeson (
   FromJSON (..),
   withText,
@@ -55,7 +56,7 @@ data VertexTree = VertexTree
 data Vertex = Vertex
   { vName :: Text
   , vX, vY, vZ :: Scientific
-  , vMeta :: Maybe Object
+  , vMeta :: Maybe (Vector Node)
   }
   deriving (Eq, Show)
 

--- a/src-extra/transformation/JbeamEdit/Transformation/VertexExtraction.hs
+++ b/src-extra/transformation/JbeamEdit/Transformation/VertexExtraction.hs
@@ -347,5 +347,5 @@ getVertexForest brks np topNode =
 
 isValidVertexHeader :: Node -> Bool
 isValidVertexHeader (Array av) =
-  V.length (avNodes av) == 4 && all isStringNode (avNodes av)
+  let ns = avNodes av in V.length ns == 4 && all isStringNode ns
 isValidVertexHeader _ = False

--- a/src-extra/transformation/JbeamEdit/Transformation/VertexExtraction.hs
+++ b/src-extra/transformation/JbeamEdit/Transformation/VertexExtraction.hs
@@ -41,9 +41,9 @@ nodeScientific (Number nv) = Just (numberValueToScientific nv)
 nodeScientific _ = Nothing
 
 newVertex :: Node -> Maybe Vertex
-newVertex (Array av) = case V.toList (avElements av) of
+newVertex (Array av) = case V.toList (avNodes av) of
   [String name, n1, n2, n3] -> mkVertex name n1 n2 n3 Nothing
-  [String name, n1, n2, n3, Object ov] -> mkVertex name n1 n2 n3 (Just (ovElements ov))
+  [String name, n1, n2, n3, Object ov] -> mkVertex name n1 n2 n3 (Just (ovNodes ov))
   _ -> Nothing
 newVertex _ = Nothing
 
@@ -165,7 +165,7 @@ metaMapFromObject :: Node -> MetaMap
 metaMapFromObject (Object ov) =
   let toKV (ObjectKey (String k, v)) = Just (k, v)
       toKV _ = Nothing
-   in M.fromList . mapMaybe toKV $ V.toList (ovElements ov)
+   in M.fromList . mapMaybe toKV $ V.toList (ovNodes ov)
 metaMapFromObject _ = M.empty
 
 toInternalComment :: Node -> Maybe InternalComment
@@ -347,5 +347,5 @@ getVertexForest brks np topNode =
 
 isValidVertexHeader :: Node -> Bool
 isValidVertexHeader (Array av) =
-  V.length (avElements av) == 4 && all isStringNode (avElements av)
+  V.length (avNodes av) == 4 && all isStringNode (avNodes av)
 isValidVertexHeader _ = False

--- a/src-extra/transformation/JbeamEdit/Transformation/VertexExtraction.hs
+++ b/src-extra/transformation/JbeamEdit/Transformation/VertexExtraction.hs
@@ -23,6 +23,7 @@ import Data.Set (Set)
 import Data.Set qualified as S
 import Data.Text (Text)
 import Data.Text qualified as T
+import Data.Vector (Vector)
 import Data.Vector qualified as V
 import GHC.IsList
 import JbeamEdit.Core.Node
@@ -40,13 +41,14 @@ nodeScientific (Number nv) = Just (numberValueToScientific nv)
 nodeScientific _ = Nothing
 
 newVertex :: Node -> Maybe Vertex
-newVertex (Array ns) = case V.toList ns of
+newVertex (Array av) = case V.toList (avElements av) of
   [String name, n1, n2, n3] -> mkVertex name n1 n2 n3 Nothing
-  [String name, n1, n2, n3, Object m] -> mkVertex name n1 n2 n3 (Just m)
+  [String name, n1, n2, n3, Object ov] -> mkVertex name n1 n2 n3 (Just (ovElements ov))
   _ -> Nothing
 newVertex _ = Nothing
 
-mkVertex :: Text -> Node -> Node -> Node -> Maybe Object -> Maybe Vertex
+mkVertex
+  :: Text -> Node -> Node -> Node -> Maybe (Vector Node) -> Maybe Vertex
 mkVertex name n1 n2 n3 meta = do
   x <- nodeScientific n1
   y <- nodeScientific n2
@@ -160,10 +162,10 @@ isSupportVertex v =
     Just (_, c) -> not (isDigit c)
 
 metaMapFromObject :: Node -> MetaMap
-metaMapFromObject (Object objKeys) =
+metaMapFromObject (Object ov) =
   let toKV (ObjectKey (String k, v)) = Just (k, v)
       toKV _ = Nothing
-   in M.fromList . mapMaybe toKV $ V.toList objKeys
+   in M.fromList . mapMaybe toKV $ V.toList (ovElements ov)
 metaMapFromObject _ = M.empty
 
 toInternalComment :: Node -> Maybe InternalComment
@@ -265,7 +267,7 @@ nodesListToTree brks nodes =
 objectKeysToObjects :: Map Text Node -> [Node]
 objectKeysToObjects =
   M.foldMapWithKey
-    (curry $ pure . Object . V.singleton . ObjectKey . first String)
+    (curry $ pure . mkObject . V.singleton . ObjectKey . first String)
 
 concatAnnotatedVertices
   :: OMap VertexTreeKey VertexTree
@@ -344,6 +346,6 @@ getVertexForest brks np topNode =
             _ -> Left "missing vertex header"
 
 isValidVertexHeader :: Node -> Bool
-isValidVertexHeader (Array header) =
-  V.length header == 4 && all isStringNode header
+isValidVertexHeader (Array av) =
+  V.length (avElements av) == 4 && all isStringNode (avElements av)
 isValidVertexHeader _ = False

--- a/src/JbeamEdit/Core/Node.hs
+++ b/src/JbeamEdit/Core/Node.hs
@@ -126,21 +126,20 @@ avNodes = V.map fst . avElements
 ovNodes :: ObjectValue -> Vector Node
 ovNodes = V.map fst . ovElements
 
+withCommas :: Vector Node -> Vector (Node, Bool)
+withCommas v =
+  let lastIdx = V.length v - 1
+   in V.imap (\i n -> (n, i < lastIdx)) v
+
 mkArray :: Vector Node -> Node
 mkArray v
   | V.null v = Array (ArrayValue V.empty)
-  | otherwise =
-      let (n, _) = V.last pairs
-          pairs = V.map (,True) v
-       in Array (ArrayValue (V.init pairs `V.snoc` (n, False)))
+  | otherwise = Array (ArrayValue (withCommas v))
 
 mkObject :: Vector Node -> Node
 mkObject v
   | V.null v = Object (ObjectValue V.empty)
-  | otherwise =
-      let (n, _) = V.last pairs
-          pairs = V.map (,True) v
-       in Object (ObjectValue (V.init pairs `V.snoc` (n, False)))
+  | otherwise = Object (ObjectValue (withCommas v))
 
 isObjectKeyNode :: Node -> Bool
 isObjectKeyNode (ObjectKey _) = True

--- a/src/JbeamEdit/Core/Node.hs
+++ b/src/JbeamEdit/Core/Node.hs
@@ -17,10 +17,12 @@ module JbeamEdit.Core.Node (
   mkNumberValueNormalized,
   Node (..),
   NumberValue (..),
+  ArrayValue (..),
+  ObjectValue (..),
   InternalComment (..),
   AssociationDirection (..),
-  Object,
-  Array,
+  mkArray,
+  mkObject,
 ) where
 
 import Control.Applicative ((<|>))
@@ -35,11 +37,19 @@ import Data.Text qualified as T
 import Data.Vector (Vector)
 import Data.Vector qualified as V
 
-type Object = Vector Node
+data ArrayValue = ArrayValue
+  { avElements :: Vector Node
+  , avTrailingComma :: Bool
+  }
+  deriving (Eq, Ord, Read, Show)
+
+data ObjectValue = ObjectValue
+  { ovElements :: Vector Node
+  , ovTrailingComma :: Bool
+  }
+  deriving (Eq, Ord, Read, Show)
 
 type ObjectKey = (Node, Node)
-
-type Array = Vector Node
 
 data AssociationDirection = PreviousNode | NextNode
   deriving (Eq, Ord, Read, Show)
@@ -78,8 +88,8 @@ data NumberValue = NumberValue
   deriving (Eq, Ord, Read, Show)
 
 data Node
-  = Array Array
-  | Object Object
+  = Array ArrayValue
+  | Object ObjectValue
   | ObjectKey ObjectKey
   | String Text
   | Number NumberValue
@@ -109,6 +119,12 @@ isCommentNode _ = False
 isObjectNode :: Node -> Bool
 isObjectNode (Object _) = True
 isObjectNode _ = False
+
+mkArray :: Vector Node -> Node
+mkArray v = Array (ArrayValue v False)
+
+mkObject :: Vector Node -> Node
+mkObject v = Object (ObjectValue v False)
 
 isObjectKeyNode :: Node -> Bool
 isObjectKeyNode (ObjectKey _) = True
@@ -141,11 +157,11 @@ isSinglelineComment (Comment (InternalComment _ False _ _)) = True
 isSinglelineComment _ = False
 
 expectArray :: Node -> Maybe (Vector Node)
-expectArray (Array ns) = Just ns
+expectArray (Array av) = Just (avElements av)
 expectArray _ = Nothing
 
 expectObject :: Node -> Maybe (Vector Node)
-expectObject (Object ns) = Just ns
+expectObject (Object ov) = Just (ovElements ov)
 expectObject _ = Nothing
 
 possiblyChildren :: Node -> Maybe (Vector Node)
@@ -173,30 +189,30 @@ moreNodesThanOne v
   Examples in AST form:
 
     -- [1] → not complex
-    Array (fromList [Number 1])
+    mkArray (fromList [Number 1])
 
     -- [[1]] → not complex
-    Array (fromList [Array (fromList [Number 1])])
+    mkArray (fromList [mkArray (fromList [Number 1])])
 
     -- [1,2] → complex
-    Array (fromList [Number 1, Number 2])
+    mkArray (fromList [Number 1, Number 2])
 
     -- { a: 1 } → not complex
-    Object (fromList [ObjectKey (String "a", Number 1)])
+    mkObject (fromList [ObjectKey (String "a", Number 1)])
 
     -- { a: 1, b: 2 } → complex
-    Object (fromList [ ObjectKey (String "a", Number 1)
-                     , ObjectKey (String "b", Number 2)
-                     ])
+    mkObject (fromList [ ObjectKey (String "a", Number 1)
+                       , ObjectKey (String "b", Number 2)
+                       ])
 
     -- { a: [1] } → not complex
-    Object (fromList [ObjectKey (String "a", Array (fromList [Number 1]))])
+    mkObject (fromList [ObjectKey (String "a", mkArray (fromList [Number 1]))])
 
     -- { a: [1,2] } → complex
-    Object (fromList [ObjectKey (String "a", Array (fromList [Number 1, Number 2]))])
+    mkObject (fromList [ObjectKey (String "a", mkArray (fromList [Number 1, Number 2]))])
 -}
 isComplexNode :: Node -> Bool
-isComplexNode (Object v) = moreNodesThanOne v
-isComplexNode (Array v) = moreNodesThanOne v
+isComplexNode (Object ov) = moreNodesThanOne (ovElements ov)
+isComplexNode (Array av) = moreNodesThanOne (avElements av)
 isComplexNode (ObjectKey (_key, val)) = isComplexNode val
 isComplexNode _ = False

--- a/src/JbeamEdit/Core/Node.hs
+++ b/src/JbeamEdit/Core/Node.hs
@@ -15,6 +15,8 @@ module JbeamEdit.Core.Node (
   scientificToText,
   mkNumberValue,
   mkNumberValueNormalized,
+  avNodes,
+  ovNodes,
   Node (..),
   NumberValue (..),
   ArrayValue (..),
@@ -37,15 +39,13 @@ import Data.Text qualified as T
 import Data.Vector (Vector)
 import Data.Vector qualified as V
 
-data ArrayValue = ArrayValue
-  { avElements :: Vector Node
-  , avTrailingComma :: Bool
+newtype ArrayValue = ArrayValue
+  { avElements :: Vector (Node, Bool)
   }
   deriving (Eq, Ord, Read, Show)
 
-data ObjectValue = ObjectValue
-  { ovElements :: Vector Node
-  , ovTrailingComma :: Bool
+newtype ObjectValue = ObjectValue
+  { ovElements :: Vector (Node, Bool)
   }
   deriving (Eq, Ord, Read, Show)
 
@@ -120,11 +120,27 @@ isObjectNode :: Node -> Bool
 isObjectNode (Object _) = True
 isObjectNode _ = False
 
+avNodes :: ArrayValue -> Vector Node
+avNodes = V.map fst . avElements
+
+ovNodes :: ObjectValue -> Vector Node
+ovNodes = V.map fst . ovElements
+
 mkArray :: Vector Node -> Node
-mkArray v = Array (ArrayValue v False)
+mkArray v
+  | V.null v = Array (ArrayValue V.empty)
+  | otherwise =
+      let (n, _) = V.last pairs
+          pairs = V.map (,True) v
+       in Array (ArrayValue (V.init pairs `V.snoc` (n, False)))
 
 mkObject :: Vector Node -> Node
-mkObject v = Object (ObjectValue v False)
+mkObject v
+  | V.null v = Object (ObjectValue V.empty)
+  | otherwise =
+      let (n, _) = V.last pairs
+          pairs = V.map (,True) v
+       in Object (ObjectValue (V.init pairs `V.snoc` (n, False)))
 
 isObjectKeyNode :: Node -> Bool
 isObjectKeyNode (ObjectKey _) = True
@@ -157,11 +173,11 @@ isSinglelineComment (Comment (InternalComment _ False _ _)) = True
 isSinglelineComment _ = False
 
 expectArray :: Node -> Maybe (Vector Node)
-expectArray (Array av) = Just (avElements av)
+expectArray (Array av) = Just (avNodes av)
 expectArray _ = Nothing
 
 expectObject :: Node -> Maybe (Vector Node)
-expectObject (Object ov) = Just (ovElements ov)
+expectObject (Object ov) = Just (ovNodes ov)
 expectObject _ = Nothing
 
 possiblyChildren :: Node -> Maybe (Vector Node)
@@ -212,7 +228,7 @@ moreNodesThanOne v
     mkObject (fromList [ObjectKey (String "a", mkArray (fromList [Number 1, Number 2]))])
 -}
 isComplexNode :: Node -> Bool
-isComplexNode (Object ov) = moreNodesThanOne (ovElements ov)
-isComplexNode (Array av) = moreNodesThanOne (avElements av)
+isComplexNode (Object ov) = moreNodesThanOne (ovNodes ov)
+isComplexNode (Array av) = moreNodesThanOne (avNodes av)
 isComplexNode (ObjectKey (_key, val)) = isComplexNode val
 isComplexNode _ = False

--- a/src/JbeamEdit/Core/NodePath.hs
+++ b/src/JbeamEdit/Core/NodePath.hs
@@ -11,12 +11,14 @@ module JbeamEdit.Core.NodePath (
 import Data.Either.Extra (maybeToEither)
 import Data.Sequence (Seq (..))
 import Data.Text (Text)
-import Data.Text qualified as T (show)
+import Data.Text qualified as T (isPrefixOf, show)
 import Data.Vector (Vector)
 import Data.Vector qualified as V
 import GHC.IsList (IsList (..))
 import JbeamEdit.Core.Node qualified as N (
+  ArrayValue (..),
   Node (..),
+  ObjectValue (..),
   expectArray,
   isCommentNode,
   maybeObjectKey,
@@ -61,9 +63,12 @@ In case the selector matches nodes at a certain point in the tree.
 And queryNodes allows use to chain the Selectors as a NodePath and perform complex queries.
 -}
 select :: NodeSelector -> N.Node -> Maybe N.Node
-select (ArrayIndex i) (N.Array ns) = getNthNonComment i ns
-select (ObjectKey k) (N.Object ns) = extractValInKey =<< V.find (elem k . N.maybeObjectKey) ns
-select (ObjectIndex i) (N.Object a) = extractValInKey =<< getNthNonComment i a
+select (ArrayIndex i) (N.Array av) = getNthNonComment i (N.avElements av)
+select (ObjectPrefixKey k) (N.Object ov) =
+  extractValInKey
+    =<< V.find (any (T.isPrefixOf k) . N.maybeObjectKey) (N.ovElements ov)
+select (ObjectKey k) (N.Object ov) = extractValInKey =<< V.find (elem k . N.maybeObjectKey) (N.ovElements ov)
+select (ObjectIndex i) (N.Object ov) = extractValInKey =<< getNthNonComment i (N.ovElements ov)
 select _ _ = Nothing
 
 queryNodes :: NodePath -> N.Node -> Either Text N.Node

--- a/src/JbeamEdit/Core/NodePath.hs
+++ b/src/JbeamEdit/Core/NodePath.hs
@@ -19,9 +19,11 @@ import JbeamEdit.Core.Node qualified as N (
   ArrayValue (..),
   Node (..),
   ObjectValue (..),
+  avNodes,
   expectArray,
   isCommentNode,
   maybeObjectKey,
+  ovNodes,
  )
 
 data NodeSelector
@@ -63,12 +65,12 @@ In case the selector matches nodes at a certain point in the tree.
 And queryNodes allows use to chain the Selectors as a NodePath and perform complex queries.
 -}
 select :: NodeSelector -> N.Node -> Maybe N.Node
-select (ArrayIndex i) (N.Array av) = getNthNonComment i (N.avElements av)
+select (ArrayIndex i) (N.Array av) = getNthNonComment i (N.avNodes av)
 select (ObjectPrefixKey k) (N.Object ov) =
   extractValInKey
-    =<< V.find (any (T.isPrefixOf k) . N.maybeObjectKey) (N.ovElements ov)
-select (ObjectKey k) (N.Object ov) = extractValInKey =<< V.find (elem k . N.maybeObjectKey) (N.ovElements ov)
-select (ObjectIndex i) (N.Object ov) = extractValInKey =<< getNthNonComment i (N.ovElements ov)
+    =<< V.find (any (T.isPrefixOf k) . N.maybeObjectKey) (N.ovNodes ov)
+select (ObjectKey k) (N.Object ov) = extractValInKey =<< V.find (elem k . N.maybeObjectKey) (N.ovNodes ov)
+select (ObjectIndex i) (N.Object ov) = extractValInKey =<< getNthNonComment i (N.ovNodes ov)
 select _ _ = Nothing
 
 queryNodes :: NodePath -> N.Node -> Either Text N.Node

--- a/src/JbeamEdit/Formatting.hs
+++ b/src/JbeamEdit/Formatting.hs
@@ -46,10 +46,10 @@ import JbeamEdit.Formatting.Rules (
   RuleSet (..),
   applyPadLogic,
   findPropertiesForCursor,
+  lookupPropertyForCursor,
   lookupRule,
  )
 import JbeamEdit.Formatting.Rules.ComplexNewLine qualified as CNL
-import JbeamEdit.Formatting.Rules.TrailingComma (TrailingComma)
 import JbeamEdit.Formatting.Rules.TrailingComma qualified as TC
 import System.File.OsPath qualified as OS (writeFile)
 import System.OsPath (OsPath)
@@ -106,9 +106,18 @@ addDelimiters
   -> [Node]
   -> [Text]
 addDelimiters _ _ _ _ _ _ _ acc [] = acc
-addDelimiters rs index rowIdx c complexChildren hasTrailingComma state acc ns@(node : rest)
+addDelimiters rs index rowIdx c complexChildren containerTrailingComma state acc ns@(node : rest)
   | complexChildren && null acc =
-      addDelimiters rs index rowIdx c complexChildren hasTrailingComma state ["\n"] ns
+      addDelimiters
+        rs
+        index
+        rowIdx
+        c
+        complexChildren
+        containerTrailingComma
+        state
+        ["\n"]
+        ns
   | isCommentNode node =
       let formattedComment =
             formatWithCursor
@@ -123,7 +132,7 @@ addDelimiters rs index rowIdx c complexChildren hasTrailingComma state acc ns@(n
             rowIdx
             c
             complexChildren
-            hasTrailingComma
+            containerTrailingComma
             state
             formatted
             rest
@@ -138,7 +147,7 @@ addDelimiters rs index rowIdx c complexChildren hasTrailingComma state acc ns@(n
                 nextRowIdx
                 c
                 complexChildren
-                hasTrailingComma
+                containerTrailingComma
                 state
                 formatted
                 rest'
@@ -151,7 +160,7 @@ addDelimiters rs index rowIdx c complexChildren hasTrailingComma state acc ns@(n
                 nextRowIdx
                 c
                 complexChildren
-                hasTrailingComma
+                containerTrailingComma
                 state
                 new_acc
                 rest
@@ -217,7 +226,22 @@ addDelimiters rs index rowIdx c complexChildren hasTrailingComma state acc ns@(n
               let (formatted, spaces) = splitTrailing comma (NC.applyCrumb c (formatWithCursor rs emptyState) idx n)
                in formatted <> singleCharIf ',' comma <> spaces
 
-    comma = notNull rest || (null rest && hasTrailingComma)
+    comma = notNull rest || (null rest && trailingComma)
+    trailingComma =
+      let tcMode =
+            NC.applyCrumb
+              c
+              ( \childCursor _ ->
+                  fromMaybe
+                    TC.Preserve
+                    (lookupPropertyForCursor PrefixMatch TrailingComma rs childCursor)
+              )
+              index
+              node
+       in case tcMode of
+            TC.Preserve -> containerTrailingComma
+            TC.Force -> True
+            TC.None -> False
     space = notNull rest && not complexChildren
     newline = complexChildren
 
@@ -359,15 +383,9 @@ doFormatNode rs cursor state containerTrailingComma nodes =
               }
         | otherwise = state
 
-      tcMode = fromMaybe TC.Preserve (lookupRule TrailingComma prefixProps)
-      trailingComma = case tcMode of
-        TC.Preserve -> containerTrailingComma
-        TC.Force -> True
-        TC.None -> False
-
       formatted =
         reverse
-          . addDelimiters rs 0 0 cursor complexChildren trailingComma state' []
+          . addDelimiters rs 0 0 cursor complexChildren containerTrailingComma state' []
           . V.toList
           $ nodes
 

--- a/src/JbeamEdit/Formatting.hs
+++ b/src/JbeamEdit/Formatting.hs
@@ -97,7 +97,7 @@ singleCharIfNot a b = singleCharIf a (not b)
 extractPreviousAssocCmtPair
   :: [(Node, Bool)]
   -> (Maybe InternalComment, [(Node, Bool)])
-extractPreviousAssocCmtPair ((Comment cmt, hc) : ns)
+extractPreviousAssocCmtPair ((Comment cmt, _) : ns)
   | commentIsAttachedToPreviousNode cmt = (Just cmt, ns)
 extractPreviousAssocCmtPair ns = (Nothing, ns)
 

--- a/src/JbeamEdit/Formatting.hs
+++ b/src/JbeamEdit/Formatting.hs
@@ -24,9 +24,11 @@ import Data.Text.Encoding (encodeUtf8)
 import Data.Vector (Vector)
 import Data.Vector qualified as V
 import JbeamEdit.Core.Node (
+  ArrayValue (..),
   InternalComment (..),
   Node (..),
   NumberValue (..),
+  ObjectValue (..),
   expectArray,
   extractPreviousAssocCmt,
   isCommentNode,
@@ -96,14 +98,15 @@ addDelimiters
   -> Int
   -> NC.NodeCursor
   -> Bool
+  -> Bool
   -> FormattingState
   -> [Text]
   -> [Node]
   -> [Text]
-addDelimiters _ _ _ _ _ _ acc [] = acc
-addDelimiters rs index rowIdx c complexChildren state acc ns@(node : rest)
+addDelimiters _ _ _ _ _ _ _ acc [] = acc
+addDelimiters rs index rowIdx c complexChildren hasTrailingComma state acc ns@(node : rest)
   | complexChildren && null acc =
-      addDelimiters rs index rowIdx c complexChildren state ["\n"] ns
+      addDelimiters rs index rowIdx c complexChildren hasTrailingComma state ["\n"] ns
   | isCommentNode node =
       let formattedComment =
             formatWithCursor
@@ -112,7 +115,16 @@ addDelimiters rs index rowIdx c complexChildren state acc ns@(node : rest)
               c
               (normalizeCommentNode complexChildren node)
           formatted = (newlineBeforeComment <> formattedComment <> "\n") : acc
-       in addDelimiters rs index rowIdx c complexChildren state formatted rest
+       in addDelimiters
+            rs
+            index
+            rowIdx
+            c
+            complexChildren
+            hasTrailingComma
+            state
+            formatted
+            rest
   | otherwise =
       case extractPreviousAssocCmt rest of
         (Just comment, rest') ->
@@ -124,13 +136,23 @@ addDelimiters rs index rowIdx c complexChildren state acc ns@(node : rest)
                 nextRowIdx
                 c
                 complexChildren
+                hasTrailingComma
                 state
                 formatted
                 rest'
         (Nothing, _) ->
           let baseTxt = applyCrumbAndFormat node index
               new_acc = (baseTxt <> singleCharIf ' ' space <> singleCharIf '\n' newline) : acc
-           in addDelimiters rs (index + 1) nextRowIdx c complexChildren state new_acc rest
+           in addDelimiters
+                rs
+                (index + 1)
+                nextRowIdx
+                c
+                complexChildren
+                hasTrailingComma
+                state
+                new_acc
+                rest
   where
     newlineBeforeComment = case node of
       Comment ic | not (cMultiline ic) ->
@@ -193,7 +215,7 @@ addDelimiters rs index rowIdx c complexChildren state acc ns@(node : rest)
               let (formatted, spaces) = splitTrailing comma (NC.applyCrumb c (formatWithCursor rs emptyState) idx n)
                in formatted <> singleCharIf ',' comma <> spaces
 
-    comma = notNull rest
+    comma = notNull rest || (null rest && hasTrailingComma)
     space = notNull rest && not complexChildren
     newline = complexChildren
 
@@ -211,7 +233,7 @@ maxColumnLengthsWithCache rs cursor nodes
   | V.null nodes = (V.empty, V.empty, False)
   | otherwise =
       let (nodesToProcess, headerWasExtracted) = case V.uncons nodes of
-            Just (Array firstRow, rest) | all isStringNode firstRow -> (rest, True)
+            Just (Array (ArrayValue firstRow _), rest) | all isStringNode firstRow -> (rest, True)
             _ -> (nodes, False)
           (arrayRows, arrayIndices) = extractArrayRows nodesToProcess (fromEnum headerWasExtracted)
           formattedColumns = transposeAndFormat rs cursor arrayRows arrayIndices
@@ -251,7 +273,7 @@ transposeAndFormat rs cursor vvs arrayIndices
                           formatRow rowCursor _rowNode =
                             let formatCell = formatWithCursor rs emptyState
                              in NC.applyCrumb rowCursor formatCell colIdx (row V.! colIdx)
-                       in NC.applyCrumb cursor formatRow actualRowIdx (Array row)
+                       in NC.applyCrumb cursor formatRow actualRowIdx (Array (ArrayValue row False))
                     else ""
               )
               vvs
@@ -260,9 +282,10 @@ doFormatNode
   :: RuleSet
   -> NC.NodeCursor
   -> FormattingState
+  -> Bool
   -> Vector Node
   -> Text
-doFormatNode rs cursor state nodes =
+doFormatNode rs cursor state containerTrailingComma nodes =
   let prefixProps = findPropertiesForCursor PrefixMatch cursor rs
       exactProps = findPropertiesForCursor ExactMatch cursor rs
 
@@ -293,7 +316,7 @@ doFormatNode rs cursor state nodes =
         | autopadSubObjectsEnabled =
             V.foldl'
               ( \acc n -> case n of
-                  ObjectKey (_, Object subNodes) ->
+                  ObjectKey (_, Object (ObjectValue subNodes _)) ->
                     V.foldl'
                       ( \acc2 sn -> case sn of
                           ObjectKey (sk, sv) ->
@@ -334,9 +357,12 @@ doFormatNode rs cursor state nodes =
               }
         | otherwise = state
 
+      preserveTC = fromMaybe True (lookupRule PreserveTrailingCommas prefixProps)
+      trailingComma = containerTrailingComma && preserveTC
+
       formatted =
         reverse
-          . addDelimiters rs 0 0 cursor complexChildren state' []
+          . addDelimiters rs 0 0 cursor complexChildren trailingComma state' []
           . V.toList
           $ nodes
 
@@ -372,20 +398,20 @@ formatScalarNode _ n = error $ "Unhandled scalar node: " <> show n
 
 formatWithCursor
   :: RuleSet -> FormattingState -> NC.NodeCursor -> Node -> Text
-formatWithCursor rs state cursor (Array a)
+formatWithCursor rs state cursor (Array (ArrayValue a tc))
   | V.null a = "[]"
   | otherwise =
       T.concat
         [ "["
-        , doFormatNode rs cursor state a
+        , doFormatNode rs cursor state tc a
         , "]"
         ]
-formatWithCursor rs state cursor (Object o)
+formatWithCursor rs state cursor (Object (ObjectValue o tc))
   | V.null o = "{}"
   | otherwise =
       T.concat
         [ "{"
-        , doFormatNode rs cursor state o
+        , doFormatNode rs cursor state tc o
         , "}"
         ]
 formatWithCursor rs state cursor (ObjectKey (k, v)) =

--- a/src/JbeamEdit/Formatting.hs
+++ b/src/JbeamEdit/Formatting.hs
@@ -29,8 +29,9 @@ import JbeamEdit.Core.Node (
   Node (..),
   NumberValue (..),
   ObjectValue (..),
+  avNodes,
+  commentIsAttachedToPreviousNode,
   expectArray,
-  extractPreviousAssocCmt,
   isCommentNode,
   isComplexNode,
   isObjectKeyNode,
@@ -94,19 +95,25 @@ singleCharIf a b = mwhen b (T.singleton a)
 singleCharIfNot :: Char -> Bool -> Text
 singleCharIfNot a b = singleCharIf a (not b)
 
+extractPreviousAssocCmtPair
+  :: [(Node, Bool)]
+  -> (Maybe InternalComment, [(Node, Bool)])
+extractPreviousAssocCmtPair ((Comment cmt, hc) : ns)
+  | commentIsAttachedToPreviousNode cmt = (Just cmt, ns)
+extractPreviousAssocCmtPair ns = (Nothing, ns)
+
 addDelimiters
   :: RuleSet
   -> Int
   -> Int
   -> NC.NodeCursor
   -> Bool
-  -> Bool
   -> FormattingState
   -> [Text]
-  -> [Node]
+  -> [(Node, Bool)]
   -> [Text]
-addDelimiters _ _ _ _ _ _ _ acc [] = acc
-addDelimiters rs index rowIdx c complexChildren containerTrailingComma state acc ns@(node : rest)
+addDelimiters _ _ _ _ _ _ acc [] = acc
+addDelimiters rs index rowIdx c complexChildren state acc ns@((node, nodeHadComma) : rest)
   | complexChildren && null acc =
       addDelimiters
         rs
@@ -114,7 +121,6 @@ addDelimiters rs index rowIdx c complexChildren containerTrailingComma state acc
         rowIdx
         c
         complexChildren
-        containerTrailingComma
         state
         ["\n"]
         ns
@@ -132,12 +138,11 @@ addDelimiters rs index rowIdx c complexChildren containerTrailingComma state acc
             rowIdx
             c
             complexChildren
-            containerTrailingComma
             state
             formatted
             rest
   | otherwise =
-      case extractPreviousAssocCmt rest of
+      case extractPreviousAssocCmtPair rest of
         (Just comment, rest') ->
           let baseTxt = applyCrumbAndFormat node index
               formatted = (baseTxt <> " " <> formatComment comment) : acc
@@ -147,7 +152,6 @@ addDelimiters rs index rowIdx c complexChildren containerTrailingComma state acc
                 nextRowIdx
                 c
                 complexChildren
-                containerTrailingComma
                 state
                 formatted
                 rest'
@@ -160,11 +164,12 @@ addDelimiters rs index rowIdx c complexChildren containerTrailingComma state acc
                 nextRowIdx
                 c
                 complexChildren
-                containerTrailingComma
                 state
                 new_acc
                 rest
   where
+    restNodes = map fst rest
+
     newlineBeforeComment = case node of
       Comment ic | not (cMultiline ic) ->
         case acc of
@@ -174,8 +179,8 @@ addDelimiters rs index rowIdx c complexChildren containerTrailingComma state acc
           _ ->
             singleCharIfNot
               '\n'
-              (["\n"] == acc || not (cHadNewlineBefore ic) && any isObjectKeyNode rest)
-      _ -> singleCharIfNot '\n' (any isObjectKeyNode rest || ["\n"] == acc)
+              (["\n"] == acc || not (cHadNewlineBefore ic) && any isObjectKeyNode restNodes)
+      _ -> singleCharIfNot '\n' (any isObjectKeyNode restNodes || ["\n"] == acc)
 
     nextRowIdx =
       rowIdx + case node of
@@ -226,8 +231,7 @@ addDelimiters rs index rowIdx c complexChildren containerTrailingComma state acc
               let (formatted, spaces) = splitTrailing comma (NC.applyCrumb c (formatWithCursor rs emptyState) idx n)
                in formatted <> singleCharIf ',' comma <> spaces
 
-    comma = notNull rest || (null rest && trailingComma)
-    trailingComma =
+    comma =
       let tcMode =
             NC.applyCrumb
               c
@@ -239,9 +243,9 @@ addDelimiters rs index rowIdx c complexChildren containerTrailingComma state acc
               index
               node
        in case tcMode of
-            TC.Preserve -> containerTrailingComma
+            TC.Preserve -> nodeHadComma
             TC.Force -> True
-            TC.None -> False
+            TC.None -> notNull rest
     space = notNull rest && not complexChildren
     newline = complexChildren
 
@@ -259,7 +263,7 @@ maxColumnLengthsWithCache rs cursor nodes
   | V.null nodes = (V.empty, V.empty, False)
   | otherwise =
       let (nodesToProcess, headerWasExtracted) = case V.uncons nodes of
-            Just (Array (ArrayValue firstRow _), rest) | all isStringNode firstRow -> (rest, True)
+            Just (Array (ArrayValue firstRow), rest) | all (isStringNode . fst) firstRow -> (rest, True)
             _ -> (nodes, False)
           (arrayRows, arrayIndices) = extractArrayRows nodesToProcess (fromEnum headerWasExtracted)
           formattedColumns = transposeAndFormat rs cursor arrayRows arrayIndices
@@ -299,7 +303,11 @@ transposeAndFormat rs cursor vvs arrayIndices
                           formatRow rowCursor _rowNode =
                             let formatCell = formatWithCursor rs emptyState
                              in NC.applyCrumb rowCursor formatCell colIdx (row V.! colIdx)
-                       in NC.applyCrumb cursor formatRow actualRowIdx (Array (ArrayValue row False))
+                       in NC.applyCrumb
+                            cursor
+                            formatRow
+                            actualRowIdx
+                            (Array (ArrayValue (V.map (,True) row)))
                     else ""
               )
               vvs
@@ -308,11 +316,11 @@ doFormatNode
   :: RuleSet
   -> NC.NodeCursor
   -> FormattingState
-  -> Bool
-  -> Vector Node
+  -> Vector (Node, Bool)
   -> Text
-doFormatNode rs cursor state containerTrailingComma nodes =
-  let prefixProps = findPropertiesForCursor PrefixMatch cursor rs
+doFormatNode rs cursor state elems =
+  let nodes = V.map fst elems
+      prefixProps = findPropertiesForCursor PrefixMatch cursor rs
       exactProps = findPropertiesForCursor ExactMatch cursor rs
 
       autoPadEnabled = lookupRule AutoPad exactProps == Just True
@@ -342,9 +350,9 @@ doFormatNode rs cursor state containerTrailingComma nodes =
         | autopadSubObjectsEnabled =
             V.foldl'
               ( \acc n -> case n of
-                  ObjectKey (_, Object (ObjectValue subNodes _)) ->
+                  ObjectKey (_, Object (ObjectValue subElems)) ->
                     V.foldl'
-                      ( \acc2 sn -> case sn of
+                      ( \acc2 (sn, _) -> case sn of
                           ObjectKey (sk, sv) ->
                             let kt = formatScalarNode False sk
                                 vw =
@@ -357,7 +365,7 @@ doFormatNode rs cursor state containerTrailingComma nodes =
                           _ -> acc2
                       )
                       acc
-                      subNodes
+                      subElems
                   _ -> acc
               )
               Map.empty
@@ -385,9 +393,9 @@ doFormatNode rs cursor state containerTrailingComma nodes =
 
       formatted =
         reverse
-          . addDelimiters rs 0 0 cursor complexChildren containerTrailingComma state' []
+          . addDelimiters rs 0 0 cursor complexChildren state' []
           . V.toList
-          $ nodes
+          $ elems
 
       indentationAmount = fromMaybe 2 (lookupRule Indent prefixProps)
    in if complexChildren
@@ -421,20 +429,20 @@ formatScalarNode _ n = error $ "Unhandled scalar node: " <> show n
 
 formatWithCursor
   :: RuleSet -> FormattingState -> NC.NodeCursor -> Node -> Text
-formatWithCursor rs state cursor (Array (ArrayValue a tc))
+formatWithCursor rs state cursor (Array (ArrayValue a))
   | V.null a = "[]"
   | otherwise =
       T.concat
         [ "["
-        , doFormatNode rs cursor state tc a
+        , doFormatNode rs cursor state a
         , "]"
         ]
-formatWithCursor rs state cursor (Object (ObjectValue o tc))
+formatWithCursor rs state cursor (Object (ObjectValue o))
   | V.null o = "{}"
   | otherwise =
       T.concat
         [ "{"
-        , doFormatNode rs cursor state tc o
+        , doFormatNode rs cursor state o
         , "}"
         ]
 formatWithCursor rs state cursor (ObjectKey (k, v)) =

--- a/src/JbeamEdit/Formatting.hs
+++ b/src/JbeamEdit/Formatting.hs
@@ -41,7 +41,6 @@ import JbeamEdit.Core.Node (
 import JbeamEdit.Core.NodeCursor (newCursor)
 import JbeamEdit.Core.NodeCursor qualified as NC
 import JbeamEdit.Formatting.Rules (
-  ComplexNewLineMode (..),
   MatchMode (..),
   PropertyKey (..),
   RuleSet (..),
@@ -49,6 +48,9 @@ import JbeamEdit.Formatting.Rules (
   findPropertiesForCursor,
   lookupRule,
  )
+import JbeamEdit.Formatting.Rules.ComplexNewLine qualified as CNL
+import JbeamEdit.Formatting.Rules.TrailingComma (TrailingComma)
+import JbeamEdit.Formatting.Rules.TrailingComma qualified as TC
 import System.File.OsPath qualified as OS (writeFile)
 import System.OsPath (OsPath)
 
@@ -294,9 +296,9 @@ doFormatNode rs cursor state containerTrailingComma nodes =
       autopadSubObjectsEnabled = lookupRule AutoPadSubObjects exactProps == Just True
 
       complexChildren =
-        lookupRule ComplexNewLine prefixProps == Just Force
+        lookupRule ComplexNewLine prefixProps == Just CNL.Force
           || any (liftA2 (||) isSinglelineComment isComplexNode) nodes
-            && lookupRule ComplexNewLine prefixProps /= Just None
+            && lookupRule ComplexNewLine prefixProps /= Just CNL.None
 
       (colWidths, formattedCache, headerWasExtracted) =
         maxColumnLengthsWithCache rs cursor nodes
@@ -357,8 +359,11 @@ doFormatNode rs cursor state containerTrailingComma nodes =
               }
         | otherwise = state
 
-      preserveTC = fromMaybe True (lookupRule PreserveTrailingCommas prefixProps)
-      trailingComma = containerTrailingComma && preserveTC
+      tcMode = fromMaybe TC.Preserve (lookupRule TrailingComma prefixProps)
+      trailingComma = case tcMode of
+        TC.Preserve -> containerTrailingComma
+        TC.Force -> True
+        TC.None -> False
 
       formatted =
         reverse

--- a/src/JbeamEdit/Formatting.hs
+++ b/src/JbeamEdit/Formatting.hs
@@ -29,7 +29,6 @@ import JbeamEdit.Core.Node (
   Node (..),
   NumberValue (..),
   ObjectValue (..),
-  avNodes,
   commentIsAttachedToPreviousNode,
   expectArray,
   isCommentNode,

--- a/src/JbeamEdit/Formatting/Rules.hs
+++ b/src/JbeamEdit/Formatting/Rules.hs
@@ -11,7 +11,8 @@ module JbeamEdit.Formatting.Rules (
   SomeKey (..),
   SomeProperty (..),
   PropertyKey (..),
-  ComplexNewLineMode (..),
+  module JbeamEdit.Formatting.Rules.ComplexNewLine,
+  module JbeamEdit.Formatting.Rules.TrailingComma,
   Rule,
   RuleSet (..),
   lookupKey,
@@ -40,6 +41,10 @@ import Data.Type.Equality ((:~:) (Refl))
 import JbeamEdit.Core.Node
 import JbeamEdit.Core.NodeCursor qualified as NC
 import JbeamEdit.Core.NodePath (NodeSelector (..))
+import JbeamEdit.Formatting.Rules.ComplexNewLine (ComplexNewLine)
+import JbeamEdit.Formatting.Rules.ComplexNewLine qualified as CNL
+import JbeamEdit.Formatting.Rules.TrailingComma (TrailingComma)
+import JbeamEdit.Formatting.Rules.TrailingComma qualified as TC
 import Text.Read qualified as TR
 
 data NodePatternSelector
@@ -72,19 +77,16 @@ instance Ord NodePattern where
       EQ -> compare a b
       c -> c
 
-data ComplexNewLineMode = Force | None
-  deriving stock (Eq, Ord, Read, Show)
-
 data PropertyKey a where
   AutoPad :: PropertyKey Bool
-  ComplexNewLine :: PropertyKey ComplexNewLineMode
+  ComplexNewLine :: PropertyKey ComplexNewLine
   AlignObjectKeys :: PropertyKey Bool
   AutoPadSubObjects :: PropertyKey Bool
   PreserveNumberFormat :: PropertyKey Bool
   PadAmount :: PropertyKey Int
   PadDecimals :: PropertyKey Int
   Indent :: PropertyKey Int
-  PreserveTrailingCommas :: PropertyKey Bool
+  TrailingComma :: PropertyKey TrailingComma
 
 data SomeKey
   = forall a.
@@ -118,7 +120,7 @@ eqKey AutoPadSubObjects AutoPadSubObjects = Just Refl
 eqKey PreserveNumberFormat PreserveNumberFormat = Just Refl
 eqKey PadDecimals PadDecimals = Just Refl
 eqKey Indent Indent = Just Refl
-eqKey PreserveTrailingCommas PreserveTrailingCommas = Just Refl
+eqKey TrailingComma TrailingComma = Just Refl
 eqKey _ _ = Nothing
 
 instance Ord SomeKey where
@@ -162,7 +164,7 @@ propertyName PreserveNumberFormat = "PreserveNumberFormat"
 propertyName PadAmount = "PadAmount"
 propertyName PadDecimals = "PadDecimals"
 propertyName Indent = "Indent"
-propertyName PreserveTrailingCommas = "PreserveTrailingCommas"
+propertyName TrailingComma = "TrailingComma"
 
 keyName :: SomeKey -> Text
 keyName (SomeKey key) = propertyName key
@@ -178,11 +180,10 @@ boolProperties =
     , AlignObjectKeys
     , AutoPadSubObjects
     , PreserveNumberFormat
-    , PreserveTrailingCommas
     ]
 
 enumProperties :: [SomeKey]
-enumProperties = [SomeKey ComplexNewLine]
+enumProperties = [SomeKey ComplexNewLine, SomeKey TrailingComma]
 
 intProperties :: [SomeKey]
 intProperties = map SomeKey [PadAmount, PadDecimals, Indent]
@@ -197,16 +198,16 @@ deprecatedAliases =
     ( "NoComplexNewLine"
     ,
       ( SomeKey ComplexNewLine
-      , SomeProperty ComplexNewLine None
-      , SomeProperty ComplexNewLine Force
+      , SomeProperty ComplexNewLine CNL.None
+      , SomeProperty ComplexNewLine CNL.Force
       )
     )
   ,
     ( "ForceComplexNewLine"
     ,
       ( SomeKey ComplexNewLine
-      , SomeProperty ComplexNewLine Force
-      , SomeProperty ComplexNewLine None
+      , SomeProperty ComplexNewLine CNL.Force
+      , SomeProperty ComplexNewLine CNL.None
       )
     )
   ]
@@ -247,7 +248,7 @@ applyPadLogic f rs n =
         | otherwise = f n
    in bool (T.justifyLeft padAmount ' ' decimalPaddedText) (f n) (isComplexNode n)
 
-complexNewLine :: RuleSet -> NC.NodeCursor -> Maybe ComplexNewLineMode
+complexNewLine :: RuleSet -> NC.NodeCursor -> Maybe ComplexNewLine
 complexNewLine rs cursor =
   let ps = findPropertiesForCursor PrefixMatch cursor rs
    in lookupProp ComplexNewLine ps

--- a/src/JbeamEdit/Formatting/Rules.hs
+++ b/src/JbeamEdit/Formatting/Rules.hs
@@ -84,6 +84,7 @@ data PropertyKey a where
   PadAmount :: PropertyKey Int
   PadDecimals :: PropertyKey Int
   Indent :: PropertyKey Int
+  PreserveTrailingCommas :: PropertyKey Bool
 
 data SomeKey
   = forall a.
@@ -117,6 +118,7 @@ eqKey AutoPadSubObjects AutoPadSubObjects = Just Refl
 eqKey PreserveNumberFormat PreserveNumberFormat = Just Refl
 eqKey PadDecimals PadDecimals = Just Refl
 eqKey Indent Indent = Just Refl
+eqKey PreserveTrailingCommas PreserveTrailingCommas = Just Refl
 eqKey _ _ = Nothing
 
 instance Ord SomeKey where
@@ -160,6 +162,7 @@ propertyName PreserveNumberFormat = "PreserveNumberFormat"
 propertyName PadAmount = "PadAmount"
 propertyName PadDecimals = "PadDecimals"
 propertyName Indent = "Indent"
+propertyName PreserveTrailingCommas = "PreserveTrailingCommas"
 
 keyName :: SomeKey -> Text
 keyName (SomeKey key) = propertyName key
@@ -175,6 +178,7 @@ boolProperties =
     , AlignObjectKeys
     , AutoPadSubObjects
     , PreserveNumberFormat
+    , PreserveTrailingCommas
     ]
 
 enumProperties :: [SomeKey]

--- a/src/JbeamEdit/Formatting/Rules/ComplexNewLine.hs
+++ b/src/JbeamEdit/Formatting/Rules/ComplexNewLine.hs
@@ -1,0 +1,4 @@
+module JbeamEdit.Formatting.Rules.ComplexNewLine (ComplexNewLine (..)) where
+
+data ComplexNewLine = Force | None
+  deriving stock (Eq, Ord, Read, Show)

--- a/src/JbeamEdit/Formatting/Rules/TrailingComma.hs
+++ b/src/JbeamEdit/Formatting/Rules/TrailingComma.hs
@@ -1,0 +1,4 @@
+module JbeamEdit.Formatting.Rules.TrailingComma (TrailingComma (..)) where
+
+data TrailingComma = Preserve | Force | None
+  deriving stock (Eq, Ord, Read, Show)

--- a/src/JbeamEdit/Parsing/DSL.hs
+++ b/src/JbeamEdit/Parsing/DSL.hs
@@ -100,6 +100,7 @@ parseValueForKey PreserveNumberFormat = parseBool <?> "bool"
 parseValueForKey PadAmount = L.decimal <?> "integer"
 parseValueForKey PadDecimals = L.decimal <?> "integer"
 parseValueForKey Indent = L.decimal <?> "integer"
+parseValueForKey PreserveTrailingCommas = parseBool <?> "bool"
 
 parseComplexNewLineMode :: JbflParser ComplexNewLineMode
 parseComplexNewLineMode =

--- a/src/JbeamEdit/Parsing/DSL.hs
+++ b/src/JbeamEdit/Parsing/DSL.hs
@@ -26,6 +26,10 @@ import Data.Text.Encoding (decodeUtf8')
 import Data.Word (Word8)
 import JbeamEdit.Core.NodePath
 import JbeamEdit.Formatting.Rules
+import JbeamEdit.Formatting.Rules.ComplexNewLine (ComplexNewLine)
+import JbeamEdit.Formatting.Rules.ComplexNewLine qualified as CNL
+import JbeamEdit.Formatting.Rules.TrailingComma (TrailingComma)
+import JbeamEdit.Formatting.Rules.TrailingComma qualified as TC
 import JbeamEdit.Parsing.Common
 import Text.Megaparsec ((<?>))
 import Text.Megaparsec qualified as MP
@@ -93,20 +97,28 @@ propertyParser (SomeKey key) = do
 
 parseValueForKey :: PropertyKey a -> JbflParser a
 parseValueForKey AutoPad = parseBool <?> "bool"
-parseValueForKey ComplexNewLine = parseComplexNewLineMode <?> "Force or None"
+parseValueForKey ComplexNewLine = parseComplexNewLine <?> "Force or None"
 parseValueForKey AlignObjectKeys = parseBool <?> "bool"
 parseValueForKey AutoPadSubObjects = parseBool <?> "bool"
 parseValueForKey PreserveNumberFormat = parseBool <?> "bool"
 parseValueForKey PadAmount = L.decimal <?> "integer"
 parseValueForKey PadDecimals = L.decimal <?> "integer"
 parseValueForKey Indent = L.decimal <?> "integer"
-parseValueForKey PreserveTrailingCommas = parseBool <?> "bool"
+parseValueForKey TrailingComma = parseTrailingCommaMode <?> "Preserve, Force or None"
 
-parseComplexNewLineMode :: JbflParser ComplexNewLineMode
-parseComplexNewLineMode =
+parseComplexNewLine :: JbflParser ComplexNewLine
+parseComplexNewLine =
   tryParsers
-    [ B.string "Force" $> Force
-    , B.string "None" $> None
+    [ B.string "Force" $> CNL.Force
+    , B.string "None" $> CNL.None
+    ]
+
+parseTrailingCommaMode :: JbflParser TrailingComma
+parseTrailingCommaMode =
+  tryParsers
+    [ B.string "Preserve" $> TC.Preserve
+    , B.string "Force" $> TC.Force
+    , B.string "None" $> TC.None
     ]
 
 skipComment :: JbflParser ()

--- a/src/JbeamEdit/Parsing/Jbeam.hs
+++ b/src/JbeamEdit/Parsing/Jbeam.hs
@@ -175,14 +175,27 @@ nodeParser = skipWhiteSpace *> (anyNode <|> failingParser expLabels)
 ---
 --- selectors for objects, object keys and arrays
 ---
+
+collectElements :: JbeamParser Node -> JbeamParser [(Node, Bool)]
+collectElements p = go []
+  where
+    go acc = do
+      skipWhiteSpace
+      done <- MP.optional (MP.lookAhead (byteChar ']' <|> byteChar '}'))
+      case done of
+        Just _ -> pure (reverse acc)
+        Nothing -> do
+          n <- p
+          separatorParser
+          hadComma <- gets lastSeparatorHadComma
+          go ((n, hadComma) : acc)
+
 arrayParser :: JbeamParser Node
 arrayParser = do
   _ <- byteChar '['
-  elems <- MP.sepEndBy nodeParser separatorParser
-  trailingComma <- gets lastSeparatorHadComma
-  _ <- MP.optional separatorParser
+  elems <- collectElements nodeParser
   _ <- byteChar ']'
-  pure . Array $ ArrayValue (V.fromList elems) (trailingComma && not (null elems))
+  pure . Array $ ArrayValue (V.fromList elems)
 
 objectKeyParser :: JbeamParser Node
 objectKeyParser = do
@@ -191,21 +204,14 @@ objectKeyParser = do
   _ <- skipWhiteSpace
   _ <- byteChar ':'
   value <- nodeParser
-  let obj = ObjectKey (key, value)
-  c <- MP.lookAhead B.asciiChar
-  case toChar c of
-    '}' -> modify (\s -> s {lastSeparatorHadComma = False}) $> obj
-    _ -> separatorParser $> obj
+  pure $ ObjectKey (key, value)
 
 objectParser :: JbeamParser Node
 objectParser = do
   _ <- byteChar '{'
-  skipWhiteSpace
-  keys <- MP.many (commentParser <* separatorParser <|> objectKeyParser)
-  trailingComma <- gets lastSeparatorHadComma
-  _ <- MP.optional separatorParser
+  elems <- collectElements (commentParser <|> objectKeyParser)
   _ <- byteChar '}'
-  pure . Object $ ObjectValue (V.fromList keys) (trailingComma && not (null keys))
+  pure . Object $ ObjectValue (V.fromList elems)
 
 topNodeParser :: JbeamParser Node
 topNodeParser = nodeParser <* skipWhiteSpace <* MP.eof

--- a/src/JbeamEdit/Parsing/Jbeam.hs
+++ b/src/JbeamEdit/Parsing/Jbeam.hs
@@ -15,7 +15,7 @@ import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as LBS
 import Data.Char (isSpace)
 import Data.Functor (($>))
-import Data.Maybe (isNothing)
+import Data.Maybe (isJust, isNothing)
 import Data.Monoid.Extra (mwhen)
 import Data.Scientific (Scientific)
 import Data.Text (Text)
@@ -24,10 +24,12 @@ import Data.Text.Encoding (decodeUtf8Lenient)
 import Data.Vector qualified as V (fromList)
 import Data.Void (Void)
 import JbeamEdit.Core.Node (
+  ArrayValue (..),
   AssociationDirection (..),
   InternalComment (..),
   Node (..),
   NumberValue (..),
+  ObjectValue (..),
   mkNumberValue,
  )
 import JbeamEdit.Parsing.Common
@@ -40,6 +42,7 @@ import Text.Megaparsec.Char qualified as C
 data ParseState = ParseState
   { lastNodeEndedWithNewline :: Bool
   , lastSeparatorHadBlankLine :: Bool
+  , lastSeparatorHadComma :: Bool
   }
 
 type JbeamParser a = Parser (State ParseState) a
@@ -61,6 +64,7 @@ separatorParser = do
         s
           { lastNodeEndedWithNewline = hasNewline
           , lastSeparatorHadBlankLine = totalNewlines >= 2
+          , lastSeparatorHadComma = isJust comma
           }
     )
 
@@ -175,9 +179,10 @@ arrayParser :: JbeamParser Node
 arrayParser = do
   _ <- byteChar '['
   elems <- MP.sepEndBy nodeParser separatorParser
+  trailingComma <- gets lastSeparatorHadComma
   _ <- MP.optional separatorParser
   _ <- byteChar ']'
-  pure . Array . V.fromList $ elems
+  pure . Array $ ArrayValue (V.fromList elems) (trailingComma && not (null elems))
 
 objectKeyParser :: JbeamParser Node
 objectKeyParser = do
@@ -189,7 +194,7 @@ objectKeyParser = do
   let obj = ObjectKey (key, value)
   c <- MP.lookAhead B.asciiChar
   case toChar c of
-    '}' -> pure obj
+    '}' -> modify (\s -> s {lastSeparatorHadComma = False}) $> obj
     _ -> separatorParser $> obj
 
 objectParser :: JbeamParser Node
@@ -197,9 +202,10 @@ objectParser = do
   _ <- byteChar '{'
   skipWhiteSpace
   keys <- MP.many (commentParser <* separatorParser <|> objectKeyParser)
+  trailingComma <- gets lastSeparatorHadComma
   _ <- MP.optional separatorParser
   _ <- byteChar '}'
-  pure . Object . V.fromList $ keys
+  pure . Object $ ObjectValue (V.fromList keys) (trailingComma && not (null keys))
 
 topNodeParser :: JbeamParser Node
 topNodeParser = nodeParser <* skipWhiteSpace <* MP.eof
@@ -210,7 +216,11 @@ parseNodesState
   -> Either (MP.ParseErrorBundle LBS.ByteString Void) a
 parseNodesState parser input =
   let initialState =
-        ParseState {lastNodeEndedWithNewline = True, lastSeparatorHadBlankLine = False}
+        ParseState
+          { lastNodeEndedWithNewline = True
+          , lastSeparatorHadBlankLine = False
+          , lastSeparatorHadComma = False
+          }
    in evalState (MP.runParserT parser "<input>" input) initialState
 
 parseNodes :: LBS.ByteString -> Either Text Node

--- a/test-extra/language-server/data/fender-custom-minimal-jbfl.jbeam
+++ b/test-extra/language-server/data/fender-custom-minimal-jbfl.jbeam
@@ -2,7 +2,7 @@
   "cot_fender" : {
     "information" : {
       "authors" : "gittarrgy01",
-      "name"    : "Fenders"
+      "name"    : "Fenders",
     },
     "sounds" : {
       "impactMetal"   : "event:>Destruction>Props>fender_metal",
@@ -55,7 +55,7 @@
       {"nodeWeight" : 1.2},
       {"group" : ""},
       ["bfsl",   0.684,    -1.079,   0.507   ],
-      ["bfsr",   -0.623,   -1.064,   0.507   ]
+      ["bfsr",   -0.623,   -1.064,   0.507   ],
     ],
     "beams" : [
       ["id1:",  "id2:"],
@@ -272,7 +272,7 @@
       ["bfr8",  "mbr0"],
       ["bfr9",  "mbr1"],
       ["bfr10", "mbr2"],
-      {"breakGroup" : "", "breakGroupType" : "", "beamType" : "|NORMAL"}
+      {"breakGroup" : "", "breakGroupType" : "", "beamType" : "|NORMAL"},
     ],
     "triangles" : [
       ["id1:",  "id2:",  "id3:"],
@@ -293,14 +293,14 @@
       ["bfr10", "bfr6",  "bfr7"],
       ["bfr9",  "bfr6",  "bfr10"],
       ["bfr9",  "bfr8",  "bfr6"],
-      ["bfr5",  "bfr6",  "bfr8"]
+      ["bfr5",  "bfr6",  "bfr8"],
     ],
     "flexbodies" : [
       ["mesh", "[group]:", "nonFlexMaterials"],
       ["impala_fender_l", ["cot_fender_l"]],
       ["impala_fender_inter_l", ["cot_fender_l"]],
       ["impala_fender_r", ["cot_fender_r"]],
-      ["impala_fender_inter_r", ["cot_fender_r"]]
-    ]
-  }
+      ["impala_fender_inter_r", ["cot_fender_r"]],
+    ],
+  },
 }

--- a/test/Core/NodePathSpec.hs
+++ b/test/Core/NodePathSpec.hs
@@ -9,7 +9,7 @@ spec :: Spec
 spec = describe "select" $ do
   it "selects an element by ArrayIndex, ignoring comments" $ do
     let arr =
-          Array $
+          mkArray $
             fromList
               [ Comment (InternalComment "c" False NextNode False)
               , String "first"
@@ -21,14 +21,14 @@ spec = describe "select" $ do
 
   it "selects a value by ObjectKey" $ do
     let obj =
-          Object $ fromList [ObjectKey (String "first_key", String "first value")]
+          mkObject $ fromList [ObjectKey (String "first_key", String "first value")]
     NP.select (NP.ObjectKey "first_key") obj
       `shouldBe` Just (String "first value")
     NP.select (NP.ObjectKey "second_key") obj `shouldBe` Nothing
 
   it "selects a value by ObjectIndex" $ do
     let obj =
-          Object $
+          mkObject $
             fromList
               [ ObjectKey (String "first_key", String "first value")
               , ObjectKey (String "second_key", String "second value")

--- a/test/Core/NodeSpec.hs
+++ b/test/Core/NodeSpec.hs
@@ -14,7 +14,7 @@ spec = do
   describe "isObjectNode" . works $
     ( do
         isObjectNode
-          ( Object
+          ( mkObject
               (V.singleton (ObjectKey (String "test", Number (mkNumberValueNormalized 1))))
           )
           `shouldBe` True
@@ -34,12 +34,12 @@ spec = do
     ( do
         isComplexNode (Number (mkNumberValueNormalized 123)) `shouldBe` False
         isComplexNode
-          ( Object
+          ( mkObject
               (V.singleton (ObjectKey (String "test", Number (mkNumberValueNormalized 1))))
           )
           `shouldBe` False
         isComplexNode
-          ( Object
+          ( mkObject
               ( V.fromList
                   [ ObjectKey (String "test", Number (mkNumberValueNormalized 1))
                   , ObjectKey (String "test", Number (mkNumberValueNormalized 1))
@@ -48,6 +48,6 @@ spec = do
           )
           `shouldBe` True
         isComplexNode
-          (Array (V.fromList [String "test", Number (mkNumberValueNormalized 1)]))
+          (mkArray (V.fromList [String "test", Number (mkNumberValueNormalized 1)]))
           `shouldBe` True
     )

--- a/test/FormattingSpec.hs
+++ b/test/FormattingSpec.hs
@@ -39,7 +39,7 @@ arraySpec :: [(String, Node)]
 arraySpec =
   [
     ( "[1, 2, 3]"
-    , Array
+    , mkArray
         ( fromList
             [ Number (mkNumberValue "1" 1)
             , Number (mkNumberValue "2" 2)
@@ -53,7 +53,7 @@ objectSpec :: [(String, Node)]
 objectSpec =
   [
     ( "{\"test\" : 1, \"test2\" : 2}"
-    , Object
+    , mkObject
         ( fromList
             [ ObjectKey (String "test", Number (mkNumberValue "1" 1))
             , ObjectKey (String "test2", Number (mkNumberValue "2" 2))

--- a/test/Parsing/DSLSpec.hs
+++ b/test/Parsing/DSLSpec.hs
@@ -10,6 +10,7 @@ import Data.Text.Encoding (encodeUtf8)
 import Data.Void (Void)
 import JbeamEdit.Core.NodePath qualified as NP (NodeSelector (..))
 import JbeamEdit.Formatting.Rules
+import JbeamEdit.Formatting.Rules.ComplexNewLine qualified as CNL
 import JbeamEdit.Parsing.Common.Helpers
 import JbeamEdit.Parsing.DSL
 import SpecHelper
@@ -40,11 +41,11 @@ enumProperties :: [(String, (SomeKey, SomeProperty))]
 enumProperties =
   [
     ( "ComplexNewLine : Force;"
-    , (SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force)
+    , (SomeKey ComplexNewLine, SomeProperty ComplexNewLine CNL.Force)
     )
   ,
     ( "ComplexNewLine : None;"
-    , (SomeKey ComplexNewLine, SomeProperty ComplexNewLine None)
+    , (SomeKey ComplexNewLine, SomeProperty ComplexNewLine CNL.None)
     )
   ]
 
@@ -52,11 +53,11 @@ deprecatedProperties :: [(String, (SomeKey, SomeProperty))]
 deprecatedProperties =
   [
     ( "NoComplexNewLine : true;"
-    , (SomeKey ComplexNewLine, SomeProperty ComplexNewLine None)
+    , (SomeKey ComplexNewLine, SomeProperty ComplexNewLine CNL.None)
     )
   ,
     ( "ForceComplexNewLine : true;"
-    , (SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force)
+    , (SomeKey ComplexNewLine, SomeProperty ComplexNewLine CNL.Force)
     )
   ]
 

--- a/test/Parsing/JbeamSpec.hs
+++ b/test/Parsing/JbeamSpec.hs
@@ -77,7 +77,7 @@ singlelineCommentSpec =
     )
   ,
     ( "[\"test\", \"test\" // cool comment \n ]"
-    , Array
+    , mkArray
         ( fromList
             [ String "test"
             , String "test"
@@ -98,7 +98,7 @@ arraySpec :: [(String, Node)]
 arraySpec =
   [
     ( "[1,2,3]"
-    , Array
+    , mkArray
         ( fromList
             [ Number (mkNumberValue "1" 1)
             , Number (mkNumberValue "2" 2)
@@ -108,7 +108,7 @@ arraySpec =
     )
   ,
     ( "[1\n 2\n 3]"
-    , Array
+    , mkArray
         ( fromList
             [ Number (mkNumberValue "1" 1)
             , Number (mkNumberValue "2" 2)
@@ -122,17 +122,17 @@ objectSpec :: [(String, Node)]
 objectSpec =
   [
     ( "{}"
-    , Object
+    , mkObject
         (fromList [])
     )
   ,
     ( "{ }"
-    , Object
+    , mkObject
         (fromList [])
     )
   ,
     ( "{\n//test\n\"test\" : 1, \"test2\" : 2}"
-    , Object
+    , mkObject
         ( fromList
             [ Comment (InternalComment "test" False NextNode False)
             , ObjectKey (String "test", Number (mkNumberValue "1" 1))
@@ -142,7 +142,7 @@ objectSpec =
     )
   ,
     ( "{\"test\" : 1, \"test2\" : 2}"
-    , Object
+    , mkObject
         ( fromList
             [ ObjectKey (String "test", Number (mkNumberValue "1" 1))
             , ObjectKey (String "test2", Number (mkNumberValue "2" 2))
@@ -151,7 +151,7 @@ objectSpec =
     )
   ,
     ( "{\"test\" : 1\n \"test2\" : 2}"
-    , Object
+    , mkObject
         ( fromList
             [ ObjectKey (String "test", Number (mkNumberValue "1" 1))
             , ObjectKey (String "test2", Number (mkNumberValue "2" 2))

--- a/test/Parsing/JbeamSpec.hs
+++ b/test/Parsing/JbeamSpec.hs
@@ -77,19 +77,27 @@ singlelineCommentSpec =
     )
   ,
     ( "[\"test\", \"test\" // cool comment \n ]"
-    , mkArray
-        ( fromList
-            [ String "test"
-            , String "test"
-            , Comment
-                ( InternalComment
-                    { cText = "cool comment"
-                    , cMultiline = False
-                    , cAssociationDirection = PreviousNode
-                    , cHadNewlineBefore = False
-                    }
-                )
-            ]
+    , Array
+        ( ArrayValue
+            ( fromList
+                [ (String "test", True)
+                ,
+                  ( String "test"
+                  , False
+                  )
+                ,
+                  ( Comment
+                      ( InternalComment
+                          { cText = "cool comment"
+                          , cMultiline = False
+                          , cAssociationDirection = PreviousNode
+                          , cHadNewlineBefore = False
+                          }
+                      )
+                  , False
+                  )
+                ]
+            )
         )
     )
   ]
@@ -98,22 +106,26 @@ arraySpec :: [(String, Node)]
 arraySpec =
   [
     ( "[1,2,3]"
-    , mkArray
-        ( fromList
-            [ Number (mkNumberValue "1" 1)
-            , Number (mkNumberValue "2" 2)
-            , Number (mkNumberValue "3" 3)
-            ]
+    , Array
+        ( ArrayValue
+            ( fromList
+                [ (Number (mkNumberValue "1" 1), True)
+                , (Number (mkNumberValue "2" 2), True)
+                , (Number (mkNumberValue "3" 3), False)
+                ]
+            )
         )
     )
   ,
     ( "[1\n 2\n 3]"
-    , mkArray
-        ( fromList
-            [ Number (mkNumberValue "1" 1)
-            , Number (mkNumberValue "2" 2)
-            , Number (mkNumberValue "3" 3)
-            ]
+    , Array
+        ( ArrayValue
+            ( fromList
+                [ (Number (mkNumberValue "1" 1), False)
+                , (Number (mkNumberValue "2" 2), False)
+                , (Number (mkNumberValue "3" 3), False)
+                ]
+            )
         )
     )
   ]
@@ -132,30 +144,36 @@ objectSpec =
     )
   ,
     ( "{\n//test\n\"test\" : 1, \"test2\" : 2}"
-    , mkObject
-        ( fromList
-            [ Comment (InternalComment "test" False NextNode False)
-            , ObjectKey (String "test", Number (mkNumberValue "1" 1))
-            , ObjectKey (String "test2", Number (mkNumberValue "2" 2))
-            ]
+    , Object
+        ( ObjectValue
+            ( fromList
+                [ (Comment (InternalComment "test" False NextNode False), False)
+                , (ObjectKey (String "test", Number (mkNumberValue "1" 1)), True)
+                , (ObjectKey (String "test2", Number (mkNumberValue "2" 2)), False)
+                ]
+            )
         )
     )
   ,
     ( "{\"test\" : 1, \"test2\" : 2}"
-    , mkObject
-        ( fromList
-            [ ObjectKey (String "test", Number (mkNumberValue "1" 1))
-            , ObjectKey (String "test2", Number (mkNumberValue "2" 2))
-            ]
+    , Object
+        ( ObjectValue
+            ( fromList
+                [ (ObjectKey (String "test", Number (mkNumberValue "1" 1)), True)
+                , (ObjectKey (String "test2", Number (mkNumberValue "2" 2)), False)
+                ]
+            )
         )
     )
   ,
     ( "{\"test\" : 1\n \"test2\" : 2}"
-    , mkObject
-        ( fromList
-            [ ObjectKey (String "test", Number (mkNumberValue "1" 1))
-            , ObjectKey (String "test2", Number (mkNumberValue "2" 2))
-            ]
+    , Object
+        ( ObjectValue
+            ( fromList
+                [ (ObjectKey (String "test", Number (mkNumberValue "1" 1)), False)
+                , (ObjectKey (String "test2", Number (mkNumberValue "2" 2)), False)
+                ]
+            )
         )
     )
   ]
@@ -214,7 +232,7 @@ invalidTopNodeSpec = do
   describe desc . works $
     parseNodes input
       `shouldBe` Left
-        "got: '{', expecting '}', comma, comment, string or white space somewhere close to {\"collision\" : true}, on line 9"
+        "got: '{\"', expecting ']', '}', comment, string or white space somewhere close to {\"collision\" : true}, on line 9"
 
 spec :: Spec
 spec = do


### PR DESCRIPTION
Added a new jbfl property which lets users whether to put commas after the last element in a array or object. A third option, Preserve, is available which retains the original commas from the source files.