### PR TITLE
Transform a file that has no beams section

### DIFF
--- a/examples/regression_jbeam/no-beams-repro.jbeam
+++ b/examples/regression_jbeam/no-beams-repro.jbeam
@@ -1,0 +1,18 @@
+{
+"testpart":{
+    "nodes":[
+        ["id", "posX", "posY", "posZ"],
+        // Synthetic regression-test fixture, not vetted by the jbeam
+        // maintainer and not intended as a demo/example.
+        //
+        // Nodes and nothing else. A jbeam file is not obliged to have a beams
+        // section, and classifying, sorting and renaming need no beams at all.
+        // Only support classification does, and its answer here is simply that
+        // there are none.
+        ["nl0", 0.9,  -1.0, 0.1],
+        ["nl1", 0.9,  0.0,  0.1],
+        ["nr2", -0.9, -1.0, 0.1],
+        ["nr3", -0.9, 0.0,  0.1],
+    ],
+},
+}

--- a/test-extra/transformation/Spec.hs
+++ b/test-extra/transformation/Spec.hs
@@ -160,6 +160,7 @@ main = hspec $ do
   letterEndingNodesSpec
   ySortingBandingSpec
   xColumnSortingSpec
+  noBeamsSpec
   metadataAcrossTreesSpec
   metadataPreservedSpec
   triangleMetadataSpec

--- a/test-extra/transformation/Spec/Helpers.hs
+++ b/test-extra/transformation/Spec/Helpers.hs
@@ -7,6 +7,7 @@ module Spec.Helpers (
   effectiveMetaByCoordinate,
   metaNumber,
   outOfOrderPairs,
+  commentTexts,
 ) where
 
 import Data.Char (isDigit)
@@ -17,7 +18,14 @@ import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Vector qualified as V
 import GHC.IsList (fromList)
-import JbeamEdit.Core.Node (Node (..), NumberValue (..), expectArray)
+import JbeamEdit.Core.Node (
+  InternalComment (..),
+  Node (..),
+  NumberValue (..),
+  avNodes,
+  expectArray,
+  ovNodes,
+ )
 import JbeamEdit.Core.NodePath qualified as NP
 import JbeamEdit.IOUtils (tryReadFile)
 import JbeamEdit.Parsing.Jbeam (parseNodes)
@@ -153,3 +161,15 @@ outOfOrderPairs thr resultNode =
   where
     positions = zip (vertexPositionsInOrder resultNode) [0 :: Int ..]
     groupPrefix = T.dropWhileEnd isDigit
+
+{- | Every comment in a top node, in no particular order. The transformation
+writes a side comment above each tree it creates, so the absence of one names
+a tree that was never created.
+-}
+commentTexts :: Node -> [Text]
+commentTexts node = case node of
+  Comment comment -> [cText comment]
+  Array arrayValue -> concatMap commentTexts (V.toList (avNodes arrayValue))
+  Object objectValue -> concatMap commentTexts (V.toList (ovNodes objectValue))
+  ObjectKey (key, value) -> commentTexts key ++ commentTexts value
+  _ -> []

--- a/test-extra/transformation/Spec/Helpers.hs
+++ b/test-extra/transformation/Spec/Helpers.hs
@@ -7,7 +7,6 @@ module Spec.Helpers (
   effectiveMetaByCoordinate,
   metaNumber,
   outOfOrderPairs,
-  commentTexts,
 ) where
 
 import Data.Char (isDigit)
@@ -161,18 +160,3 @@ outOfOrderPairs thr resultNode =
   where
     positions = zip (vertexPositionsInOrder resultNode) [0 :: Int ..]
     groupPrefix = T.dropWhileEnd isDigit
-
-{- | Every comment in a top node, in no particular order. The transformation
-writes a side comment above each tree it creates, so the absence of one names
-a tree that was never created.
--}
-commentTexts :: Node -> [Text]
-commentTexts node = case node of
-  Comment comment -> [cText comment]
-  Array arrayValue -> concatMap commentTexts (V.toList (avNodes arrayValue))
-  Object objectValue -> concatMap commentTexts (V.toList (ovNodes objectValue))
-  ObjectKey (key, value) -> commentTexts key ++ commentTexts value
-  String _ -> []
-  Number _ -> []
-  Bool _ -> []
-  Null -> []

