### PR TITLE
Drop GHC 9.6.6, add GHC 9.14.1 support

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -161,8 +161,6 @@ jobs:
         shell: bash
         run:
           cabal configure --project-file cabal.project.ci --prefer-oldest
-      - run: sed -i 's/ +lsp-server//' cabal.project.ci
-        if: matrix.ghc == '9.6.6'
       - name: Freeze and check dependencies
         env:
           CABAL_PROJECT: cabal.project.ci

--- a/cabal.project.ci
+++ b/cabal.project.ci
@@ -8,3 +8,4 @@ package jbeam-edit
   ghc-options:
     -Werror
     -Wwarn=unused-imports
+    -Wwarn=redundant-constraints

--- a/cabal.project.release
+++ b/cabal.project.release
@@ -1,7 +1,7 @@
 import: cabal.project
 executable-static: True
 executable-stripping: True
-index-state: hackage.haskell.org 2026-01-11T16:27:22Z
+index-state: hackage.haskell.org 2026-06-15T00:00:00Z
 
 package *
   ghc-options:

--- a/jbeam-edit.cabal
+++ b/jbeam-edit.cabal
@@ -11,7 +11,7 @@ license-file:       LICENSE
 copyright:          2025 webdevred
 maintainer:         example@example.com
 author:             webdevred
-tested-with:        ghc ==9.6.6 ghc ==9.10.3
+tested-with:        ghc ==9.10.3
 homepage:           https://github.com/webdevred/jbeam-edit#readme
 bug-reports:        https://github.com/webdevred/jbeam-edit/issues
 synopsis:
@@ -98,7 +98,7 @@ library
         -Wunused-packages
 
     build-depends:
-        base >=4.18 && <4.22,
+        base >=4.20 && <4.22,
         bytestring,
         containers,
         directory >=1.3.8.0,
@@ -150,7 +150,7 @@ library jbeam-edit-transformation
         -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints
 
     build-depends:
-        base >=4.18 && <4.22,
+        base >=4.20 && <4.22,
         bytestring,
         containers,
         directory >=1.3.8.0,
@@ -198,7 +198,7 @@ library jbeam-language-server
         -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints
 
     build-depends:
-        base >=4.18 && <4.22,
+        base >=4.20 && <4.22,
         bytestring,
         containers,
         directory >=1.3.8.0,
@@ -244,7 +244,7 @@ executable jbeam-edit
         -threaded -rtsopts -with-rtsopts=-N
 
     build-depends:
-        base >=4.18 && <4.22,
+        base >=4.20 && <4.22,
         bytestring,
         containers,
         directory >=1.3.8.0,
@@ -282,7 +282,7 @@ executable jbeam-edit-dump-ast
         -threaded -rtsopts -with-rtsopts=-N
 
     build-depends:
-        base >=4.18 && <4.22,
+        base >=4.20 && <4.22,
         bytestring,
         containers,
         directory >=1.3.8.0,
@@ -327,7 +327,7 @@ executable jbeam-lsp-server
         -threaded -rtsopts -with-rtsopts=-N
 
     build-depends:
-        base >=4.18 && <4.22,
+        base >=4.20 && <4.22,
         bytestring,
         containers,
         directory >=1.3.8.0,
@@ -379,7 +379,7 @@ test-suite jbeam-edit-test
         -threaded -rtsopts -with-rtsopts=-N
 
     build-depends:
-        base >=4.18 && <4.22,
+        base >=4.20 && <4.22,
         bytestring,
         containers,
         directory >=1.3.8.0,
@@ -420,7 +420,7 @@ test-suite jbeam-edit-transformation-test
         -threaded -rtsopts -with-rtsopts=-N
 
     build-depends:
-        base >=4.18 && <4.22,
+        base >=4.20 && <4.22,
         bytestring,
         containers,
         directory >=1.3.8.0,
@@ -470,7 +470,7 @@ test-suite jbeam-language-server-test
         -threaded -rtsopts -with-rtsopts=-N
 
     build-depends:
-        base >=4.18 && <4.22,
+        base >=4.20 && <4.22,
         bytestring,
         containers,
         directory >=1.3.8.0,

--- a/jbeam-edit.cabal
+++ b/jbeam-edit.cabal
@@ -11,7 +11,7 @@ license-file:       LICENSE
 copyright:          2025 webdevred
 maintainer:         example@example.com
 author:             webdevred
