### PR TITLE
Stop caching local build artifacts in Actions workflows

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -68,12 +68,10 @@ jobs:
           CABAL_PROJECT: cabal.project.release
         shell: bash
         run: bash ./.github/scripts/freeze_dependencies.sh
-      - name: Cache GHC, Cabal store, and build artifacts
+      - name: Cache Cabal store
         uses: actions/cache@v6.1.0
         with:
-          path: |
-            dist-newstyle
-            ${{ steps.setup-ghc.outputs.cabal-store }}
+          path: ${{ steps.setup-ghc.outputs.cabal-store }}
           key: >-
             ${{ runner.os }}-cabal-${{
               matrix.ghc

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -174,12 +174,10 @@ jobs:
           CABAL_PROJECT: cabal.project.ci
         shell: bash
         run: bash ./.github/scripts/freeze_dependencies.sh
-      - name: Cache Cabal store and build artifacts
+      - name: Cache Cabal store
         uses: actions/cache@v6.1.0
         with:
-          path: |
-            ${{ steps.setup-ghc.outputs.cabal-store }}
-            dist-newstyle
+          path: ${{ steps.setup-ghc.outputs.cabal-store }}
           key: >-
             ${{
               runner.os

--- a/.github/workflows/future-proofing.yaml
+++ b/.github/workflows/future-proofing.yaml
@@ -54,12 +54,10 @@ jobs:
           CABAL_PROJECT: cabal.project.ci
         shell: bash
         run: bash ./.github/scripts/freeze_dependencies.sh
-      - name: Cache GHC, Cabal store, and build artifacts
+      - name: Cache Cabal store
         uses: actions/cache@v6.1.0
         with:
-          path: |
-            dist-newstyle
-            ${{ steps.setup-ghc.outputs.cabal-store }}
+          path: ${{ steps.setup-ghc.outputs.cabal-store }}
           key: >-
             ${{ runner.os }}-cabal-${{
               steps.get-ghc.outputs.ghc-version


### PR DESCRIPTION
## Summary

- The release build's Actions cache restored the whole `dist-newstyle` directory keyed only on the dependency freeze file. Since dependencies rarely change, the same cache entry was reused for weeks, and a stale local package build (including its registered inplace package) could survive a source or version change. This actually happened: a tagged release build shipped a binary that still reported version 0.0.5.0 and the pre-change transformation behaviour, despite the tag's `.cabal` file saying 0.0.6.0.
- `build-and-test.yaml` and `future-proofing.yaml` cache their cabal builds the same way and carry the same risk, even though it hasn't been observed there yet.
- Fix: cache only the external Cabal store in all three workflows. Local packages (`jbeam-edit` and its internal libraries) now build fresh every run, so there's nothing stale to reuse.
