### PR TITLE
Pin which of two overlapping JBFL patterns wins

### DIFF
--- a/test/Formatting/RulesSpec.hs
+++ b/test/Formatting/RulesSpec.hs
@@ -1,6 +1,8 @@
 module Formatting.RulesSpec (spec) where
 
 import GHC.IsList (fromList)
+import JbeamEdit.Core.NodeCursor (NodeBreadcrumb (..), NodeCursor (..))
+import JbeamEdit.Core.NodePath qualified as NP
 import JbeamEdit.Formatting
 import JbeamEdit.Formatting.Rules
 import SpecHelper
@@ -34,3 +36,33 @@ spec = do
             ]
     it "applies PadAmount and PadDecimals" $
       applyPadLogic (formatScalarNode False) ruleSet fakeNode `shouldBe` "123.50 "
+
+  -- Which of two overlapping patterns wins is stated nowhere; it falls out of
+  -- `Ord NodePattern`. The named-key case is already pinned by the glowMap
+  -- rules in complex.jbfl, the length case by nothing.
+  describe "overlapping patterns" $ do
+    let cursor =
+          NodeCursor $
+            fromList
+              [ObjectIndexAndKey 0 "chassis", ObjectIndexAndKey 0 "nodes"]
+        ruleFor n = fromList [(SomeKey PadAmount, SomeProperty PadAmount n)]
+        ruleSetOf ps = RuleSet (fromList [(NodePattern (fromList p), ruleFor n) | (p, n) <- ps])
+        padAmount rs = lookupPropertyForCursor PrefixMatch PadAmount rs cursor
+
+    it "lets the longer pattern win" $
+      padAmount
+        ( ruleSetOf
+            [ ([AnyObjectKey], 1)
+            , ([AnyObjectKey, Selector (NP.ObjectKey "nodes")], 2)
+            ]
+        )
+        `shouldBe` Just 2
+
+    it "lets a named key beat a wildcard of the same length" $
+      padAmount
+        ( ruleSetOf
+            [ ([AnyObjectKey, AnyObjectKey], 1)
+            , ([AnyObjectKey, Selector (NP.ObjectKey "nodes")], 2)
+            ]
+        )
+        `shouldBe` Just 2


### PR DESCRIPTION
When two JBFL patterns both match a cursor, which one supplies the property is decided by `Ord NodePattern`, `fold` walking the map in ascending order, and the left-biased union in `Map`'s `Monoid`. Nothing states the resulting rule, and it has two halves: the longer pattern wins, and at equal length a named key beats a wildcard.

The second half is already covered by the fixtures. `complex.jbfl` gives `.*.glowMap.*` and `.*.glowMap.chassis_gaugelight_warning` different `ComplexNewLine` values, and `frame-complex-jbfl.jbeam` shows the named key expanded across lines while its five siblings stay inline. The first half is covered by nothing, because no example sets one property from two patterns of different length.

This adds two specs, one per half. Both were checked by mutating the source rather than the test: dropping `Down` from the length comparison reddens the first and leaves the second green, and flipping the rank of `AnyObjectKey` does the opposite.

Relevant to #187, where the rule lookup becomes a trie. Precedence is the part most likely to change without any existing test noticing.
