### PR TITLE
Let the last row in a leading metadata block win

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,18 +233,28 @@ This reformats all files in one pass. You may run this when needed, but **do not
 
 ## package.yaml → hpack
 
-After editing `package.yaml`, regenerate the `.cabal` file:
+After editing `package.yaml`, regenerate the `.cabal` file by running `hpack`
+directly.
 
-```bash
-stack build --hpack-force
-```
+**The hpack version has to match the one that generated the committed file.**
+Line 3 of `jbeam-edit.cabal` records it. Any other version reformats the whole
+file, and `check_cabal_file.sh` then rejects it even though nothing meaningful
+changed.
 
-**Do not run `hpack` directly.** CI regenerates the file through Stack, which
-bundles its own hpack. A locally installed hpack of a different version
-reformats the whole file, and `check_cabal_file.sh` then rejects it even though
-nothing meaningful changed. If Stack is not available, edit the `.cabal` file by
-hand to match what the `package.yaml` change implies, and keep the diff to those
-lines.
+**Do not regenerate through `stack build --hpack-force`.** Stack bundles its own
+hpack, and the bundled one is currently older than the version the committed
+file was generated with, so it rewrites the entire file. If the matching hpack
+is not available, edit the `.cabal` file by hand to match what the change
+implies, and keep the diff to those lines. Ask before doing that.
+
+Two things that are easy to get wrong here:
+
+- Adding a module under an existing `source-dirs` needs no `package.yaml`
+  change at all. hpack builds `other-modules` by reading the directory, so a
+  regeneration is the whole job.
+- `check_cabal_file.sh` diffs the working tree against `HEAD`, so it fails on
+  any uncommitted change to the `.cabal` file, correct or not. It only tells
+  you something once the change is committed.
 
 ## Git Commits
 

--- a/examples/regression_jbeam/last-metadata-row-repro.jbeam
+++ b/examples/regression_jbeam/last-metadata-row-repro.jbeam
@@ -1,0 +1,25 @@
+{
+"testpart":{
+    "nodes":[
+        ["id", "posX", "posY", "posZ"],
+        // Synthetic regression-test fixture for the leading-block metadata
+        // bias, not vetted by the jbeam maintainer and not intended as a
+        // demo/example.
+        //
+        // nodeWeight is set twice in the same leading block, with an
+        // unrelated key in between so the two are not adjacent. jbeam
+        // metadata is sticky and the last row wins, so both nodes must come
+        // out weighing 2.0 and keeping frictionCoef.
+        {"nodeWeight":1.0},
+        {"frictionCoef":0.5},
+        {"nodeWeight":2.0},
+        ["nl0", 0.9, -1.0, 0.1],
+        ["nl1", 0.9, 0.0, 0.1],
+        ["nr2", -0.9, -1.0, 0.1],
+        ["nr3", -0.9, 0.0, 0.1],
+    ],
+    "beams":[
+        ["id1:", "id2:"],
+    ],
+},
+}