--- a/test-extra/transformation/Spec/Helpers.hs
+++ b/test-extra/transformation/Spec/Helpers.hs
@@ -172,4 +172,7 @@ commentTexts node = case node of
   Array arrayValue -> concatMap commentTexts (V.toList (avNodes arrayValue))
   Object objectValue -> concatMap commentTexts (V.toList (ovNodes objectValue))
   ObjectKey (key, value) -> commentTexts key ++ commentTexts value
-  _ -> []
+  String _ -> []
+  Number _ -> []
+  Bool _ -> []
+  Null -> []

--- a/test-extra/transformation/Spec/Regression.hs
+++ b/test-extra/transformation/Spec/Regression.hs
@@ -235,13 +235,11 @@ noBeamsFixture = "examples/regression_jbeam/no-beams-repro.jbeam"
 noBeamsSpec :: Spec
 noBeamsSpec =
   describe "a file with no beams section" $ do
-    it "is transformed, keeping every node" $
-      withNoBeams $ \resultNode ->
-        length (vertexCoordinates resultNode) `shouldBe` 4
+    it "is transformed, keeping every node" . withNoBeams $ \resultNode ->
+      length (vertexCoordinates resultNode) `shouldBe` 4
 
-    it "classifies no node as support" $
-      withNoBeams $ \resultNode ->
-        commentTexts resultNode `shouldNotContain` ["Support nodes"]
+    it "classifies no node as support" . withNoBeams $ \resultNode ->
+      commentTexts resultNode `shouldNotContain` ["Support nodes"]
   where
     withNoBeams assert = do
       topNode <- parseJbeamFile noBeamsFixture

--- a/test-extra/transformation/Spec/Regression.hs
+++ b/test-extra/transformation/Spec/Regression.hs
@@ -13,11 +13,26 @@ module Spec.Regression (
   noBeamsSpec,
 ) where
 
+import Data.List (sort)
+import Data.List.NonEmpty qualified as NE
 import Data.Map qualified as M
 import Data.Set qualified as S
+import Data.Text (Text)
 import Data.Text qualified as T
+import GHC.IsList (toList)
+import JbeamEdit.Core.Node (Node)
 import JbeamEdit.Transformation
+import JbeamEdit.Transformation.BeamExtraction (vertexConns)
 import JbeamEdit.Transformation.Config
+import JbeamEdit.Transformation.Types (
+  AnnotatedVertex (..),
+  VertexTree (..),
+ )
+import JbeamEdit.Transformation.VertexExtraction (
+  determineGroup',
+  getVertexForest,
+  verticesQuery,
+ )
 import Spec.Helpers
 import Test.Hspec
 
@@ -235,14 +250,35 @@ noBeamsFixture = "examples/regression_jbeam/no-beams-repro.jbeam"
 noBeamsSpec :: Spec
 noBeamsSpec =
   describe "a file with no beams section" $ do
-    it "is transformed, keeping every node" . withNoBeams $ \resultNode ->
-      length (vertexCoordinates resultNode) `shouldBe` 4
-
-    it "classifies no node as support" . withNoBeams $ \resultNode ->
-      commentTexts resultNode `shouldNotContain` ["Support nodes"]
-  where
-    withNoBeams assert = do
+    it "is transformed, keeping every node" $ do
       topNode <- parseJbeamFile noBeamsFixture
       case transform M.empty newTransformationConfig topNode of
         Left err -> expectationFailure ("transform failed: " ++ T.unpack err)
-        Right (_, _, _, resultNode) -> assert resultNode
+        Right (_, _, _, resultNode) ->
+          length (vertexCoordinates resultNode) `shouldBe` 4
+
+    it "counts a connection for every beamed vertex when there are beams" $ do
+      topNode <- parseJbeamFile supportRenameIdempotencyFixture
+      connectionCounts topNode
+        `shouldBe` Right [("nl0", 3), ("nl10", 3), ("nl20", 3)]
+
+    it "counts nothing at all when there are none" $ do
+      topNode <- parseJbeamFile noBeamsFixture
+      connectionCounts topNode `shouldBe` Right []
+
+{- | The connection count `vertexConns` produces, as a sorted list so a spec
+can read it. Grouping the vertices by tree type is what `transform` does
+before it asks, and is repeated here because the wrapper it uses is internal.
+-}
+connectionCounts :: Node -> Either Text [(Text, Int)]
+connectionCounts topNode = do
+  (_, _, forest) <- getVertexForest brks verticesQuery topNode
+  let annotated =
+        concatMap (concatMap (NE.toList . tAnnotatedVertices . snd) . toList) forest
+  grouped <- M.fromListWith (++) <$> mapM withGroup annotated
+  (_, conns) <-
+    vertexConns (maxSupportCoordinates newTransformationConfig) topNode grouped
+  pure (sort [(name, count) | (name, (_, count)) <- M.toList conns])
+  where
+    brks = xGroupBreakpoints newTransformationConfig
+    withGroup av = (,[av]) <$> determineGroup' brks (aVertex av)