-tested-with:        ghc ==9.10.3
+tested-with:        ghc ==9.10.3 ghc ==9.14.1
 homepage:           https://github.com/webdevred/jbeam-edit#readme
 bug-reports:        https://github.com/webdevred/jbeam-edit/issues
 synopsis:
@@ -98,7 +98,7 @@ library
         -Wunused-packages
 
     build-depends:
-        base >=4.20 && <4.22,
+        base >=4.20,
         bytestring,
         containers,
         directory >=1.3.8.0,
@@ -150,7 +150,7 @@ library jbeam-edit-transformation
         -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints
 
     build-depends:
-        base >=4.20 && <4.22,
+        base >=4.20,
         bytestring,
         containers,
         directory >=1.3.8.0,
@@ -198,7 +198,7 @@ library jbeam-language-server
         -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints
 
     build-depends:
-        base >=4.20 && <4.22,
+        base >=4.20,
         bytestring,
         containers,
         directory >=1.3.8.0,
@@ -244,7 +244,7 @@ executable jbeam-edit
         -threaded -rtsopts -with-rtsopts=-N
 
     build-depends:
-        base >=4.20 && <4.22,
+        base >=4.20,
         bytestring,
         containers,
         directory >=1.3.8.0,
@@ -282,7 +282,7 @@ executable jbeam-edit-dump-ast
         -threaded -rtsopts -with-rtsopts=-N
 
     build-depends:
-        base >=4.20 && <4.22,
+        base >=4.20,
         bytestring,
         containers,
         directory >=1.3.8.0,
@@ -327,7 +327,7 @@ executable jbeam-lsp-server
         -threaded -rtsopts -with-rtsopts=-N
 
     build-depends:
-        base >=4.20 && <4.22,
+        base >=4.20,
         bytestring,
         containers,
         directory >=1.3.8.0,
@@ -379,7 +379,7 @@ test-suite jbeam-edit-test
         -threaded -rtsopts -with-rtsopts=-N
 
     build-depends:
-        base >=4.20 && <4.22,
+        base >=4.20,
         bytestring,
         containers,
         directory >=1.3.8.0,
@@ -420,7 +420,7 @@ test-suite jbeam-edit-transformation-test
         -threaded -rtsopts -with-rtsopts=-N
 
     build-depends:
-        base >=4.20 && <4.22,
+        base >=4.20,
         bytestring,
         containers,
         directory >=1.3.8.0,
@@ -470,7 +470,7 @@ test-suite jbeam-language-server-test
         -threaded -rtsopts -with-rtsopts=-N
 
     build-depends:
-        base >=4.20 && <4.22,
+        base >=4.20,
         bytestring,
         containers,
         directory >=1.3.8.0,

--- a/package.yaml
+++ b/package.yaml
@@ -25,10 +25,10 @@ description: >-
   and can automatically rename nodes and update references. Custom formatting rules
   are supported via JBFL (JBeam Formatting Language). See the README for usage instructions
   and examples: https://github.com/webdevred/jbeam-edit#readme
-tested-with: [GHC == 9.10.3]
+tested-with: [GHC == 9.10.3, GHC == 9.14.1]
 
 dependencies:
-  - base >= 4.20 && < 4.22
+  - base >= 4.20
   - bytestring
   - vector >= 0.13
   - text >= 2.1.2

--- a/package.yaml
+++ b/package.yaml
@@ -25,10 +25,10 @@ description: >-
   and can automatically rename nodes and update references. Custom formatting rules
   are supported via JBFL (JBeam Formatting Language). See the README for usage instructions
   and examples: https://github.com/webdevred/jbeam-edit#readme
-tested-with: [GHC == 9.6.6, GHC == 9.10.3]
+tested-with: [GHC == 9.10.3]
 
 dependencies:
-  - base >= 4.18 && < 4.22
+  - base >= 4.20 && < 4.22
   - bytestring
   - vector >= 0.13
   - text >= 2.1.2


### PR DESCRIPTION
Remove GHC 9.6.6 from the tested-with list and raise the base lower bound from 4.18 to 4.20, matching the base version shipped with GHC 9.10.x. Also removes the CI workaround that stripped the lsp-server flag for 9.6.6 builds.

Add GHC 9.14.1 to the tested-with list and drop the base upper bound (previously < 4.22) to allow building with the base version shipped with GHC 9.14.x.