### PR TITLE
Add the > operator for restricting how far a rule reaches

### DIFF
--- a/src/JbeamEdit/Parsing/DSL.hs
+++ b/src/JbeamEdit/Parsing/DSL.hs
@@ -9,6 +9,7 @@ module JbeamEdit.Parsing.DSL (
   ruleSetParser,
 ) where
 
+import Control.Applicative ((<|>))
 import Data.Bifunctor (first)
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as LBS
@@ -26,6 +27,8 @@ import Data.Map qualified as M (
   singleton,
  )
 import Data.Monoid (Dual (..))
+import Data.Sequence (Seq (..))
+import Data.Sequence qualified as Seq (fromList)
 import Data.Set qualified as S (fromList)
 import Data.Text (Text)
 import Data.Text qualified as T (init, isSuffixOf, unpack)
@@ -44,6 +47,11 @@ import Text.Megaparsec.Byte.Lexer qualified as L (
   skipBlockComment,
   skipLineComment,
  )
+
+data NodePattern
+  = PrefixPattern (Seq NodePatternSelector)
+  | ExactPattern (Seq NodePatternSelector) NodePatternSelector
+  deriving stock (Read, Show)
 
 type JbflParser a = Parser Identity a
 
@@ -74,15 +82,20 @@ patternSelectorParser =
     , arrayIndexParser <?> "array index"
     ]
 
-patternParser :: JbflParser [NodePatternSelector]
+patternParser :: JbflParser NodePattern
 patternParser = do
-  pat <- skipWhiteSpace *> patternSelectors
+  pat <- skipWhiteSpace *> (MP.try exactPattern <|> prefixPattern)
   c <- MP.lookAhead B.asciiChar
   case toChar c of
     ',' -> byteChar ',' $> pat
     _ -> skipWhiteSpace $> pat
   where
-    patternSelectors = MP.some patternSelectorParser
+    exactPattern = do
+      basePattern <- MP.some patternSelectorParser
+      B.space1 *> void (byteChar '>') <* B.space1
+      ExactPattern (Seq.fromList basePattern) <$> patternSelectorParser
+
+    prefixPattern = PrefixPattern . Seq.fromList <$> MP.some patternSelectorParser
 
 tryDecodeKey :: [Word8] -> (Text -> Maybe SomeKey) -> Maybe SomeKey
 tryDecodeKey bs f =
@@ -166,7 +179,7 @@ deprecatedBoolPropertyParser sk valTrue valFalse = do
 separatorParser :: JbflParser ()
 separatorParser = skipWhiteSpace *> void (byteChar ';') <* skipWhiteSpace
 
-ruleParser :: JbflParser ([[NodePatternSelector]], Map SomeKey SomeProperty)
+ruleParser :: JbflParser ([NodePattern], Map SomeKey SomeProperty)
 ruleParser = do
   pats <- MP.some patternParser
   skipWhiteSpace
@@ -178,19 +191,22 @@ ruleParser = do
   pure (pats, M.fromList props)
 
 combineRuleSets
-  :: ([[NodePatternSelector]], Map SomeKey SomeProperty) -> RuleSet
+  :: ([NodePattern], Map SomeKey SomeProperty) -> RuleSet
 combineRuleSets (_, props)
   | M.null props = mempty
-combineRuleSets (pats, props) = fold [fold (go pat) | pat <- pats]
+combineRuleSets (pats, props) = fold [fold (rsFromPattern pat) | pat <- pats]
   where
-    go :: [NodePatternSelector] -> Maybe RuleSet
-    go [] = Just (mempty {rsHere = hereProps, rsBelow = belowProps})
+    go :: Seq NodePatternSelector -> Bool -> Maybe RuleSet
+    go Empty exact = Just (mempty {rsHere = hereProps, rsBelow = belowProps})
       where