--- a/test-extra/transformation/Spec/Regression.hs
+++ b/test-extra/transformation/Spec/Regression.hs
@@ -266,9 +266,9 @@ noBeamsSpec =
       topNode <- parseJbeamFile noBeamsFixture
       connectionCounts topNode `shouldBe` Right []
 
-{- | The connection count `vertexConns` produces, as a sorted list so a spec
-can read it. Grouping the vertices by tree type is what `transform` does
-before it asks, and is repeated here because the wrapper it uses is internal.
+{- | Grouping the vertices by tree type is what `transform` does before it
+asks for the counts, and is repeated here because the wrapper it uses is
+internal.
 -}
 connectionCounts :: Node -> Either Text [(Text, Int)]
 connectionCounts topNode = do

--- a/test-extra/transformation/Spec/Regression.hs
+++ b/test-extra/transformation/Spec/Regression.hs
@@ -10,6 +10,7 @@ module Spec.Regression (
   metadataAcrossTreesSpec,
   metadataPreservedSpec,
   xColumnSortingSpec,
+  noBeamsSpec,
 ) where
 
 import Data.Map qualified as M
@@ -220,3 +221,24 @@ xColumnSortingSpec =
       case transform M.empty columnSortingConfig node of
         Left err -> expectationFailure ("transform failed: " ++ T.unpack err)
         Right (_, _, _, resultNode) -> assert resultNode
+
+{- | A jbeam file is not obliged to have a beams section. Classifying, sorting
+and renaming need none: only support classification reads beams, and its
+answer without them is that there are no support nodes. Issue #229.
+
+`transform` instead fails the whole file, and the tool still exits 0, so a
+run over a directory leaves such files untouched without saying why.
+-}
+noBeamsFixture :: FilePath
+noBeamsFixture = "examples/regression_jbeam/no-beams-repro.jbeam"
+
+noBeamsSpec :: Spec
+noBeamsSpec =
+  describe "a file with no beams section"
+    . it "is transformed, with no node classified as support"
+    $ do
+      topNode <- parseJbeamFile noBeamsFixture
+      case transform M.empty newTransformationConfig topNode of
+        Left err -> expectationFailure ("transform failed: " ++ T.unpack err)
+        Right (_, _, _, resultNode) ->
+          length (vertexCoordinates resultNode) `shouldBe` 4

--- a/test-extra/transformation/Spec/Regression.hs
+++ b/test-extra/transformation/Spec/Regression.hs
@@ -234,11 +234,17 @@ noBeamsFixture = "examples/regression_jbeam/no-beams-repro.jbeam"
 
 noBeamsSpec :: Spec
 noBeamsSpec =
-  describe "a file with no beams section"
-    . it "is transformed, with no node classified as support"
-    $ do
+  describe "a file with no beams section" $ do
+    it "is transformed, keeping every node" $
+      withNoBeams $ \resultNode ->
+        length (vertexCoordinates resultNode) `shouldBe` 4
+
+    it "classifies no node as support" $
+      withNoBeams $ \resultNode ->
+        commentTexts resultNode `shouldNotContain` ["Support nodes"]
+  where
+    withNoBeams assert = do
       topNode <- parseJbeamFile noBeamsFixture
       case transform M.empty newTransformationConfig topNode of
         Left err -> expectationFailure ("transform failed: " ++ T.unpack err)
-        Right (_, _, _, resultNode) ->
-          length (vertexCoordinates resultNode) `shouldBe` 4
+        Right (_, _, _, resultNode) -> assert resultNode


### PR DESCRIPTION
Closes #229.

A jbeam file is not obliged to have a beams section, and classifying, sorting and renaming need none. Only support classification reads beams, and without them the answer is simply that no node is a support node. `transform` fails the whole file instead.

The failure is quiet. The tool prints the reason to stderr and exits 0, so a run over a directory leaves those files untouched and reports nothing. That is the same shape as the parse failures fixed in #238, where 97 stock files were silently skipped.
