### PR TITLE
fix: update megaparsec to 9.8+ and fix parser backtracking

### DIFF
--- a/jbeam-edit.cabal
+++ b/jbeam-edit.cabal
@@ -100,7 +100,7 @@ library
         extra >=1.7.13,
         file-io,
         filepath >=1.5.1.0,
-        megaparsec <9.8,
+        megaparsec,
         mtl,
         scientific,
         text >=2.1.2,
@@ -306,7 +306,7 @@ test-suite jbeam-edit-test
     if True
         build-depends:
             hspec-megaparsec,
-            megaparsec <9.8
+            megaparsec
 
 test-suite jbeam-edit-transformation-test
     type:               exitcode-stdio-1.0

--- a/package.yaml
+++ b/package.yaml
@@ -95,7 +95,7 @@ library:
   ghc-options: [-Wunused-packages]
   source-dirs: src
   generated-other-modules: Paths_jbeam_edit
-  dependencies: [extra >= 1.7.13, megaparsec < 9.8, file-io]
+  dependencies: [extra >= 1.7.13, megaparsec, file-io]
   when:
     - condition: flag(transformation)
       cpp-options: -DENABLE_TRANSFORMATION
@@ -154,7 +154,7 @@ tests:
     source-dirs: test
     when:
       - condition: true
-        dependencies: [megaparsec < 9.8, hspec-megaparsec]
+        dependencies: [megaparsec, hspec-megaparsec]
   jbeam-edit-transformation-test:
     <<: *jbeam-test-common
     main: Spec.hs

--- a/src/JbeamEdit/Parsing/Jbeam.hs
+++ b/src/JbeamEdit/Parsing/Jbeam.hs
@@ -7,6 +7,7 @@ module JbeamEdit.Parsing.Jbeam (
   parseNodesState,
 ) where
 
+import Control.Applicative (asum)
 import Control.Monad.State (State, evalState)
 import Control.Monad.State.Class
 import Data.Bifunctor (first)
@@ -164,13 +165,13 @@ scalarParser =
     , nullParser
     ]
   where
-    tryScalarParsers = MP.try . tryParsers . map MP.hidden
+    tryScalarParsers = asum . map MP.hidden
 
 nodeParser :: JbeamParser Node
 nodeParser = skipWhiteSpace *> (anyNode <|> failingParser expLabels)
   where
     expLabels = ["a valid scalar", "object", "array"]
-    anyNode = MP.try (tryParsers [arrayParser, objectParser, scalarParser])
+    anyNode = asum [arrayParser, objectParser, scalarParser]
 
 ---
 --- selectors for objects, object keys and arrays


### PR DESCRIPTION
Remove upper bound on megaparsec and fix overly aggressive MP.try wrapping that caused incorrect error positions with the corrected <|> associativity in 9.8.