### PR TITLE
Use the new get-tested rc

### DIFF
--- a/.github/scripts/add_experimental_flags.sh
+++ b/.github/scripts/add_experimental_flags.sh
@@ -12,8 +12,9 @@ if [[ -z "$CABAL_FILE" || ! -f "$CABAL_FILE" ]]; then
   exit 1
 fi
 
+echo "output from get-tested: $MATRIX"
 MATRIX_JSON=$(sed -E 's/^matrix=//' <<<"$MATRIX")
-
+MATRIX_JSON=$(jq '{include: map({ghc: .})}' <<<"$MATRIX_JSON")
 readarray -t EXP_FLAGS < <(awk -f ./.github/script_helpers/extract_flags.awk "$CABAL_FILE")
 
 ORIGINAL=$(jq --arg label "stable" '.include[0] += {label: $label}' <<<"$MATRIX_JSON")
@@ -25,8 +26,7 @@ if [[ ${#EXP_FLAGS[@]} -eq 0 ]]; then
 else
   EXP_FLAGS_STRING=$(printf '+%s ' "${EXP_FLAGS[@]}")
   EXPERIMENTAL=$(jq --arg flags "$EXP_FLAGS_STRING" --arg label "experimental" \
-    '.include[0] += {ghc: .include[0].ghc, flags: $flags, label: $label}' <<<"$MATRIX_JSON")
-
+    '.include[0] += {flags: $flags, label: $label}' <<<"$ORIGINAL")
   UPDATED=$(jq --argjson exp_include "$(jq '.include' <<<"$EXPERIMENTAL")" \
     '.include += $exp_include' <<<"$ORIGINAL")
 fi

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -28,12 +28,12 @@ jobs:
     steps:
       - name: Extract the tested GHC versions
         id: get-latest-version
-        uses: Kleidukos/get-tested@v0.1.9.1
+        uses: Kleidukos/get-tested@31055ac4c402ea72a6410d5e035ed591473e1736
         with:
           cabal-file: jbeam-edit.cabal
-          windows-version: latest
-          version: 0.1.9.1
+          version: 0.1.10.0-rc2
           newest: true
+          versions-only: true
       - uses: actions/checkout@v6
       - name: Add experimental flags
         id: add-exp


### PR DESCRIPTION
get-tested@0.1.10.0-rc2 with versions-only: true returns a bare
version array instead of a wrapped matrix object. Normalize the
input into `{include: [{ghc, label}]}` before processing.