### PR TITLE
Stop copying default config to app data

### DIFF
--- a/src/JbeamEdit/Formatting/Config.hs
+++ b/src/JbeamEdit/Formatting/Config.hs
@@ -72,14 +72,10 @@ copyConfigFile configType dest = do
 copyToConfigDir :: ConfigType -> IO ()
 copyToConfigDir configType = getConfigDir >>= copyConfigFile configType . (</> userRuleFile)
 
-createRuleFileIfDoesNotExist :: OsPath -> IO ()
-createRuleFileIfDoesNotExist configPath = doesFileExist configPath `unlessM` copyConfigFile MinimalConfig configPath
-
 readFormattingConfig :: Maybe OsPath -> IO RuleSet
 readFormattingConfig maybeJbflPath = do
   configDir <- getConfigDir
   traverse_ (putErrorLine . (<>) "Loading jbfl: " . T.show) maybeJbflPath
-  createRuleFileIfDoesNotExist (configDir </> userRuleFile)
   configPath <- getConfigPath maybeJbflPath configDir
   userCfg <- tryReadFile [NoSuchThing] configPath
   defaultRulesetPath <- getJbflSourcePath MinimalConfig


### PR DESCRIPTION
No longer needed since we merge the app data config with the shipped config anyway.