--- a/examples/regression_jbeam/last-metadata-row-repro.jbeam
+++ b/examples/regression_jbeam/last-metadata-row-repro.jbeam
@@ -2,21 +2,32 @@
 "testpart":{
     "nodes":[
         ["id", "posX", "posY", "posZ"],
-        // Synthetic regression-test fixture for the leading-block metadata
-        // bias, not vetted by the jbeam maintainer and not intended as a
-        // demo/example.
+        // Synthetic regression-test fixture for jbeam metadata semantics, not
+        // vetted by the jbeam maintainer and not intended as a demo/example.
         //
-        // nodeWeight is set twice in the same leading block, with an
-        // unrelated key in between so the two are not adjacent. jbeam
-        // metadata is sticky and the last row wins, so both nodes must come
-        // out weighing 2.0 and keeping frictionCoef.
+        // Every shape that decides what a node ends up carrying:
+        //
+        //   nodeWeight set twice in one leading block, with an unrelated key
+        //   between them, so the two are not adjacent. Last one wins, so nl0
+        //   and nl1 weigh 2.0.
+        //
+        //   nodeWeight set again further down, so nl2 weighs 3.0 while the
+        //   nodes above it keep 2.0.
+        //
+        //   an inline object on nl3, which overrides the section value for
+        //   that node only, so nl3 weighs 4.0 and nr4 is back to 3.0.
+        //
+        //   frictionCoef set once and never again, so every node keeps it.
         {"nodeWeight":1.0},
         {"frictionCoef":0.5},
         {"nodeWeight":2.0},
         ["nl0", 0.9, -1.0, 0.1],
         ["nl1", 0.9, 0.0, 0.1],
-        ["nr2", -0.9, -1.0, 0.1],
-        ["nr3", -0.9, 0.0, 0.1],
+        {"nodeWeight":3.0},
+        ["nl2", 0.9, 1.0, 0.1],
+        ["nl3", 0.9, 2.0, 0.1, {"nodeWeight":4.0}],
+        ["nr4", -0.9, -1.0, 0.1],
+        ["nr5", -0.9, 0.0, 0.1],
     ],
     "beams":[
         ["id1:", "id2:"],

--- a/jbeam-edit.cabal
+++ b/jbeam-edit.cabal
@@ -311,7 +311,11 @@ test-suite jbeam-edit-transformation-test
     type:               exitcode-stdio-1.0
     main-is:            Spec.hs
     hs-source-dirs:     test-extra/transformation
-    other-modules:      Paths_jbeam_edit
+    other-modules:
+        Spec.Helpers
+        Spec.Regression
+        Paths_jbeam_edit
+
     autogen-modules:    Paths_jbeam_edit
     default-language:   GHC2021
     default-extensions:

--- a/src-extra/transformation/JbeamEdit/Transformation/BeamExtraction.hs
+++ b/src-extra/transformation/JbeamEdit/Transformation/BeamExtraction.hs
@@ -39,6 +39,9 @@ extractBeamFromArray sectionMeta vec
         then Nothing
         else
           let inlineObjects = mapMaybe maybeObject (V.toList (V.drop 2 vec))
+              -- M.unions lets the first map win a repeated key, the wrong way
+              -- round for jbeam. No stock beam row carries two inline objects,
+              -- so there is never a second map to lose to.
               inlineMeta = M.unions (map metaMapFromObject inlineObjects)
               effectiveMeta = M.union inlineMeta sectionMeta
            in Just (Beam (mkBeamPair n1 n2) effectiveMeta)

--- a/src-extra/transformation/JbeamEdit/Transformation/VertexExtraction.hs
+++ b/src-extra/transformation/JbeamEdit/Transformation/VertexExtraction.hs
@@ -12,7 +12,7 @@ import Control.Monad.Except (runExcept)
 import Control.Monad.Trans.Except (except)
 import Data.Bifunctor (first)
 import Data.Char (isDigit)
-import Data.List (partition)
+import Data.List (foldl', partition)
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.List.NonEmpty qualified as NE
 import Data.Map (Map)
@@ -222,7 +222,8 @@ newVertexTree
 newVertexTree brks vertexNames badAcc startingMeta vertexForest nodes =
   let (topNodes, nodes') = NE.span isNonVertex nodes
       topComments = mapMaybe toInternalComment topNodes
-      topMeta = foldr (M.union . metaMapFromObject) startingMeta topNodes
+      addMetaFromObject acc node = M.union (metaMapFromObject node) acc
+      topMeta = foldl' addMetaFromObject startingMeta topNodes
       vertexPrefix = getVertexPrefix' nodes'
    in runExcept
         ( do

--- a/test-extra/transformation/Spec.hs
+++ b/test-extra/transformation/Spec.hs
@@ -1,29 +1,27 @@
+{- | The fixture-driven half of the transformation suite: every file in
+`examples/ast/jbeam/` transformed under both configs and compared against
+its expected output, plus the cross-file beam checks. One reproduced defect
+per spec lives in "Spec.Regression" instead.
+-}
 module Spec (
   main,
 ) where
 
 import Data.ByteString.Lazy qualified as LBS
-import Data.Char (isDigit)
 import Data.List (isPrefixOf, isSuffixOf)
 import Data.Map qualified as M
-import Data.Set (Set)
 import Data.Set qualified as S
-import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.Encoding (encodeUtf8)
-import Data.Vector qualified as V
-import GHC.IsList (fromList)
-import JbeamEdit.Core.Node (Node (..), NumberValue (..), expectArray)
-import JbeamEdit.Core.NodePath qualified as NP
 import JbeamEdit.Formatting
-import JbeamEdit.IOUtils (tryReadFile)
 import JbeamEdit.Parsing.Jbeam (parseNodes)
 import JbeamEdit.Transformation
 import JbeamEdit.Transformation.BeamExtraction (beamInKnownSet)
 import JbeamEdit.Transformation.BeamValidation
 import JbeamEdit.Transformation.Config
-import JbeamEdit.Transformation.Types (Beam, MetaMap)
-import JbeamEdit.Transformation.VertexExtraction (metaMapFromObject)
+import JbeamEdit.Transformation.Types (Beam)
+import Spec.Helpers (parseJbeamFile)
+import Spec.Regression
 import System.Directory (getDirectoryContents)
 import System.OsPath
 import Test.Hspec
@@ -85,14 +83,6 @@ fixedPointSpec rs cfName tfConfig outFilename = do
               Right (_, _, _, again) -> formatNode rs again `shouldBe` expected
   describe desc . it "works" $ check
 
-parseJbeamFile :: FilePath -> IO Node
-parseJbeamFile path = do
-  let osPath = unsafeEncodeUtf path
-  contents <- tryReadFile [] osPath
-  case contents >>= parseNodes of
-    Right node -> pure node
-    Left err -> fail $ "Failed to parse " ++ path ++ ": " ++ T.unpack err
-
 beamValidationSpec :: Spec
 beamValidationSpec = do
   frameNode <-
@@ -124,218 +114,6 @@ beamValidationSpec = do
 
     it "has no duplicate beams" $
       findDuplicateBeams internalBeams `shouldBe` []
-
-nodesQuery :: NP.NodePath
-nodesQuery = fromList [NP.ObjectIndex 0, NP.ObjectKey "nodes"]
-
-{- | (name, Y position) for every vertex in a transformed top node's
-"nodes" section, in file order (i.e. the order `transform` actually
-wrote them out in). Read straight back out of the output rather than
-correlated against the input names, since `transform` renames vertices.
--}
-vertexPositionsInOrder :: Node -> [(Text, Double)]
-vertexPositionsInOrder topNode =
-  case NP.queryNodes nodesQuery topNode >>= NP.expectArray nodesQuery of
-    Left _ -> []
-    Right rows ->
-      [ (name, realToFrac (nvValue yNum))
-      | row <- V.toList rows
-      , Just inner <- [expectArray row]
-      , Just (String name) <- [inner V.!? 0]
-      , name /= "id"
-      , Just (Number yNum) <- [inner V.!? 2]
-      ]
-
-{- | Every vertex coordinate in a top node's "nodes" section. Positions
-survive renaming, so they identify a vertex across a transform.
--}
-vertexCoordinates :: Node -> Set (Double, Double, Double)
-vertexCoordinates topNode =
-  case NP.queryNodes nodesQuery topNode >>= NP.expectArray nodesQuery of
-    Left _ -> S.empty
-    Right rows ->
-      S.fromList
-        [ (realToFrac (nvValue x), realToFrac (nvValue y), realToFrac (nvValue z))
-        | row <- V.toList rows
-        , Just inner <- [expectArray row]
-        , Just (String name) <- [inner V.!? 0]
-        , name /= "id"
-        , Just (Number x) <- [inner V.!? 1]
-        , Just (Number y) <- [inner V.!? 2]
-        , Just (Number z) <- [inner V.!? 3]
-        ]
-
-{- | The metadata the first vertex in a transformed file actually carries.
-jbeam metadata is sticky and a later row overrides an earlier one, so this
-replays the rows ahead of that vertex the way the game reads them back rather
-than trusting how many rows the tool chose to emit.
--}
-effectiveMetaAtFirstVertex :: Node -> MetaMap
-effectiveMetaAtFirstVertex topNode =
-  case NP.queryNodes nodesQuery topNode >>= NP.expectArray nodesQuery of
-    Left _ -> M.empty
-    Right rows -> go M.empty (V.toList rows)
-  where
-    go acc [] = acc
-    go acc (row : rest)
-      | isVertexRow row = acc
-      | otherwise = go (M.union (metaMapFromObject row) acc) rest
-    isVertexRow row =
-      case expectArray row >>= (V.!? 0) of
-        Just (String name) -> name /= "id"
-        _ -> False
-
-metaNumber :: Text -> MetaMap -> Maybe Double
-metaNumber key meta =
-  case M.lookup key meta of
-    Just (Number n) -> Just (realToFrac (nvValue n))
-    _ -> Nothing
-
-{- | A key set twice in one leading metadata block must end up with the second
-value. `topMeta` folds that block with `foldr` over a left-biased `M.union`,
-which puts the first row in the outermost position and lets it win instead.
-None of the files in `examples/jbeam/` repeats a key inside one leading block,
-so the whole-output fixture specs cannot see this; 485 of the 4943 stock
-vehicle files do.
--}
-lastMetadataRowFixture :: FilePath
-lastMetadataRowFixture =
-  "examples/regression_jbeam/last-metadata-row-repro.jbeam"
-
-lastMetadataRowSpec :: Spec
-lastMetadataRowSpec =
-  describe "a key set twice in one leading metadata block"
-    . it "leaves the last row in force"
-    $ do
-      topNode <- parseJbeamFile lastMetadataRowFixture
-      case transform M.empty newTransformationConfig topNode of
-        Left err -> expectationFailure ("transform failed: " ++ T.unpack err)
-        Right (_, _, _, resultNode) -> do
-          let meta = effectiveMetaAtFirstVertex resultNode
-          meta `shouldNotBe` M.empty
-          metaNumber "nodeWeight" meta `shouldBe` Just 2.0
-          metaNumber "frictionCoef" meta `shouldBe` Just 0.5
-
-{- | Names ending in a letter rather than a digit all map to the same
-SupportKey, so an insert that replaced instead of merged used to drop
-every group but the last.
--}
-letterEndingNodesFixture :: FilePath
-letterEndingNodesFixture =
-  "examples/regression_jbeam/letter-ending-nodes-repro.jbeam"
-
-letterEndingNodesSpec :: Spec
-letterEndingNodesSpec =
-  describe "letter-ending node names"
-    . it "keeps every vertex through a transform"
-    $ do
-      topNode <- parseJbeamFile letterEndingNodesFixture
-      let expected = vertexCoordinates topNode
-      expected `shouldNotBe` S.empty
-      case transform M.empty newTransformationConfig topNode of
-        Left err -> expectationFailure ("transform failed: " ++ T.unpack err)
-        Right (_, _, _, resultNode) ->
-          vertexCoordinates resultNode `shouldBe` expected
-
-{- | Three small hubs (nl0, nl10, nl20; front/mid/rear), each beamed to
-three of its own ordinary leaf nodes (see issue #215). At
-support-threshold 20 with 12 nodes in the group, thrCount =
-round(0.2*12) = 2: each hub (3 connections) clears it and becomes a
-support vertex, each leaf (1 connection) doesn't. This mirrors the
-support-hub shape seen in real body files (three support nodes sharing
-one prefix group) at a size small enough to reason about by hand: after
-the first transform, the mid/rear hubs get a trailing index (e.g. nlsl1,
-nlsl2) while the front one doesn't (nlsl), and that index is exactly
-what trips up the second pass. Y positions are spaced well outside the
-(default 0.05) y-sorting-threshold so this test stays isolated from the
-separate y-sorting-threshold banding bug (issue #214).
--}
-supportRenameIdempotencyFixture :: FilePath
-supportRenameIdempotencyFixture =
-  "examples/regression_jbeam/support-rename-idempotency-repro.jbeam"
-
-supportRenameIdempotencySpec :: Spec
-supportRenameIdempotencySpec =
-  describe "support vertex renaming"
-    . it "is a fixed point: transforming the output again renames nothing further"
-    $ do
-      let cfg = newTransformationConfig {supportThreshold = 20}
-      topNode <- parseJbeamFile supportRenameIdempotencyFixture
-      case transform M.empty cfg topNode of
-        Left err -> expectationFailure ("first transform failed: " ++ T.unpack err)
-        Right (_, _, _, onceNode) ->
-          case transform M.empty cfg onceNode of
-            Left err -> expectationFailure ("second transform failed: " ++ T.unpack err)
-            Right (_, _, _, twiceNode) -> do
-              let once = vertexPositionsInOrder onceNode
-              once `shouldNotBe` []
-              vertexPositionsInOrder twiceNode `shouldBe` once
-
-{- | Y positions of vertex pairs a transform wrote out of order: a later
-vertex sitting more than the threshold further forward than an earlier
-one in the same output group. Only vertices within one group are
-compared (e.g. "nll", "nlm"): a Left-tree vertex and a Middle-tree
-vertex are unrelated blocks in the file, not a single ordered sequence,
-so their relative position isn't meaningful.
--}
-outOfOrderPairs :: Double -> Node -> [(Double, Double)]
-outOfOrderPairs thr resultNode =
-  [ (y1, y2)
-  | ((n1, y1), i1) <- positions
-  , ((n2, y2), i2) <- positions
-  , i1 < i2
-  , groupPrefix n1 == groupPrefix n2
-  , y1 - y2 > thr
-  ]
-  where
-    positions = zip (vertexPositionsInOrder resultNode) [0 :: Int ..]
-    groupPrefix = T.dropWhileEnd isDigit
-
-{- | Real left-side structural node positions from a NASCAR gen4-style body
-file (see issue #214). This specific spacing reproduces a real transform
-run: with y-sorting-threshold 0.1, the frontmost node (nl0, Y=-1.967) ends
-up sorted to the back of its group instead of the front.
--}
-ySortingReproFixture :: FilePath
-ySortingReproFixture = "examples/regression_jbeam/y-sorting-repro.jbeam"
-
-ySortingBandingSpec :: Spec
-ySortingBandingSpec =
-  describe "y-sorting-threshold"
-    . it
-      "never places a node behind another node that is more than the threshold further forward"
-    $ do
-      let cfg = newTransformationConfig {ySortingThreshold = 0.1}
-      topNode <- parseJbeamFile ySortingReproFixture
-      case transform M.empty cfg topNode of
-        Left err -> expectationFailure ("transform failed: " ++ T.unpack err)
-        Right (_, _, _, resultNode) -> outOfOrderPairs 0.1 resultNode `shouldBe` []
-
-{- | A metadata row ahead of the first vertex applies to the whole section,
-and the transform writes it back out at the top, so it says nothing about
-any individual vertex and must not decide where one is placed. It does
-today (issue #221): `newVertexTree` seeds each tree from its own leading
-block, and `breakVertices` splits on prefix, so alternating nl/nr names
-leave only the first vertex carrying the row. `compareAV` sorts on `aMeta`
-ahead of the Y band and an empty map sorts first, which drops that one
-vertex at the end of its group while its mirror on the other side stays
-in front.
--}
-metadataAcrossTreesFixture :: FilePath
-metadataAcrossTreesFixture =
-  "examples/regression_jbeam/metadata-across-trees-repro.jbeam"
-
-metadataAcrossTreesSpec :: Spec
-metadataAcrossTreesSpec =
-  describe "metadata ahead of the first vertex"
-    . it "does not decide where a vertex is placed"
-    $ do
-      topNode <- parseJbeamFile metadataAcrossTreesFixture
-      case transform M.empty newTransformationConfig topNode of
-        Left err -> expectationFailure ("transform failed: " ++ T.unpack err)
-        Right (_, _, _, resultNode) -> do
-          vertexPositionsInOrder resultNode `shouldNotBe` []
-          outOfOrderPairs 0.05 resultNode `shouldBe` []
 
 main :: IO ()
 main = hspec $ do

--- a/test-extra/transformation/Spec.hs
+++ b/test-extra/transformation/Spec.hs
@@ -140,4 +140,4 @@ main = hspec $ do
   letterEndingNodesSpec
   ySortingBandingSpec
   metadataAcrossTreesSpec
-  lastMetadataRowSpec
+  metadataPreservedSpec

--- a/test-extra/transformation/Spec.hs
+++ b/test-extra/transformation/Spec.hs
@@ -22,7 +22,8 @@ import JbeamEdit.Transformation
 import JbeamEdit.Transformation.BeamExtraction (beamInKnownSet)
 import JbeamEdit.Transformation.BeamValidation
 import JbeamEdit.Transformation.Config
-import JbeamEdit.Transformation.Types (Beam)
+import JbeamEdit.Transformation.Types (Beam, MetaMap)
+import JbeamEdit.Transformation.VertexExtraction (metaMapFromObject)
 import System.Directory (getDirectoryContents)
 import System.OsPath
 import Test.Hspec
@@ -163,6 +164,57 @@ vertexCoordinates topNode =
         , Just (Number y) <- [inner V.!? 2]
         , Just (Number z) <- [inner V.!? 3]
         ]
+
+{- | The metadata the first vertex in a transformed file actually carries.
+jbeam metadata is sticky and a later row overrides an earlier one, so this
+replays the rows ahead of that vertex the way the game reads them back rather
+than trusting how many rows the tool chose to emit.
+-}
+effectiveMetaAtFirstVertex :: Node -> MetaMap
+effectiveMetaAtFirstVertex topNode =
+  case NP.queryNodes nodesQuery topNode >>= NP.expectArray nodesQuery of
+    Left _ -> M.empty
+    Right rows -> go M.empty (V.toList rows)
+  where
+    go acc [] = acc
+    go acc (row : rest)
+      | isVertexRow row = acc
+      | otherwise = go (M.union (metaMapFromObject row) acc) rest
+    isVertexRow row =
+      case expectArray row >>= (V.!? 0) of
+        Just (String name) -> name /= "id"
+        _ -> False
+
+metaNumber :: Text -> MetaMap -> Maybe Double
+metaNumber key meta =
+  case M.lookup key meta of
+    Just (Number n) -> Just (realToFrac (nvValue n))
+    _ -> Nothing
+
+{- | A key set twice in one leading metadata block must end up with the second
+value. `topMeta` folds that block with `foldr` over a left-biased `M.union`,
+which puts the first row in the outermost position and lets it win instead.
+None of the files in `examples/jbeam/` repeats a key inside one leading block,
+so the whole-output fixture specs cannot see this; 485 of the 4943 stock
+vehicle files do.
+-}
+lastMetadataRowFixture :: FilePath
+lastMetadataRowFixture =
+  "examples/regression_jbeam/last-metadata-row-repro.jbeam"
+
+lastMetadataRowSpec :: Spec
+lastMetadataRowSpec =
+  describe "a key set twice in one leading metadata block"
+    . it "leaves the last row in force"
+    $ do
+      topNode <- parseJbeamFile lastMetadataRowFixture
+      case transform M.empty newTransformationConfig topNode of
+        Left err -> expectationFailure ("transform failed: " ++ T.unpack err)
+        Right (_, _, _, resultNode) -> do
+          let meta = effectiveMetaAtFirstVertex resultNode
+          meta `shouldNotBe` M.empty
+          metaNumber "nodeWeight" meta `shouldBe` Just 2.0
+          metaNumber "frictionCoef" meta `shouldBe` Just 0.5
 
 {- | Names ending in a letter rather than a digit all map to the same
 SupportKey, so an insert that replaced instead of merged used to drop
@@ -310,3 +362,4 @@ main = hspec $ do
   letterEndingNodesSpec
   ySortingBandingSpec
   metadataAcrossTreesSpec
+  lastMetadataRowSpec

--- a/test-extra/transformation/Spec/Helpers.hs
+++ b/test-extra/transformation/Spec/Helpers.hs
@@ -3,7 +3,7 @@ module Spec.Helpers (
   parseJbeamFile,
   vertexPositionsInOrder,
   vertexCoordinates,
-  effectiveMetaAtFirstVertex,
+  effectiveMetaByCoordinate,
   metaNumber,
   outOfOrderPairs,
 ) where
@@ -72,25 +72,41 @@ vertexCoordinates topNode =
         , Just (Number z) <- [inner V.!? 3]
         ]
 
-{- | The metadata the first vertex in a transformed file actually carries.
-jbeam metadata is sticky and a later row overrides an earlier one, so this
-replays the rows ahead of that vertex the way the game reads them back rather
-than trusting how many rows the tool chose to emit.
+{- | What each vertex in a "nodes" section actually carries, keyed by
+position so it can be compared across a transform that renames and reorders.
+
+jbeam metadata is sticky: a bare object sets properties on every row after it
+until a later row overrides the same key, and an object on the vertex row
+itself overrides the section value for that one vertex. This replays both the
+way the game reads them back, rather than trusting how many rows the tool chose
+to emit, so it holds whatever the output looks like.
 -}
-effectiveMetaAtFirstVertex :: Node -> MetaMap
-effectiveMetaAtFirstVertex topNode =
+effectiveMetaByCoordinate :: Node -> M.Map (Double, Double, Double) MetaMap
+effectiveMetaByCoordinate topNode =
   case NP.queryNodes nodesQuery topNode >>= NP.expectArray nodesQuery of
     Left _ -> M.empty
-    Right rows -> go M.empty (V.toList rows)
+    Right rows -> go M.empty M.empty (V.toList rows)
   where
-    go acc [] = acc
-    go acc (row : rest)
-      | isVertexRow row = acc
-      | otherwise = go (M.union (metaMapFromObject row) acc) rest
-    isVertexRow row =
-      case expectArray row >>= (V.!? 0) of
-        Just (String name) -> name /= "id"
-        _ -> False
+    go _ found [] = found
+    go sticky found (row : rest) =
+      case vertexRow row of
+        Just (pos, inline) ->
+          go sticky (M.insert pos (M.union inline sticky) found) rest
+        Nothing -> go (M.union (metaMapFromObject row) sticky) found rest
+
+    vertexRow row = do
+      inner <- expectArray row
+      String name <- inner V.!? 0
+      Number x <- inner V.!? 1
+      Number y <- inner V.!? 2
+      Number z <- inner V.!? 3
+      if name == "id"
+        then Nothing
+        else
+          Just
+            ( (realToFrac (nvValue x), realToFrac (nvValue y), realToFrac (nvValue z))
+            , maybe M.empty metaMapFromObject (inner V.!? 4)
+            )
 
 metaNumber :: Text -> MetaMap -> Maybe Double
 metaNumber key meta =

--- a/test-extra/transformation/Spec/Helpers.hs
+++ b/test-extra/transformation/Spec/Helpers.hs
@@ -1,0 +1,119 @@
+-- | Ways of reading a transformed top node back out, shared by the specs.
+module Spec.Helpers (
+  parseJbeamFile,
+  vertexPositionsInOrder,
+  vertexCoordinates,
+  effectiveMetaAtFirstVertex,
+  metaNumber,
+  outOfOrderPairs,
+) where
+
+import Data.Char (isDigit)
+import Data.Map qualified as M
+import Data.Set (Set)
+import Data.Set qualified as S
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Vector qualified as V
+import GHC.IsList (fromList)
+import JbeamEdit.Core.Node (Node (..), NumberValue (..), expectArray)
+import JbeamEdit.Core.NodePath qualified as NP
+import JbeamEdit.IOUtils (tryReadFile)
+import JbeamEdit.Parsing.Jbeam (parseNodes)
+import JbeamEdit.Transformation.Types (MetaMap)
+import JbeamEdit.Transformation.VertexExtraction (metaMapFromObject)
+import System.OsPath
+
+parseJbeamFile :: FilePath -> IO Node
+parseJbeamFile path = do
+  let osPath = unsafeEncodeUtf path
+  contents <- tryReadFile [] osPath
+  case contents >>= parseNodes of
+    Right node -> pure node
+    Left err -> fail $ "Failed to parse " ++ path ++ ": " ++ T.unpack err
+
+nodesQuery :: NP.NodePath
+nodesQuery = fromList [NP.ObjectIndex 0, NP.ObjectKey "nodes"]
+
+{- | (name, Y position) for every vertex in a transformed top node's
+"nodes" section, in file order (i.e. the order `transform` actually
+wrote them out in). Read straight back out of the output rather than
+correlated against the input names, since `transform` renames vertices.
+-}
+vertexPositionsInOrder :: Node -> [(Text, Double)]
+vertexPositionsInOrder topNode =
+  case NP.queryNodes nodesQuery topNode >>= NP.expectArray nodesQuery of
+    Left _ -> []
+    Right rows ->
+      [ (name, realToFrac (nvValue yNum))
+      | row <- V.toList rows
+      , Just inner <- [expectArray row]
+      , Just (String name) <- [inner V.!? 0]
+      , name /= "id"
+      , Just (Number yNum) <- [inner V.!? 2]
+      ]
+
+{- | Every vertex coordinate in a top node's "nodes" section. Positions
+survive renaming, so they identify a vertex across a transform.
+-}
+vertexCoordinates :: Node -> Set (Double, Double, Double)
+vertexCoordinates topNode =
+  case NP.queryNodes nodesQuery topNode >>= NP.expectArray nodesQuery of
+    Left _ -> S.empty
+    Right rows ->
+      S.fromList
+        [ (realToFrac (nvValue x), realToFrac (nvValue y), realToFrac (nvValue z))
+        | row <- V.toList rows
+        , Just inner <- [expectArray row]
+        , Just (String name) <- [inner V.!? 0]
+        , name /= "id"
+        , Just (Number x) <- [inner V.!? 1]
+        , Just (Number y) <- [inner V.!? 2]
+        , Just (Number z) <- [inner V.!? 3]
+        ]
+
+{- | The metadata the first vertex in a transformed file actually carries.
+jbeam metadata is sticky and a later row overrides an earlier one, so this
+replays the rows ahead of that vertex the way the game reads them back rather
+than trusting how many rows the tool chose to emit.
+-}
+effectiveMetaAtFirstVertex :: Node -> MetaMap
+effectiveMetaAtFirstVertex topNode =
+  case NP.queryNodes nodesQuery topNode >>= NP.expectArray nodesQuery of
+    Left _ -> M.empty
+    Right rows -> go M.empty (V.toList rows)
+  where
+    go acc [] = acc
+    go acc (row : rest)
+      | isVertexRow row = acc
+      | otherwise = go (M.union (metaMapFromObject row) acc) rest
+    isVertexRow row =
+      case expectArray row >>= (V.!? 0) of
+        Just (String name) -> name /= "id"
+        _ -> False
+
+metaNumber :: Text -> MetaMap -> Maybe Double
+metaNumber key meta =
+  case M.lookup key meta of
+    Just (Number n) -> Just (realToFrac (nvValue n))
+    _ -> Nothing
+
+{- | Y positions of vertex pairs a transform wrote out of order: a later
+vertex sitting more than the threshold further forward than an earlier
+one in the same output group. Only vertices within one group are
+compared (e.g. "nll", "nlm"): a Left-tree vertex and a Middle-tree
+vertex are unrelated blocks in the file, not a single ordered sequence,
+so their relative position isn't meaningful.
+-}
+outOfOrderPairs :: Double -> Node -> [(Double, Double)]
+outOfOrderPairs thr resultNode =
+  [ (y1, y2)
+  | ((n1, y1), i1) <- positions
+  , ((n2, y2), i2) <- positions
+  , i1 < i2
+  , groupPrefix n1 == groupPrefix n2
+  , y1 - y2 > thr
+  ]
+  where
+    positions = zip (vertexPositionsInOrder resultNode) [0 :: Int ..]
+    groupPrefix = T.dropWhileEnd isDigit

--- a/test-extra/transformation/Spec/Regression.hs
+++ b/test-extra/transformation/Spec/Regression.hs
@@ -1,0 +1,145 @@
+{- | One spec per reproduced defect, each with its own fixture under
+`examples/regression_jbeam/`. Unlike the fixture-driven specs in "Spec",
+these assert one property rather than comparing whole output, so they say
+what broke rather than that something did.
+-}
+module Spec.Regression (
+  letterEndingNodesSpec,
+  supportRenameIdempotencySpec,
+  ySortingBandingSpec,
+  metadataAcrossTreesSpec,
+  lastMetadataRowSpec,
+) where
+
+import Data.Map qualified as M
+import Data.Set qualified as S
+import Data.Text qualified as T
+import JbeamEdit.Transformation
+import JbeamEdit.Transformation.Config
+import Spec.Helpers
+import Test.Hspec
+
+{- | Names ending in a letter rather than a digit all map to the same
+SupportKey, so an insert that replaced instead of merged used to drop
+every group but the last.
+-}
+letterEndingNodesFixture :: FilePath
+letterEndingNodesFixture =
+  "examples/regression_jbeam/letter-ending-nodes-repro.jbeam"
+
+letterEndingNodesSpec :: Spec
+letterEndingNodesSpec =
+  describe "letter-ending node names"
+    . it "keeps every vertex through a transform"
+    $ do
+      topNode <- parseJbeamFile letterEndingNodesFixture
+      let expected = vertexCoordinates topNode
+      expected `shouldNotBe` S.empty
+      case transform M.empty newTransformationConfig topNode of
+        Left err -> expectationFailure ("transform failed: " ++ T.unpack err)
+        Right (_, _, _, resultNode) ->
+          vertexCoordinates resultNode `shouldBe` expected
+
+{- | Three small hubs (nl0, nl10, nl20; front/mid/rear), each beamed to
+three of its own ordinary leaf nodes (see issue #215). At
+support-threshold 20 with 12 nodes in the group, thrCount =
+round(0.2*12) = 2: each hub (3 connections) clears it and becomes a
+support vertex, each leaf (1 connection) doesn't. This mirrors the
+support-hub shape seen in real body files (three support nodes sharing
+one prefix group) at a size small enough to reason about by hand: after
+the first transform, the mid/rear hubs get a trailing index (e.g. nlsl1,
+nlsl2) while the front one doesn't (nlsl), and that index is exactly
+what trips up the second pass. Y positions are spaced well outside the
+(default 0.05) y-sorting-threshold so this test stays isolated from the
+separate y-sorting-threshold banding bug (issue #214).
+-}
+supportRenameIdempotencyFixture :: FilePath
+supportRenameIdempotencyFixture =
+  "examples/regression_jbeam/support-rename-idempotency-repro.jbeam"
+
+supportRenameIdempotencySpec :: Spec
+supportRenameIdempotencySpec =
+  describe "support vertex renaming"
+    . it "is a fixed point: transforming the output again renames nothing further"
+    $ do
+      let cfg = newTransformationConfig {supportThreshold = 20}
+      topNode <- parseJbeamFile supportRenameIdempotencyFixture
+      case transform M.empty cfg topNode of
+        Left err -> expectationFailure ("first transform failed: " ++ T.unpack err)
+        Right (_, _, _, onceNode) ->
+          case transform M.empty cfg onceNode of
+            Left err -> expectationFailure ("second transform failed: " ++ T.unpack err)
+            Right (_, _, _, twiceNode) -> do
+              let once = vertexPositionsInOrder onceNode
+              once `shouldNotBe` []
+              vertexPositionsInOrder twiceNode `shouldBe` once
+
+{- | Real left-side structural node positions from a NASCAR gen4-style body
+file (see issue #214). This specific spacing reproduces a real transform
+run: with y-sorting-threshold 0.1, the frontmost node (nl0, Y=-1.967) ends
+up sorted to the back of its group instead of the front.
+-}
+ySortingReproFixture :: FilePath
+ySortingReproFixture = "examples/regression_jbeam/y-sorting-repro.jbeam"
+
+ySortingBandingSpec :: Spec
+ySortingBandingSpec =
+  describe "y-sorting-threshold"
+    . it
+      "never places a node behind another node that is more than the threshold further forward"
+    $ do
+      let cfg = newTransformationConfig {ySortingThreshold = 0.1}
+      topNode <- parseJbeamFile ySortingReproFixture
+      case transform M.empty cfg topNode of
+        Left err -> expectationFailure ("transform failed: " ++ T.unpack err)
+        Right (_, _, _, resultNode) -> outOfOrderPairs 0.1 resultNode `shouldBe` []
+
+{- | A metadata row ahead of the first vertex applies to the whole section,
+and the transform writes it back out at the top, so it says nothing about
+any individual vertex and must not decide where one is placed. It did
+(issue #221): `newVertexTree` seeded each tree from its own leading block,
+and `breakVertices` splits on prefix, so alternating nl/nr names left only
+the first vertex carrying the row. `compareAV` sorts on `aMeta` ahead of
+the Y band and an empty map sorts first, which dropped that one vertex at
+the end of its group while its mirror on the other side stayed in front.
+-}
+metadataAcrossTreesFixture :: FilePath
+metadataAcrossTreesFixture =
+  "examples/regression_jbeam/metadata-across-trees-repro.jbeam"
+
+metadataAcrossTreesSpec :: Spec
+metadataAcrossTreesSpec =
+  describe "metadata ahead of the first vertex"
+    . it "does not decide where a vertex is placed"
+    $ do
+      topNode <- parseJbeamFile metadataAcrossTreesFixture
+      case transform M.empty newTransformationConfig topNode of
+        Left err -> expectationFailure ("transform failed: " ++ T.unpack err)
+        Right (_, _, _, resultNode) -> do
+          vertexPositionsInOrder resultNode `shouldNotBe` []
+          outOfOrderPairs 0.05 resultNode `shouldBe` []
+
+{- | A key set twice in one leading metadata block must end up with the second
+value. `topMeta` folds that block with `foldr` over a left-biased `M.union`,
+which puts the first row in the outermost position and lets it win instead.
+None of the files in `examples/jbeam/` repeats a key inside one leading block,
+so the whole-output fixture specs cannot see this; 485 of the 4943 stock
+vehicle files do.
+-}
+lastMetadataRowFixture :: FilePath
+lastMetadataRowFixture =
+  "examples/regression_jbeam/last-metadata-row-repro.jbeam"
+
+lastMetadataRowSpec :: Spec
+lastMetadataRowSpec =
+  describe "a key set twice in one leading metadata block"
+    . it "leaves the last row in force"
+    $ do
+      topNode <- parseJbeamFile lastMetadataRowFixture
+      case transform M.empty newTransformationConfig topNode of
+        Left err -> expectationFailure ("transform failed: " ++ T.unpack err)
+        Right (_, _, _, resultNode) -> do
+          let meta = effectiveMetaAtFirstVertex resultNode
+          meta `shouldNotBe` M.empty
+          metaNumber "nodeWeight" meta `shouldBe` Just 2.0
+          metaNumber "frictionCoef" meta `shouldBe` Just 0.5

--- a/test-extra/transformation/Spec/Regression.hs
+++ b/test-extra/transformation/Spec/Regression.hs
@@ -8,7 +8,7 @@ module Spec.Regression (
   supportRenameIdempotencySpec,
   ySortingBandingSpec,
   metadataAcrossTreesSpec,
-  lastMetadataRowSpec,
+  metadataPreservedSpec,
 ) where
 
 import Data.Map qualified as M
@@ -119,27 +119,55 @@ metadataAcrossTreesSpec =
           vertexPositionsInOrder resultNode `shouldNotBe` []
           outOfOrderPairs 0.05 resultNode `shouldBe` []
 
-{- | A key set twice in one leading metadata block must end up with the second
-value. `topMeta` folds that block with `foldr` over a left-biased `M.union`,
-which puts the first row in the outermost position and lets it win instead.
-None of the files in `examples/jbeam/` repeats a key inside one leading block,
-so the whole-output fixture specs cannot see this; 485 of the 4943 stock
+{- | The transform renames nodes, reorders them and rewrites the metadata rows,
+but what any one node ends up carrying has to come out the same. The fixture
+covers every shape that decides that: a key set twice in one leading block, a
+key set again further down, an object on the node row overriding the section
+value for that node alone, and a key set once and never again.
+
+Today the leading block is folded with `foldr` over a left-biased `M.union`,
+which puts the first row in the outermost position and lets it beat the later
+one. None of the files in `examples/jbeam/` repeats a key inside one leading
+block, so the whole-output fixture specs cannot see it; 485 of the 4943 stock
 vehicle files do.
 -}
-lastMetadataRowFixture :: FilePath
-lastMetadataRowFixture =
+metadataPreservedFixture :: FilePath
+metadataPreservedFixture =
   "examples/regression_jbeam/last-metadata-row-repro.jbeam"
 
-lastMetadataRowSpec :: Spec
-lastMetadataRowSpec =
-  describe "a key set twice in one leading metadata block"
-    . it "leaves the last row in force"
-    $ do
-      topNode <- parseJbeamFile lastMetadataRowFixture
+metadataPreservedSpec :: Spec
+metadataPreservedSpec =
+  describe "the metadata a node carries" $ do
+    it "reads back from the fixture as jbeam defines it" $ do
+      topNode <- parseJbeamFile metadataPreservedFixture
+      let before = effectiveMetaByCoordinate topNode
+      -- Guards the helper and the fixture against each other, so a failure
+      -- below is the transform rather than a fixture nobody re-read.
+      M.size before `shouldBe` 6
+      metaNumber "nodeWeight" <$> M.lookup (0.9, -1.0, 0.1) before
+        `shouldBe` Just (Just 2.0)
+      metaNumber "nodeWeight" <$> M.lookup (0.9, 1.0, 0.1) before
+        `shouldBe` Just (Just 3.0)
+      metaNumber "nodeWeight" <$> M.lookup (0.9, 2.0, 0.1) before
+        `shouldBe` Just (Just 4.0)
+      metaNumber "frictionCoef" <$> M.lookup (-0.9, 0.0, 0.1) before
+        `shouldBe` Just (Just 0.5)
+
+    it "survives a transform unchanged" $ do
+      topNode <- parseJbeamFile metadataPreservedFixture
+      let before = effectiveMetaByCoordinate topNode
       case transform M.empty newTransformationConfig topNode of
         Left err -> expectationFailure ("transform failed: " ++ T.unpack err)
         Right (_, _, _, resultNode) -> do
-          let meta = effectiveMetaAtFirstVertex resultNode
-          meta `shouldNotBe` M.empty
-          metaNumber "nodeWeight" meta `shouldBe` Just 2.0
-          metaNumber "frictionCoef" meta `shouldBe` Just 0.5
+          let after = effectiveMetaByCoordinate resultNode
+              -- Report only the nodes whose metadata moved, with both values.
+              -- Comparing the maps whole prints each of them in full, which
+              -- buries which node actually broke.
+              changed =
+                [ (pos, expected, actual)
+                | (pos, expected) <- M.toList before
+                , Just actual <- [M.lookup pos after]
+                , actual /= expected
+                ]
+          M.keys after `shouldBe` M.keys before
+          changed `shouldBe` []

--- a/test-extra/transformation/Spec/Regression.hs
+++ b/test-extra/transformation/Spec/Regression.hs
@@ -140,34 +140,34 @@ metadataPreservedSpec =
   describe "the metadata a node carries" $ do
     it "reads back from the fixture as jbeam defines it" $ do
       topNode <- parseJbeamFile metadataPreservedFixture
-      let before = effectiveMetaByCoordinate topNode
+      let metaBefore = effectiveMetaByCoordinate topNode
       -- Guards the helper and the fixture against each other, so a failure
       -- below is the transform rather than a fixture nobody re-read.
-      M.size before `shouldBe` 6
-      metaNumber "nodeWeight" <$> M.lookup (0.9, -1.0, 0.1) before
+      M.size metaBefore `shouldBe` 6
+      metaNumber "nodeWeight" <$> M.lookup (0.9, -1.0, 0.1) metaBefore
         `shouldBe` Just (Just 2.0)
-      metaNumber "nodeWeight" <$> M.lookup (0.9, 1.0, 0.1) before
+      metaNumber "nodeWeight" <$> M.lookup (0.9, 1.0, 0.1) metaBefore
         `shouldBe` Just (Just 3.0)
-      metaNumber "nodeWeight" <$> M.lookup (0.9, 2.0, 0.1) before
+      metaNumber "nodeWeight" <$> M.lookup (0.9, 2.0, 0.1) metaBefore
         `shouldBe` Just (Just 4.0)
-      metaNumber "frictionCoef" <$> M.lookup (-0.9, 0.0, 0.1) before
+      metaNumber "frictionCoef" <$> M.lookup (-0.9, 0.0, 0.1) metaBefore
         `shouldBe` Just (Just 0.5)
 
     it "survives a transform unchanged" $ do
       topNode <- parseJbeamFile metadataPreservedFixture
-      let before = effectiveMetaByCoordinate topNode
+      let metaBefore = effectiveMetaByCoordinate topNode
       case transform M.empty newTransformationConfig topNode of
         Left err -> expectationFailure ("transform failed: " ++ T.unpack err)
         Right (_, _, _, resultNode) -> do
-          let after = effectiveMetaByCoordinate resultNode
+          let metaAfter = effectiveMetaByCoordinate resultNode
               -- Report only the nodes whose metadata moved, with both values.
               -- Comparing the maps whole prints each of them in full, which
               -- buries which node actually broke.
               changed =
                 [ (pos, expected, actual)
-                | (pos, expected) <- M.toList before
-                , Just actual <- [M.lookup pos after]
+                | (pos, expected) <- M.toList metaBefore
+                , Just actual <- [M.lookup pos metaAfter]
                 , actual /= expected
                 ]
-          M.keys after `shouldBe` M.keys before
+          M.keys metaAfter `shouldBe` M.keys metaBefore
           changed `shouldBe` []

--- a/tools/dump_ast/Main.hs
+++ b/tools/dump_ast/Main.hs
@@ -7,16 +7,18 @@ import Data.List (isPrefixOf, isSuffixOf)
 import Data.Map qualified as M
 import Data.Text qualified as T
 import Data.Text.Lazy qualified as LT
+import JbeamEdit.Core.Newline
 import JbeamEdit.Formatting
 import JbeamEdit.Parsing.DSL (parseDSL)
 import JbeamEdit.Parsing.Jbeam (parseNodes)
 import JbeamEdit.Transformation
 import JbeamEdit.Transformation.Config
 import JbeamEdit.Transformation.Types
-import System.Directory (copyFile, getDirectoryContents)
+import System.Directory (doesFileExist, getDirectoryContents)
 import System.Exit (exitFailure)
 import System.FilePath (dropExtension, takeBaseName, (</>))
-import System.IO qualified as IO (readFile)
+import System.IO (IOMode (..), Newline (..))
+import System.IO qualified as IO (hClose, openFile, readFile)
 import System.OsPath qualified as OS (unsafeEncodeUtf, (</>))
 import Text.Pretty.Simple (
   StringOutputStyle (..),
@@ -78,9 +80,36 @@ getDirectoryContents' :: FilePath -> IO [String]
 getDirectoryContents' path = filter (not . isPrefixOf ".#") <$> getDirectoryContents path
 
 saveDump :: String -> String -> IO ()
-saveDump outFile formatted =
+saveDump outFile formatted = do
   putStrLn ("creating " ++ outFile)
-    >> writeFile outFile formatted
+  existing <- doesFileExist outFile
+  lineEnding <-
+    if existing
+      then checkFileNewline outFile
+      else pure LF
+  let converted =
+        if lineEnding == CRLF
+          then toCRLF (toLF formatted)
+          else toLF formatted
+  writeFile outFile converted
+  where
+    checkFileNewline existing =
+      do
+        handle <- IO.openFile existing ReadMode
+        contents <- LBS.hGetContents handle
+        let !newline = detectNewline contents
+        IO.hClose handle
+        pure newline
+
+toLF :: String -> String
+toLF ('\r' : '\n' : rest) = '\n' : toLF rest
+toLF (c : rest) = c : toLF rest
+toLF [] = []
+
+toCRLF :: String -> String
+toCRLF ('\n' : rest) = '\r' : '\n' : toCRLF rest
+toCRLF (c : rest) = c : toCRLF rest
+toCRLF [] = []
 
 saveAstDump :: Show a => String -> a -> IO ()
 saveAstDump outFile contents =
@@ -138,12 +167,9 @@ fenderAfterFrame
   -> IO ()
 fenderAfterFrame "frame" rs updateNames input out cfName = do
   let outFile = out </> "fender-after-frame-" ++ cfName ++ ".jbeam"
-  copyFile input outFile
-  putStrLn ("creating " ++ outFile)
-  updateOtherFiles
-    rs
-    updateNames
-    (OS.unsafeEncodeUtf outFile)
+  contents <- IO.readFile input
+  saveDump outFile contents
+  updateOtherFiles rs updateNames (OS.unsafeEncodeUtf outFile)
 fenderAfterFrame _ _ _ _ _ _ = pure ()
 
 dumpTransformedJbeam


### PR DESCRIPTION
jbeam metadata is sticky and a later row overrides an earlier one, but `topMeta` folds a tree's leading block with `foldr` over a left-biased `M.union`. That puts the first row in the outermost position, so it wins and the later value is thrown away. Two rows setting `nodeWeight` ahead of the first node leave every node in the section weighing the first value, which is a wrong number rather than a formatting difference.

Nothing in `examples/jbeam/` repeats a key inside one leading block, which is why the whole-output fixture specs never saw it. 485 of the 4943 stock vehicle files do.

Two things in here are outside that scope, both in their own commits. The transformation spec is split into `Spec.Helpers` and `Spec.Regression`, since six independent regression specs had accumulated in one file alongside the readers they share. 
