### PR TITLE
Replace prefixProperties with a total propertyReach

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -359,7 +359,7 @@ everywhere and passes.
 
 ### Adding a new JBFL property
 
-`PropertyKey` is a GADT in `Formatting/Rules.hs`. Adding a new property requires updates in all of these places:
+`PropertyKey` is a GADT in `Formatting/Rules.hs`. Adding a new property requires updates in all of these places — missing any one causes a compile error:
 
 1. `PropertyKey a` GADT definition
 2. `propertyName`
@@ -367,11 +367,9 @@ everywhere and passes.
 4. `boolProperties`, `enumProperties` or `intProperties`
 5. `parseValueForKey` in `Parsing/DSL.hs`
 6. Formatting logic in `Formatting.hs`
-7. `prefixProperties`, if the property should reach below the node its rule names
+7. `propertyReach`, saying whether the property reaches below the node its rule names
 
-The first six fail to compile if you miss them. The seventh does not: leave a
-property out of `prefixProperties` and everything builds, the property just
-stops cascading. `JBFL_DOCS.md` has the table of which ones do.
+`JBFL_DOCS.md` has the user-facing table of which ones do.
 
 ### `examples/` directory structure
 

--- a/src/JbeamEdit/Formatting/Rules.hs
+++ b/src/JbeamEdit/Formatting/Rules.hs
@@ -17,7 +17,8 @@ module JbeamEdit.Formatting.Rules (
   lookupKey,
   allProperties,
   deprecatedAliases,
-  prefixProperties,
+  Reach (..),
+  propertyReach,
   keyName,
   applyPadLogic,
   complexNewLine,
@@ -183,12 +184,19 @@ mergePrefixes ps1 ps2 =
   sortOn (Down . T.length . fst) . M.toList . M.fromListWith (flip (<>)) $
     ps1 <> ps2
 
-prefixProperties :: [SomeKey]
-prefixProperties =
-  SomeKey ComplexNewLine
-    : SomeKey TrailingComma
-    : SomeKey PreserveNumberFormat
-    : map SomeKey [PadAmount, PadDecimals, Indent]
+data Reach = Here | Below
+  deriving stock (Eq, Show)
+
+propertyReach :: PropertyKey a -> Reach
+propertyReach AutoPad = Here
+propertyReach AlignObjectKeys = Here
+propertyReach AutoPadSubObjects = Here
+propertyReach ComplexNewLine = Below
+propertyReach PreserveNumberFormat = Below
+propertyReach PadAmount = Below
+propertyReach PadDecimals = Below
+propertyReach Indent = Below
+propertyReach TrailingComma = Below
 
 -- | Maps deprecated property names to (key, value-when-true, value-when-false).
 deprecatedAliases :: [(Text, (SomeKey, SomeProperty, SomeProperty))]

--- a/src/JbeamEdit/Parsing/DSL.hs
+++ b/src/JbeamEdit/Parsing/DSL.hs
@@ -186,7 +186,7 @@ combineRuleSets (pats, props) = fold [fold (go pat) | pat <- pats]
     go :: [NodePatternSelector] -> Maybe RuleSet
     go [] = Just (mempty {rsHere = hereProps, rsBelow = belowProps})
       where
-        (belowProps, hereProps) = M.partitionWithKey (\k _ -> k `elem` prefixProperties) props
+        (belowProps, hereProps) = M.partitionWithKey (\(SomeKey k) _ -> propertyReach k == Below) props
     go (AnyObjectKey : pats') = Just (mempty {rsAnyObjectKey = go pats'})
     go (AnyArrayIndex : pats') = Just (mempty {rsAnyArrayIndex = go pats'})
     go (Selector (ObjectPrefixKey p) : pats') = Just (mempty {rsPrefixes = maybe [] (\x -> [(p, x)]) (go pats')})


### PR DESCRIPTION
Whether a property reaches below the node its rule names is a fact about the property, not a choice for whoever writes the ruleset, and `prefixProperties` held that as a hand-kept list of keys. Leaving a property out of it compiled, and the property just stopped cascading.

`propertyReach` is one equation per constructor of the `PropertyKey` GADT, so an unclassified property is a non-exhaustive pattern. Removing the `Indent` line to check gives `Patterns of type 'PropertyKey a' not matched: Indent`, which CI turns into a failure through the `-Werror` in `stack.yaml`.

Same classification as before and no behaviour change, so the fixtures under `examples/` are untouched. That also lets the property checklist in `CLAUDE.md` go back to saying every step fails to compile, which it could not while the list existed.

It makes `>` in #187 smaller too: the operator forces `Here` for a block instead of introducing the idea of reach at the same time.
