### PR TITLE
Fail CI on unused imports for the oldest GHC

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -182,6 +182,18 @@ jobs:
             }}
           restore-keys: |
             ${{ runner.os }}-cabal-${{ matrix.ghc }}-
+      - name: Fail on unused imports for the oldest GHC
+        if: matrix.oldest == true
+        shell: bash
+        run: |
+          # cabal.project.ci demotes unused-imports to a warning because
+          # widening the supported GHC range makes some imports look
+          # redundant on one version while still required on another. An
+          # import flagged unused on the OLDEST GHC can't be a version
+          # false positive though, it's unused on every newer GHC too, so
+          # only that leg can safely drop the downgrade and fall back to
+          # the plain -Werror already set in the file.
+          sed -i '/-Wwarn=unused-imports/d' cabal.project.ci
       - name: Build project (GHC ${{ steps.setup-ghc.outputs.ghc-version }})
         run: cabal build --project-file cabal.project.ci all
       - name: Run tests (GHC ${{ steps.setup-ghc.outputs.ghc-version }})

--- a/src-extra/transformation/JbeamEdit/Transformation.hs
+++ b/src-extra/transformation/JbeamEdit/Transformation.hs
@@ -5,7 +5,7 @@ import Data.Bifunctor (first)
 import Data.Bool (bool)
 import Data.Foldable.Extra (notNull)
 import Data.Function (on)
-import Data.List (foldl', partition)
+import Data.List (partition)
 import Data.List.NonEmpty (NonEmpty)
 import Data.List.NonEmpty qualified as NE
 import Data.Map (Map)

--- a/src-extra/transformation/JbeamEdit/Transformation/BeamValidation.hs
+++ b/src-extra/transformation/JbeamEdit/Transformation/BeamValidation.hs
@@ -7,7 +7,6 @@ module JbeamEdit.Transformation.BeamValidation (
 ) where
 
 import Control.Monad (forM_, unless)
-import Data.Foldable (foldl')
 import Data.List.NonEmpty (toList)
 import Data.Map qualified as M
 import Data.Set (Set)

--- a/src/JbeamEdit/Core/NodePath.hs
+++ b/src/JbeamEdit/Core/NodePath.hs
@@ -16,9 +16,7 @@ import Data.Vector (Vector)
 import Data.Vector qualified as V
 import GHC.IsList (IsList (..))
 import JbeamEdit.Core.Node qualified as N (
-  ArrayValue (..),
   Node (..),
-  ObjectValue (..),
   avNodes,
   expectArray,
   isCommentNode,

--- a/src/JbeamEdit/Formatting/Config.hs
+++ b/src/JbeamEdit/Formatting/Config.hs
@@ -2,7 +2,6 @@
 
 module JbeamEdit.Formatting.Config (localRuleFile, readFormattingConfig, copyToConfigDir, ConfigType (..)) where
 
-import Control.Monad.Extra (unlessM)
 import Data.Foldable (traverse_)
 import Data.Text qualified as T
 import GHC.IO.Exception (IOErrorType (NoSuchThing))

--- a/src/JbeamEdit/Formatting/Rules.hs
+++ b/src/JbeamEdit/Formatting/Rules.hs
@@ -44,7 +44,6 @@ import JbeamEdit.Core.NodePath (NodeSelector (..))
 import JbeamEdit.Formatting.Rules.ComplexNewLine (ComplexNewLine)
 import JbeamEdit.Formatting.Rules.ComplexNewLine qualified as CNL
 import JbeamEdit.Formatting.Rules.TrailingComma (TrailingComma)
-import JbeamEdit.Formatting.Rules.TrailingComma qualified as TC
 import Text.Read qualified as TR
 
 data NodePatternSelector

--- a/src/JbeamEdit/Parsing/DSL.hs
+++ b/src/JbeamEdit/Parsing/DSL.hs
@@ -26,9 +26,7 @@ import Data.Text.Encoding (decodeUtf8')
 import Data.Word (Word8)
 import JbeamEdit.Core.NodePath
 import JbeamEdit.Formatting.Rules
-import JbeamEdit.Formatting.Rules.ComplexNewLine (ComplexNewLine)
 import JbeamEdit.Formatting.Rules.ComplexNewLine qualified as CNL
-import JbeamEdit.Formatting.Rules.TrailingComma (TrailingComma)
 import JbeamEdit.Formatting.Rules.TrailingComma qualified as TC
 import JbeamEdit.Parsing.Common
 import Text.Megaparsec ((<?>))

--- a/src/JbeamEdit/Parsing/Jbeam.hs
+++ b/src/JbeamEdit/Parsing/Jbeam.hs
@@ -29,7 +29,6 @@ import JbeamEdit.Core.Node (
   AssociationDirection (..),
   InternalComment (..),
   Node (..),
-  NumberValue (..),
   ObjectValue (..),
   mkNumberValue,
  )


### PR DESCRIPTION
## Fail CI on unused imports for the oldest GHC

`cabal.project.ci` demotes unused-imports to a warning (`-Wwarn=unused-imports`) because widening the supported GHC range made some imports look redundant on one version while still required on another. That blanket downgrade means genuinely dead imports never get caught anywhere. An import flagged unused specifically on the oldest supported GHC can't be a version-specific false positive though, since it's unused on every newer GHC too, so only that matrix leg can safely drop the downgrade.

The oldest-GHC job strips the `-Wwarn=unused-imports` line from `cabal.project.ci` with sed before building, falling back to the plain `-Werror` already in the file. A plain `--ghc-options` flag on the command line doesn't work for this: cabal places project-file options after command-line ones on the actual GHC invocation, so the project file's `-Wwarn` would still win. Verified both directions locally before settling on sed.

Also removes the 8 unused imports this newly surfaces across the project, found by running the same check locally against GHC 9.10.3 (the oldest version in `tested-with`) with a full clean build.