-        (belowProps, hereProps) = M.partitionWithKey (\(SomeKey k) _ -> propertyReach k == Below) props
-    go (AnyObjectKey : pats') = Just (mempty {rsAnyObjectKey = go pats'})
-    go (AnyArrayIndex : pats') = Just (mempty {rsAnyArrayIndex = go pats'})
-    go (Selector (ObjectPrefixKey p) : pats') = Just (mempty {rsPrefixes = maybe [] (\x -> [(p, x)]) (go pats')})
-    go (Selector s : pats') = Just (mempty {rsBySelectors = maybe M.empty (M.singleton s) (go pats')})
+        (hereProps, belowProps) = M.partitionWithKey (\(SomeKey k) _ -> propertyReach k == Here || exact) props
+    go (AnyObjectKey :<| pats') exact = Just (mempty {rsAnyObjectKey = go pats' exact})
+    go (AnyArrayIndex :<| pats') exact = Just (mempty {rsAnyArrayIndex = go pats' exact})
+    go (Selector (ObjectPrefixKey p) :<| pats') exact = Just (mempty {rsPrefixes = maybe [] (\x -> [(p, x)]) (go pats' exact)})
+    go (Selector s :<| pats') exact =
+      Just (mempty {rsBySelectors = maybe M.empty (M.singleton s) (go pats' exact)})
+    rsFromPattern (ExactPattern pat selector) = go (pat :|> selector) True
+    rsFromPattern (PrefixPattern pat) = go pat False
 
 ruleSetParser :: JbflParser RuleSet
 ruleSetParser = getDual . foldMap (Dual . combineRuleSets) <$> MP.some singleRuleSet

--- a/src/JbeamEdit/Parsing/DSL.hs
+++ b/src/JbeamEdit/Parsing/DSL.hs
@@ -9,7 +9,6 @@ module JbeamEdit.Parsing.DSL (
   ruleSetParser,
 ) where
 
-import Control.Applicative ((<|>))
 import Data.Bifunctor (first)
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as LBS
@@ -60,7 +59,7 @@ objectKeyParser = byteChar '.' *> key
   where
     key = parseWord8s (Selector . t) (MP.some . MP.satisfy $ p)
     t k = if T.isSuffixOf "*" k then ObjectPrefixKey (T.init k) else ObjectKey k
-    p = charBoth (not . isSpace) (`notElem` [',', '[', '.']) . toChar
+    p = charBoth (not . isSpace) (`notElem` [',', '[', '.', '>']) . toChar
 
 objectIndexParser :: JbflParser NodePatternSelector
 objectIndexParser = byteChar '.' *> index
@@ -84,18 +83,19 @@ patternSelectorParser =
 
 patternParser :: JbflParser NodePattern
 patternParser = do
-  pat <- skipWhiteSpace *> (MP.try exactPattern <|> prefixPattern)
+  pat <- nodePattern
   c <- MP.lookAhead B.asciiChar
   case toChar c of
     ',' -> byteChar ',' $> pat
     _ -> skipWhiteSpace $> pat
   where
-    exactPattern = do
-      basePattern <- MP.some patternSelectorParser
-      B.space1 *> void (byteChar '>') <* B.space1
-      ExactPattern (Seq.fromList basePattern) <$> patternSelectorParser
-
-    prefixPattern = PrefixPattern . Seq.fromList <$> MP.some patternSelectorParser
+    nodePattern = do
+      skipWhiteSpace
+      basePattern <- Seq.fromList <$> MP.some patternSelectorParser
+      arrow <- MP.optional (MP.try $ B.space1 *> byteChar '>' <* B.space1)
+      case arrow of
+        Nothing -> pure (PrefixPattern basePattern)
+        Just _ -> ExactPattern basePattern <$> patternSelectorParser
 
 tryDecodeKey :: [Word8] -> (Text -> Maybe SomeKey) -> Maybe SomeKey
 tryDecodeKey bs f =

--- a/test/Formatting/RulesSpec.hs
+++ b/test/Formatting/RulesSpec.hs
@@ -151,6 +151,18 @@ precedenceSpec = do
       formatWith (winnerOnly <> "\n" <> loserOnly)
         `shouldNotBe` formatWith loserOnly
 
+  describe "the > operator" $ do
+    let cur c = NodeCursor (fromList c)
+        at = cur [ObjectIndexAndKey 0 "part", ObjectIndexAndKey 0 "nodes"]
+        below = cur [ObjectIndexAndKey 0 "part", ObjectIndexAndKey 0 "nodes", ArrayIndex 0]
+        restricted = rulesFrom ".* > .nodes { PadAmount : 7; }"
+        cascading = rulesFrom ".*.nodes { PadAmount : 7; }"
+
+    it "keeps a cascading property at the node it names" $ do
+      lookupPropertyForCursor PadAmount restricted at `shouldBe` Just 7
+      lookupPropertyForCursor PadAmount restricted below `shouldBe` Nothing
+      lookupPropertyForCursor PadAmount cascading below `shouldBe` Just 7
+
   describe "two rules with the same pattern" $ do
     let twice = rulesFrom ".deformGroups { Indent : 1; }\n.deformGroups { Indent : 2; }"
         cur = NodeCursor (fromList [ObjectIndexAndKey 0 "deformGroups"])

--- a/test/Parsing/DSLSpec.hs
+++ b/test/Parsing/DSLSpec.hs
@@ -5,6 +5,7 @@ module Parsing.DSLSpec (
 import Data.ByteString.Lazy (ByteString)
 import Data.ByteString.Lazy qualified as BS (fromStrict, readFile)
 import Data.Functor.Identity (Identity (..))
+import Data.List.NonEmpty qualified as NE (head)
 import Data.Text qualified as T
 import Data.Text.Encoding (encodeUtf8)
 import Data.Void (Void)
@@ -119,12 +120,22 @@ invalidKeyPropertySpecs =
     (assertParserFailure keyPropertyPairParser)
     (invalidEnumProperties ++ invalidIntProperties)
 
+misplacedArrowSpecs :: [Spec]
+misplacedArrowSpecs = [assertFailsAt ruleSetParser (".a > { Indent: 2; }", 5)]
+
 applyParserSpec
   :: (Eq a, Show a) => ParsecT Void ByteString Identity a -> (String, a) -> Spec
 applyParserSpec parser = uncurry $ applySpecOnInput descFun assertParsesTo
   where
     assertParsesTo input = shouldParse . parse parser "" . BS.fromStrict . encodeUtf8 $ T.pack input
     descFun input expResult = "should parse " <> input <> " to " <> expResult
+
+assertFailsAt :: Show a => JbflParser a -> (String, Int) -> Spec
+assertFailsAt parser (input, offset) =
+  describe ("should reject " <> input <> " at offset " <> show offset) . works $
+    case parse parser "" (textToLazyByteString input) of
+      Left bundle -> errorOffset (NE.head (bundleErrors bundle)) `shouldBe` offset
+      Right r -> expectationFailure ("parsed to " <> show r)
 
 assertParserFailure
   :: Show a => JbflParser a -> (String, ParseError ByteString Void) -> Spec
@@ -138,5 +149,8 @@ assertParserFailure parser (input, expError) =
 spec :: Spec
 spec = do
   sequence_ $
-    keyPropertyPairSpecs ++ invalidKeyPropertySpecs ++ patternSelectorSpecs
+    keyPropertyPairSpecs
+      ++ invalidKeyPropertySpecs
+      ++ patternSelectorSpecs
+      ++ misplacedArrowSpecs
   ruleSetSpecs

--- a/test/Parsing/DSLSpec.hs
+++ b/test/Parsing/DSLSpec.hs
@@ -26,6 +26,7 @@ patternSelectorSpecs =
     , (".test", Selector (NP.ObjectKey "test"))
     , (".test*", Selector (NP.ObjectPrefixKey "test"))
     , (".deformGroups_oilPan*", Selector (NP.ObjectPrefixKey "deformGroups_oilPan"))
+    , (".a>.b", Selector (NP.ObjectKey "a"))
     , (".3", Selector (NP.ObjectIndex 3))
     , ("[3]", Selector (NP.ArrayIndex 3))
     ]


### PR DESCRIPTION
The last of the three steps in #187. A rule reaches below the node its pattern names, and there is no way to say it should not. `>` restricts that: `a > b { ... }` applies at `b` and nowhere below it.