### PR TITLE
Format config sections as config, not as node tables

### DIFF
--- a/examples/ast/jbfl/complex.hs
+++ b/examples/ast/jbfl/complex.hs
@@ -24,6 +24,37 @@ RuleSet
                     ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList
               [
                 ( SomeKey AutoPad, SomeProperty AutoPad True ) ], rsBelow = fromList [] } ),
+          ( ObjectKey "camerasInternal", RuleSet
+            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Just
+              ( RuleSet
+                { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
+                  ( RuleSet
+                    { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
+                      [
+                        ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                        ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Just
+                  ( RuleSet
+                    { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
+                      ( RuleSet
+                        { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
+                          [
+                            ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                            ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList [] } ), rsHere = fromList [], rsBelow = fromList
+                  [
+                    ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList [], rsBelow = fromList [] } ),
+          ( ObjectKey "clutch", RuleSet
+            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
+              ( RuleSet
+                { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
+                  [
+                    ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Nothing, rsHere = fromList
+              [
+                ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ) ], rsBelow = fromList
+              [
+                ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ),
+                ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ),
           ( ObjectKey "components", RuleSet
             { rsBySelectors = fromList
               [
@@ -44,6 +75,85 @@ RuleSet
                   [
                     ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
                     ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList [], rsBelow = fromList [] } ),
+          ( ObjectKey "differential_C", RuleSet
+            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList
+              [
+                ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ) ], rsBelow = fromList
+              [
+                ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ),
+                ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ),
+          ( ObjectKey "differential_F", RuleSet
+            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList
+              [
+                ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ) ], rsBelow = fromList
+              [
+                ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ),
+                ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ),
+          ( ObjectKey "differential_R", RuleSet
+            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList
+              [
+                ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ) ], rsBelow = fromList
+              [
+                ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ),
+                ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ),
+          ( ObjectKey "driveModes", RuleSet
+            { rsBySelectors = fromList
+              [
+                ( ObjectKey "defaultSettings", RuleSet
+                  { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Just
+                    ( RuleSet
+                      { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
+                        ( RuleSet
+                          { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
+                            [
+                              ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                              ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Just
+                        ( RuleSet
+                          { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
+                            ( RuleSet
+                              { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
+                                [
+                                  ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                                  ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList [] } ), rsHere = fromList [], rsBelow = fromList
+                        [
+                          ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                          ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList [], rsBelow = fromList [] } ),
+                ( ObjectKey "modes", RuleSet
+                  { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
+                    ( RuleSet
+                      { rsBySelectors = fromList
+                        [
+                          ( ObjectKey "settings", RuleSet
+                            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Just
+                              ( RuleSet
+                                { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
+                                  ( RuleSet
+                                    { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
+                                      [
+                                        ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                                        ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Just
+                                  ( RuleSet
+                                    { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
+                                      ( RuleSet
+                                        { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
+                                          [
+                                            ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                                            ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList [] } ), rsHere = fromList [], rsBelow = fromList
+                                  [
+                                    ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList [], rsBelow = fromList [] } ) ], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList [] } ), rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList [] } ) ], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList [] } ),
+          ( ObjectKey "engineBlock", RuleSet
+            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
+              ( RuleSet
+                { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
+                  [
+                    ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Nothing, rsHere = fromList
+              [
+                ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ) ], rsBelow = fromList
+              [
+                ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ),
+                ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ),
           ( ObjectKey "flexbodies", RuleSet
             { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Just
               ( RuleSet
@@ -63,6 +173,40 @@ RuleSet
                   [
                     ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
                     ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList [], rsBelow = fromList [] } ),
+          ( ObjectKey "gauges", RuleSet
+            { rsBySelectors = fromList
+              [
+                ( ObjectKey "configuration", RuleSet
+                  { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList
+                    [
+                      ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ) ], rsBelow = fromList
+                    [
+                      ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ),
+                      ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ),
+                ( ObjectKey "displayData", RuleSet
+                  { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList
+                    [
+                      ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ) ], rsBelow = fromList
+                    [
+                      ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ),
+                      ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ) ], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList
+              [
+                ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ) ], rsBelow = fromList
+              [
+                ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ),
+                ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ),
+          ( ObjectKey "gearbox", RuleSet
+            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
+              ( RuleSet
+                { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
+                  [
+                    ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Nothing, rsHere = fromList
+              [
+                ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ) ], rsBelow = fromList
+              [
+                ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ),
+                ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ),
           ( ObjectKey "glowMap", RuleSet
             { rsBySelectors = fromList
               [
@@ -152,6 +296,13 @@ RuleSet
                         [
                           ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
                           ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList [], rsBelow = fromList [] } ),
+                ( ObjectKey "torqueCompressionBrake", RuleSet
+                  { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Just
+                    ( RuleSet
+                      { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
+                        [
+                          ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                          ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList [], rsBelow = fromList [] } ),
                 ( ObjectKey "torqueModIntake", RuleSet
                   { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Just
                     ( RuleSet
@@ -165,12 +316,37 @@ RuleSet
                       { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
                         [
                           ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
-                          ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList [], rsBelow = fromList [] } ) ], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList
+                          ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList [], rsBelow = fromList [] } ) ], rsPrefixes =
+              [
+                ( "deformGroups", RuleSet
+                  { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
+                    [
+                      ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                      ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ) ], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList
               [
                 ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ) ], rsBelow = fromList
               [
                 ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ),
                 ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ),
+          ( ObjectKey "mirrors", RuleSet
+            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Just
+              ( RuleSet
+                { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
+                  ( RuleSet
+                    { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
+                      [
+                        ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                        ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Just
+                  ( RuleSet
+                    { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
+                      ( RuleSet
+                        { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
+                          [
+                            ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                            ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList [] } ), rsHere = fromList [], rsBelow = fromList
+                  [
+                    ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList [], rsBelow = fromList [] } ),
           ( ObjectKey "nodes", RuleSet
             { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Just
               ( RuleSet
@@ -197,7 +373,24 @@ RuleSet
           ( ObjectKey "powertrain", RuleSet
             { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Just
               ( RuleSet
-                { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
+                { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
+                  ( RuleSet
+                    { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
+                      [
+                        ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                        ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
+                  [
+                    ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList [], rsBelow = fromList [] } ),
+          ( ObjectKey "pressureWheels", RuleSet
+            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Just
+              ( RuleSet
+                { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
+                  ( RuleSet
+                    { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
+                      [
+                        ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                        ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
                   [
                     ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
                     ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList [], rsBelow = fromList [] } ),
@@ -219,7 +412,21 @@ RuleSet
                             ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList [] } ), rsHere = fromList [], rsBelow = fromList
                   [
                     ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
-                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList [], rsBelow = fromList [] } ),
+                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList
+              [
+                ( SomeKey AutoPad, SomeProperty AutoPad True ) ], rsBelow = fromList [] } ),
+          ( ObjectKey "radiator", RuleSet
+            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
+              ( RuleSet
+                { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
+                  [
+                    ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Nothing, rsHere = fromList
+              [
+                ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ) ], rsBelow = fromList
+              [
+                ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ),
+                ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ),
           ( ObjectKey "rails", RuleSet
             { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
               ( RuleSet
@@ -227,6 +434,20 @@ RuleSet
                   [
                     ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
                     ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList [] } ),
+          ( ObjectKey "slidenodes", RuleSet
+            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Just
+              ( RuleSet
+                { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
+                  ( RuleSet
+                    { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
+                      [
+                        ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                        ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
+                  [
+                    ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList
+              [
+                ( SomeKey AutoPad, SomeProperty AutoPad True ) ], rsBelow = fromList [] } ),
           ( ObjectKey "slots", RuleSet
             { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Just
               ( RuleSet
@@ -245,7 +466,9 @@ RuleSet
                             ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList [] } ), rsHere = fromList [], rsBelow = fromList
                   [
                     ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
-                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList [], rsBelow = fromList [] } ),
+                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList
+              [
+                ( SomeKey AutoPad, SomeProperty AutoPad True ) ], rsBelow = fromList [] } ),
           ( ObjectKey "slots2", RuleSet
             { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Just
               ( RuleSet
@@ -264,7 +487,9 @@ RuleSet
                             ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList [] } ), rsHere = fromList [], rsBelow = fromList
                   [
                     ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
-                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList [], rsBelow = fromList [] } ),
+                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList
+              [
+                ( SomeKey AutoPad, SomeProperty AutoPad True ) ], rsBelow = fromList [] } ),
           ( ObjectKey "soundConfig", RuleSet
             { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList
               [
@@ -286,6 +511,39 @@ RuleSet
               [
                 ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ),
                 ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ),
+          ( ObjectKey "soundscape", RuleSet
+            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Just
+              ( RuleSet
+                { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
+                  ( RuleSet
+                    { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
+                      [
+                        ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                        ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Just
+                  ( RuleSet
+                    { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
+                      ( RuleSet
+                        { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
+                          [
+                            ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                            ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList [] } ), rsHere = fromList [], rsBelow = fromList
+                  [
+                    ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList [], rsBelow = fromList [] } ),
+          ( ObjectKey "torsionbars", RuleSet
+            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Just
+              ( RuleSet
+                { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
+                  ( RuleSet
+                    { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
+                      [
+                        ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                        ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
+                  [
+                    ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList
+              [
+                ( SomeKey AutoPad, SomeProperty AutoPad True ) ], rsBelow = fromList [] } ),
           ( ObjectKey "triangles", RuleSet
             { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Just
               ( RuleSet
@@ -295,13 +553,49 @@ RuleSet
                     ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList
               [
                 ( SomeKey AutoPad, SomeProperty AutoPad True ) ], rsBelow = fromList [] } ),
+          ( ObjectKey "turbocharger", RuleSet
+            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
+              ( RuleSet
+                { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
+                  [
+                    ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Nothing, rsHere = fromList
+              [
+                ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ) ], rsBelow = fromList
+              [
+                ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ),
+                ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ),
           ( ObjectKey "variables", RuleSet
             { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Just
               ( RuleSet
                 { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
                   [
                     ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
-                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList [], rsBelow = fromList [] } ) ], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
+                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList [], rsBelow = fromList [] } ),
+          ( ObjectKey "vehicleController", RuleSet
+            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
+              ( RuleSet
+                { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
+                  [
+                    ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Nothing, rsHere = fromList
+              [
+                ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ) ], rsBelow = fromList
+              [
+                ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ),
+                ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ),
+          ( ObjectKey "waterDamage", RuleSet
+            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
+              ( RuleSet
+                { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
+                  [
+                    ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Nothing, rsHere = fromList
+              [
+                ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ) ], rsBelow = fromList
+              [
+                ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ),
+                ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ) ], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
         [
           ( SomeKey Indent, SomeProperty Indent 2 ),
           ( SomeKey TrailingComma, SomeProperty TrailingComma None ) ] } ), rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList [] }

--- a/examples/ast/jbfl/complex.hs
+++ b/examples/ast/jbfl/complex.hs
@@ -44,16 +44,11 @@ RuleSet
                     ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
                     ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList [], rsBelow = fromList [] } ),
           ( ObjectKey "clutch", RuleSet
-            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
-              ( RuleSet
-                { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
-                  [
-                    ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
-                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Nothing, rsHere = fromList
+            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList
               [
-                ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ) ], rsBelow = fromList
+                ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ),
+                ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ) ], rsBelow = fromList
               [
-                ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ),
                 ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ),
           ( ObjectKey "components", RuleSet
             { rsBySelectors = fromList
@@ -143,16 +138,11 @@ RuleSet
                                     ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
                                     ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList [], rsBelow = fromList [] } ) ], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList [] } ), rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList [] } ) ], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList [] } ),
           ( ObjectKey "engineBlock", RuleSet
-            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
-              ( RuleSet
-                { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
-                  [
-                    ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
-                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Nothing, rsHere = fromList
+            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList
               [
-                ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ) ], rsBelow = fromList
+                ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ),
+                ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ) ], rsBelow = fromList
               [
-                ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ),
                 ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ),
           ( ObjectKey "flexbodies", RuleSet
             { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Just
@@ -196,16 +186,11 @@ RuleSet
                 ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ),
                 ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ),
           ( ObjectKey "gearbox", RuleSet
-            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
-              ( RuleSet
-                { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
-                  [
-                    ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
-                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Nothing, rsHere = fromList
+            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList
               [
-                ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ) ], rsBelow = fromList
+                ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ),
+                ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ) ], rsBelow = fromList
               [
-                ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ),
                 ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ),
           ( ObjectKey "glowMap", RuleSet
             { rsBySelectors = fromList
@@ -416,16 +401,11 @@ RuleSet
               [
                 ( SomeKey AutoPad, SomeProperty AutoPad True ) ], rsBelow = fromList [] } ),
           ( ObjectKey "radiator", RuleSet
-            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
-              ( RuleSet
-                { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
-                  [
-                    ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
-                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Nothing, rsHere = fromList
+            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList
               [
-                ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ) ], rsBelow = fromList
+                ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ),
+                ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ) ], rsBelow = fromList
               [
-                ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ),
                 ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ),
           ( ObjectKey "rails", RuleSet
             { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
@@ -554,16 +534,11 @@ RuleSet
               [
                 ( SomeKey AutoPad, SomeProperty AutoPad True ) ], rsBelow = fromList [] } ),
           ( ObjectKey "turbocharger", RuleSet
-            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
-              ( RuleSet
-                { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
-                  [
-                    ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
-                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Nothing, rsHere = fromList
+            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList
               [
-                ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ) ], rsBelow = fromList
+                ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ),
+                ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ) ], rsBelow = fromList
               [
-                ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ),
                 ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ),
           ( ObjectKey "variables", RuleSet
             { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Just
@@ -573,28 +548,18 @@ RuleSet
                     ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
                     ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList [], rsBelow = fromList [] } ),
           ( ObjectKey "vehicleController", RuleSet
-            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
-              ( RuleSet
-                { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
-                  [
-                    ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
-                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Nothing, rsHere = fromList
+            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList
               [
-                ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ) ], rsBelow = fromList
+                ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ),
+                ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ) ], rsBelow = fromList
               [
-                ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ),
                 ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ),
           ( ObjectKey "waterDamage", RuleSet
-            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
-              ( RuleSet
-                { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
-                  [
-                    ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
-                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Nothing, rsHere = fromList
+            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList
               [
-                ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ) ], rsBelow = fromList
+                ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ),
+                ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ) ], rsBelow = fromList
               [
-                ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ),
                 ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ) ], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
         [
           ( SomeKey Indent, SomeProperty Indent 2 ),

--- a/examples/ast/jbfl/minimal.hs
+++ b/examples/ast/jbfl/minimal.hs
@@ -24,6 +24,37 @@ RuleSet
                     ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList
               [
                 ( SomeKey AutoPad, SomeProperty AutoPad True ) ], rsBelow = fromList [] } ),
+          ( ObjectKey "camerasInternal", RuleSet
+            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Just
+              ( RuleSet
+                { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
+                  ( RuleSet
+                    { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
+                      [
+                        ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                        ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Just
+                  ( RuleSet
+                    { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
+                      ( RuleSet
+                        { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
+                          [
+                            ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                            ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList [] } ), rsHere = fromList [], rsBelow = fromList
+                  [
+                    ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList [], rsBelow = fromList [] } ),
+          ( ObjectKey "clutch", RuleSet
+            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
+              ( RuleSet
+                { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
+                  [
+                    ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Nothing, rsHere = fromList
+              [
+                ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ) ], rsBelow = fromList
+              [
+                ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ),
+                ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ),
           ( ObjectKey "components", RuleSet
             { rsBySelectors = fromList
               [
@@ -44,6 +75,85 @@ RuleSet
                   [
                     ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
                     ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList [], rsBelow = fromList [] } ),
+          ( ObjectKey "differential_C", RuleSet
+            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList
+              [
+                ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ) ], rsBelow = fromList
+              [
+                ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ),
+                ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ),
+          ( ObjectKey "differential_F", RuleSet
+            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList
+              [
+                ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ) ], rsBelow = fromList
+              [
+                ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ),
+                ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ),
+          ( ObjectKey "differential_R", RuleSet
+            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList
+              [
+                ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ) ], rsBelow = fromList
+              [
+                ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ),
+                ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ),
+          ( ObjectKey "driveModes", RuleSet
+            { rsBySelectors = fromList
+              [
+                ( ObjectKey "defaultSettings", RuleSet
+                  { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Just
+                    ( RuleSet
+                      { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
+                        ( RuleSet
+                          { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
+                            [
+                              ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                              ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Just
+                        ( RuleSet
+                          { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
+                            ( RuleSet
+                              { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
+                                [
+                                  ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                                  ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList [] } ), rsHere = fromList [], rsBelow = fromList
+                        [
+                          ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                          ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList [], rsBelow = fromList [] } ),
+                ( ObjectKey "modes", RuleSet
+                  { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
+                    ( RuleSet
+                      { rsBySelectors = fromList
+                        [
+                          ( ObjectKey "settings", RuleSet
+                            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Just
+                              ( RuleSet
+                                { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
+                                  ( RuleSet
+                                    { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
+                                      [
+                                        ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                                        ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Just
+                                  ( RuleSet
+                                    { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
+                                      ( RuleSet
+                                        { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
+                                          [
+                                            ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                                            ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList [] } ), rsHere = fromList [], rsBelow = fromList
+                                  [
+                                    ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList [], rsBelow = fromList [] } ) ], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList [] } ), rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList [] } ) ], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList [] } ),
+          ( ObjectKey "engineBlock", RuleSet
+            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
+              ( RuleSet
+                { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
+                  [
+                    ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Nothing, rsHere = fromList
+              [
+                ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ) ], rsBelow = fromList
+              [
+                ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ),
+                ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ),
           ( ObjectKey "flexbodies", RuleSet
             { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Just
               ( RuleSet
@@ -63,6 +173,40 @@ RuleSet
                   [
                     ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
                     ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList [], rsBelow = fromList [] } ),
+          ( ObjectKey "gauges", RuleSet
+            { rsBySelectors = fromList
+              [
+                ( ObjectKey "configuration", RuleSet
+                  { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList
+                    [
+                      ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ) ], rsBelow = fromList
+                    [
+                      ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ),
+                      ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ),
+                ( ObjectKey "displayData", RuleSet
+                  { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList
+                    [
+                      ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ) ], rsBelow = fromList
+                    [
+                      ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ),
+                      ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ) ], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList
+              [
+                ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ) ], rsBelow = fromList
+              [
+                ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ),
+                ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ),
+          ( ObjectKey "gearbox", RuleSet
+            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
+              ( RuleSet
+                { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
+                  [
+                    ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Nothing, rsHere = fromList
+              [
+                ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ) ], rsBelow = fromList
+              [
+                ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ),
+                ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ),
           ( ObjectKey "glowMap", RuleSet
             { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
               ( RuleSet
@@ -97,6 +241,13 @@ RuleSet
                         [
                           ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
                           ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList [], rsBelow = fromList [] } ),
+                ( ObjectKey "torqueCompressionBrake", RuleSet
+                  { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Just
+                    ( RuleSet
+                      { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
+                        [
+                          ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                          ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList [], rsBelow = fromList [] } ),
                 ( ObjectKey "torqueModIntake", RuleSet
                   { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Just
                     ( RuleSet
@@ -110,12 +261,37 @@ RuleSet
                       { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
                         [
                           ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
-                          ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList [], rsBelow = fromList [] } ) ], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList
+                          ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList [], rsBelow = fromList [] } ) ], rsPrefixes =
+              [
+                ( "deformGroups", RuleSet
+                  { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
+                    [
+                      ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                      ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ) ], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList
               [
                 ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ) ], rsBelow = fromList
               [
                 ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ),
                 ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ),
+          ( ObjectKey "mirrors", RuleSet
+            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Just
+              ( RuleSet
+                { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
+                  ( RuleSet
+                    { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
+                      [
+                        ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                        ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Just
+                  ( RuleSet
+                    { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
+                      ( RuleSet
+                        { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
+                          [
+                            ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                            ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList [] } ), rsHere = fromList [], rsBelow = fromList
+                  [
+                    ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList [], rsBelow = fromList [] } ),
           ( ObjectKey "nodes", RuleSet
             { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Just
               ( RuleSet
@@ -142,7 +318,24 @@ RuleSet
           ( ObjectKey "powertrain", RuleSet
             { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Just
               ( RuleSet
-                { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
+                { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
+                  ( RuleSet
+                    { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
+                      [
+                        ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                        ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
+                  [
+                    ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList [], rsBelow = fromList [] } ),
+          ( ObjectKey "pressureWheels", RuleSet
+            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Just
+              ( RuleSet
+                { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
+                  ( RuleSet
+                    { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
+                      [
+                        ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                        ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
                   [
                     ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
                     ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList [], rsBelow = fromList [] } ),
@@ -164,7 +357,21 @@ RuleSet
                             ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList [] } ), rsHere = fromList [], rsBelow = fromList
                   [
                     ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
-                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList [], rsBelow = fromList [] } ),
+                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList
+              [
+                ( SomeKey AutoPad, SomeProperty AutoPad True ) ], rsBelow = fromList [] } ),
+          ( ObjectKey "radiator", RuleSet
+            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
+              ( RuleSet
+                { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
+                  [
+                    ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Nothing, rsHere = fromList
+              [
+                ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ) ], rsBelow = fromList
+              [
+                ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ),
+                ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ),
           ( ObjectKey "rails", RuleSet
             { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
               ( RuleSet
@@ -172,6 +379,20 @@ RuleSet
                   [
                     ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
                     ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList [] } ),
+          ( ObjectKey "slidenodes", RuleSet
+            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Just
+              ( RuleSet
+                { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
+                  ( RuleSet
+                    { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
+                      [
+                        ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                        ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
+                  [
+                    ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList
+              [
+                ( SomeKey AutoPad, SomeProperty AutoPad True ) ], rsBelow = fromList [] } ),
           ( ObjectKey "slots", RuleSet
             { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Just
               ( RuleSet
@@ -190,7 +411,9 @@ RuleSet
                             ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList [] } ), rsHere = fromList [], rsBelow = fromList
                   [
                     ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
-                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList [], rsBelow = fromList [] } ),
+                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList
+              [
+                ( SomeKey AutoPad, SomeProperty AutoPad True ) ], rsBelow = fromList [] } ),
           ( ObjectKey "slots2", RuleSet
             { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Just
               ( RuleSet
@@ -209,7 +432,9 @@ RuleSet
                             ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList [] } ), rsHere = fromList [], rsBelow = fromList
                   [
                     ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
-                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList [], rsBelow = fromList [] } ),
+                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList
+              [
+                ( SomeKey AutoPad, SomeProperty AutoPad True ) ], rsBelow = fromList [] } ),
           ( ObjectKey "soundConfig", RuleSet
             { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList
               [
@@ -231,6 +456,39 @@ RuleSet
               [
                 ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ),
                 ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ),
+          ( ObjectKey "soundscape", RuleSet
+            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Just
+              ( RuleSet
+                { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
+                  ( RuleSet
+                    { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
+                      [
+                        ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                        ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Just
+                  ( RuleSet
+                    { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
+                      ( RuleSet
+                        { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
+                          [
+                            ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                            ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList [] } ), rsHere = fromList [], rsBelow = fromList
+                  [
+                    ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList [], rsBelow = fromList [] } ),
+          ( ObjectKey "torsionbars", RuleSet
+            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Just
+              ( RuleSet
+                { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
+                  ( RuleSet
+                    { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
+                      [
+                        ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                        ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
+                  [
+                    ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList
+              [
+                ( SomeKey AutoPad, SomeProperty AutoPad True ) ], rsBelow = fromList [] } ),
           ( ObjectKey "triangles", RuleSet
             { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Just
               ( RuleSet
@@ -240,10 +498,46 @@ RuleSet
                     ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList
               [
                 ( SomeKey AutoPad, SomeProperty AutoPad True ) ], rsBelow = fromList [] } ),
+          ( ObjectKey "turbocharger", RuleSet
+            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
+              ( RuleSet
+                { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
+                  [
+                    ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Nothing, rsHere = fromList
+              [
+                ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ) ], rsBelow = fromList
+              [
+                ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ),
+                ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ),
           ( ObjectKey "variables", RuleSet
             { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Just
               ( RuleSet
                 { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
                   [
                     ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
-                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList [], rsBelow = fromList [] } ) ], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList [] } ), rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList [] }
+                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList [], rsBelow = fromList [] } ),
+          ( ObjectKey "vehicleController", RuleSet
+            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
+              ( RuleSet
+                { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
+                  [
+                    ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Nothing, rsHere = fromList
+              [
+                ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ) ], rsBelow = fromList
+              [
+                ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ),
+                ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ),
+          ( ObjectKey "waterDamage", RuleSet
+            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
+              ( RuleSet
+                { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
+                  [
+                    ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
+                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Nothing, rsHere = fromList
+              [
+                ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ) ], rsBelow = fromList
+              [
+                ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ),
+                ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ) ], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList [] } ), rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList [] }

--- a/examples/ast/jbfl/minimal.hs
+++ b/examples/ast/jbfl/minimal.hs
@@ -44,16 +44,11 @@ RuleSet
                     ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
                     ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList [], rsBelow = fromList [] } ),
           ( ObjectKey "clutch", RuleSet
-            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
-              ( RuleSet
-                { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
-                  [
-                    ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
-                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Nothing, rsHere = fromList
+            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList
               [
-                ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ) ], rsBelow = fromList
+                ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ),
+                ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ) ], rsBelow = fromList
               [
-                ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ),
                 ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ),
           ( ObjectKey "components", RuleSet
             { rsBySelectors = fromList
@@ -143,16 +138,11 @@ RuleSet
                                     ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
                                     ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList [], rsBelow = fromList [] } ) ], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList [] } ), rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList [] } ) ], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList [] } ),
           ( ObjectKey "engineBlock", RuleSet
-            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
-              ( RuleSet
-                { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
-                  [
-                    ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
-                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Nothing, rsHere = fromList
+            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList
               [
-                ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ) ], rsBelow = fromList
+                ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ),
+                ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ) ], rsBelow = fromList
               [
-                ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ),
                 ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ),
           ( ObjectKey "flexbodies", RuleSet
             { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Just
@@ -196,16 +186,11 @@ RuleSet
                 ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ),
                 ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ),
           ( ObjectKey "gearbox", RuleSet
-            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
-              ( RuleSet
-                { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
-                  [
-                    ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
-                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Nothing, rsHere = fromList
+            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList
               [
-                ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ) ], rsBelow = fromList
+                ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ),
+                ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ) ], rsBelow = fromList
               [
-                ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ),
                 ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ),
           ( ObjectKey "glowMap", RuleSet
             { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
@@ -361,16 +346,11 @@ RuleSet
               [
                 ( SomeKey AutoPad, SomeProperty AutoPad True ) ], rsBelow = fromList [] } ),
           ( ObjectKey "radiator", RuleSet
-            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
-              ( RuleSet
-                { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
-                  [
-                    ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
-                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Nothing, rsHere = fromList
+            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList
               [
-                ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ) ], rsBelow = fromList
+                ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ),
+                ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ) ], rsBelow = fromList
               [
-                ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ),
                 ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ),
           ( ObjectKey "rails", RuleSet
             { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
@@ -499,16 +479,11 @@ RuleSet
               [
                 ( SomeKey AutoPad, SomeProperty AutoPad True ) ], rsBelow = fromList [] } ),
           ( ObjectKey "turbocharger", RuleSet
-            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
-              ( RuleSet
-                { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
-                  [
-                    ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
-                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Nothing, rsHere = fromList
+            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList
               [
-                ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ) ], rsBelow = fromList
+                ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ),
+                ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ) ], rsBelow = fromList
               [
-                ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ),
                 ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ),
           ( ObjectKey "variables", RuleSet
             { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Just
@@ -518,26 +493,16 @@ RuleSet
                     ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
                     ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsHere = fromList [], rsBelow = fromList [] } ),
           ( ObjectKey "vehicleController", RuleSet
-            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
-              ( RuleSet
-                { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
-                  [
-                    ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
-                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Nothing, rsHere = fromList
+            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList
               [
-                ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ) ], rsBelow = fromList
+                ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ),
+                ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ) ], rsBelow = fromList
               [
-                ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ),
                 ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ),
           ( ObjectKey "waterDamage", RuleSet
-            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Just
-              ( RuleSet
-                { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList
-                  [
-                    ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine None ),
-                    ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ), rsAnyArrayIndex = Nothing, rsHere = fromList
+            { rsBySelectors = fromList [], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList
               [
-                ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ) ], rsBelow = fromList
+                ( SomeKey AlignObjectKeys, SomeProperty AlignObjectKeys True ),
+                ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ) ], rsBelow = fromList
               [
-                ( SomeKey ComplexNewLine, SomeProperty ComplexNewLine Force ),
                 ( SomeKey PreserveNumberFormat, SomeProperty PreserveNumberFormat True ) ] } ) ], rsPrefixes = [], rsAnyObjectKey = Nothing, rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList [] } ), rsAnyArrayIndex = Nothing, rsHere = fromList [], rsBelow = fromList [] }

--- a/examples/jbfl/complex.jbfl
+++ b/examples/jbfl/complex.jbfl
@@ -13,7 +13,9 @@
 }
 
 .*.nodes, .*.beams,
-.*.triangles {
+.*.triangles, .*.slots,
+.*.slots2, .*.props,
+.*.slidenodes, .*.torsionbars {
    AutoPad : true;
 }
 
@@ -28,7 +30,20 @@
 .*.mainEngine.burnEfficiency[*],
 .*.mainEngine.torqueModIntake[*],
 .*.mainEngine.torqueModMult[*],
-.*.powertrain[*], .*.flexbodies[*] {
+.*.mainEngine.torqueCompressionBrake[*],
+.*.powertrain[*], .*.flexbodies[*],
+.*.gearbox.*, .*.clutch.*,
+.*.turbocharger.*,
+.*.vehicleController.*,
+.*.radiator.*, .*.waterDamage.*,
+.*.engineBlock.*,
+.*.pressureWheels[*],
+.*.slidenodes[*], .*.torsionbars[*],
+.*.mainEngine.deformGroups*,
+.*.driveModes.defaultSettings[*],
+.*.driveModes.modes.*.settings[*],
+.*.mirrors[*], .*.soundscape[*],
+.*.camerasInternal[*] {
     PreserveNumberFormat : true;
     ComplexNewLine : None;
 }
@@ -43,7 +58,20 @@
 .*.slots2[*].*, .*.slots2[*][*].*,
 .*.props[*].*, .*.props[*][*].*,
 .*.flexbodies[*].*,
-.*.flexbodies[*][*].* {
+.*.flexbodies[*][*].*,
+.*.driveModes.defaultSettings[*].*,
+.*.driveModes.defaultSettings[*][*].*,
+.*.driveModes.modes.*.settings[*].*,
+.*.driveModes.modes.*.settings[*][*].*,
+.*.mirrors[*].*, .*.mirrors[*][*].*,
+.*.soundscape[*].*,
+.*.soundscape[*][*].*,
+.*.camerasInternal[*].*,
+.*.camerasInternal[*][*].*,
+.*.slidenodes[*].*,
+.*.torsionbars[*].*,
+.*.pressureWheels[*].*,
+.*.powertrain[*].* {
     PreserveNumberFormat : true;
     ComplexNewLine : None;
 }
@@ -55,7 +83,14 @@
 
 .*.mainEngine, .*.sounds,
 .*.soundConfig, .*.soundConfigExhaust,
-.*.information,
+.*.information, .*.gearbox,
+.*.clutch, .*.turbocharger,
+.*.vehicleController, .*.radiator,
+.*.waterDamage, .*.engineBlock,
+.*.gauges, .*.gauges.configuration,
+.*.gauges.displayData,
+.*.differential_R, .*.differential_F,
+.*.differential_C,
 .*.glowMap.dumptruck_gaugelight_warning,
 .*.glowMap.chassis_gaugelight_warning {
     ComplexNewLine: Force;

--- a/examples/jbfl/complex.jbfl
+++ b/examples/jbfl/complex.jbfl
@@ -32,11 +32,6 @@
 .*.mainEngine.torqueModMult[*],
 .*.mainEngine.torqueCompressionBrake[*],
 .*.powertrain[*], .*.flexbodies[*],
-.*.gearbox.*, .*.clutch.*,
-.*.turbocharger.*,
-.*.vehicleController.*,
-.*.radiator.*, .*.waterDamage.*,
-.*.engineBlock.*,
 .*.pressureWheels[*],
 .*.slidenodes[*], .*.torsionbars[*],
 .*.mainEngine.deformGroups*,
@@ -76,6 +71,28 @@
     ComplexNewLine : None;
 }
 
+/* These containers render multi-line with aligned keys, but the arrays and
+  objects inside them stay on one line. ComplexNewLine reaches below the node
+  its rule names, so without > each of the seven needed a second rule setting
+  None on its children purely to undo the first. PreserveNumberFormat has to
+  keep reaching down, which is why it cannot join the > block. */
+.* > .gearbox, .* > .clutch,
+.* > .turbocharger,
+.* > .vehicleController,
+.* > .radiator, .* > .waterDamage,
+.* > .engineBlock {
+    ComplexNewLine: Force;
+    AlignObjectKeys: true;
+}
+
+.*.gearbox, .*.clutch,
+.*.turbocharger,
+.*.vehicleController,
+.*.radiator, .*.waterDamage,
+.*.engineBlock {
+    PreserveNumberFormat: true;
+}
+
 .*.glowMap {
     AlignObjectKeys: true;
     AutoPadSubObjects: true;
@@ -83,11 +100,8 @@
 
 .*.mainEngine, .*.sounds,
 .*.soundConfig, .*.soundConfigExhaust,
-.*.information, .*.gearbox,
-.*.clutch, .*.turbocharger,
-.*.vehicleController, .*.radiator,
-.*.waterDamage, .*.engineBlock,
-.*.gauges, .*.gauges.configuration,
+.*.information, .*.gauges,
+.*.gauges.configuration,
 .*.gauges.displayData,
 .*.differential_R, .*.differential_F,
 .*.differential_C,

--- a/examples/jbfl/minimal.jbfl
+++ b/examples/jbfl/minimal.jbfl
@@ -7,7 +7,9 @@
 }
 
 .*.nodes, .*.beams,
-.*.triangles {
+.*.triangles, .*.slots,
+.*.slots2, .*.props,
+.*.slidenodes, .*.torsionbars {
     AutoPad: true;
 }
 
@@ -25,7 +27,20 @@
 .*.mainEngine.burnEfficiency[*],
 .*.mainEngine.torqueModIntake[*],
 .*.mainEngine.torqueModMult[*],
-.*.powertrain[*], .*.flexbodies[*] {
+.*.mainEngine.torqueCompressionBrake[*],
+.*.powertrain[*], .*.flexbodies[*],
+.*.gearbox.*, .*.clutch.*,
+.*.turbocharger.*,
+.*.vehicleController.*,
+.*.radiator.*, .*.waterDamage.*,
+.*.engineBlock.*,
+.*.pressureWheels[*],
+.*.slidenodes[*], .*.torsionbars[*],
+.*.mainEngine.deformGroups*,
+.*.driveModes.defaultSettings[*],
+.*.driveModes.modes.*.settings[*],
+.*.mirrors[*], .*.soundscape[*],
+.*.camerasInternal[*] {
     PreserveNumberFormat : true;
     ComplexNewLine : None;
 }
@@ -40,14 +55,34 @@
 .*.slots2[*].*, .*.slots2[*][*].*,
 .*.props[*].*, .*.props[*][*].*,
 .*.flexbodies[*].*,
-.*.flexbodies[*][*].* {
+.*.flexbodies[*][*].*,
+.*.driveModes.defaultSettings[*].*,
+.*.driveModes.defaultSettings[*][*].*,
+.*.driveModes.modes.*.settings[*].*,
+.*.driveModes.modes.*.settings[*][*].*,
+.*.mirrors[*].*, .*.mirrors[*][*].*,
+.*.soundscape[*].*,
+.*.soundscape[*][*].*,
+.*.camerasInternal[*].*,
+.*.camerasInternal[*][*].*,
+.*.slidenodes[*].*,
+.*.torsionbars[*].*,
+.*.pressureWheels[*].*,
+.*.powertrain[*].* {
     PreserveNumberFormat : true;
     ComplexNewLine : None;
 }
 
 .*.mainEngine, .*.sounds,
 .*.soundConfig, .*.soundConfigExhaust,
-.*.information {
+.*.information, .*.gearbox,
+.*.clutch, .*.turbocharger,
+.*.vehicleController, .*.radiator,
+.*.waterDamage, .*.engineBlock,
+.*.gauges, .*.gauges.configuration,
+.*.gauges.displayData,
+.*.differential_R, .*.differential_F,
+.*.differential_C {
     ComplexNewLine: Force;
     AlignObjectKeys: true;
     PreserveNumberFormat: true;

--- a/examples/jbfl/minimal.jbfl
+++ b/examples/jbfl/minimal.jbfl
@@ -29,11 +29,6 @@
 .*.mainEngine.torqueModMult[*],
 .*.mainEngine.torqueCompressionBrake[*],
 .*.powertrain[*], .*.flexbodies[*],
-.*.gearbox.*, .*.clutch.*,
-.*.turbocharger.*,
-.*.vehicleController.*,
-.*.radiator.*, .*.waterDamage.*,
-.*.engineBlock.*,
 .*.pressureWheels[*],
 .*.slidenodes[*], .*.torsionbars[*],
 .*.mainEngine.deformGroups*,
@@ -75,16 +70,35 @@
 
 .*.mainEngine, .*.sounds,
 .*.soundConfig, .*.soundConfigExhaust,
-.*.information, .*.gearbox,
-.*.clutch, .*.turbocharger,
-.*.vehicleController, .*.radiator,
-.*.waterDamage, .*.engineBlock,
-.*.gauges, .*.gauges.configuration,
+.*.information, .*.gauges,
+.*.gauges.configuration,
 .*.gauges.displayData,
 .*.differential_R, .*.differential_F,
 .*.differential_C {
     ComplexNewLine: Force;
     AlignObjectKeys: true;
+    PreserveNumberFormat: true;
+}
+
+/* These containers render multi-line with aligned keys, but the arrays and
+  objects inside them stay on one line. ComplexNewLine reaches below the node
+  its rule names, so without > each of the seven needed a second rule setting
+  None on its children purely to undo the first. PreserveNumberFormat has to
+  keep reaching down, which is why it cannot join the > block. */
+.* > .gearbox, .* > .clutch,
+.* > .turbocharger,
+.* > .vehicleController,
+.* > .radiator, .* > .waterDamage,
+.* > .engineBlock {
+    ComplexNewLine: Force;
+    AlignObjectKeys: true;
+}
+
+.*.gearbox, .*.clutch,
+.*.turbocharger,
+.*.vehicleController,
+.*.radiator, .*.waterDamage,
+.*.engineBlock {
     PreserveNumberFormat: true;
 }
 


### PR DESCRIPTION
The shipped rulesets knew about `nodes`, `beams` and a handful of table-like sections, and treated everything else the same way. That is wrong for the config objects: `driveModes`, `mirrors`, `soundscape` and the powertrain containers came out with their compact rows exploded across many lines, and with the numbers their authors wrote rewritten, so `[0.60, 0.00]` became `[0.6, 0]`.

Formatting every jbeam in the stock vehicle zips, extracted with `tools/extract-and-format-jbeam/corpus-extract.sh`, these rules leave 523 files closer to how they were written, by 15380 lines. The drivemodes files gain 200 to 325 lines each.

The seven config containers use the `>` operator. Each was written twice before, once with `ComplexNewLine: Force` and again as `.X.*` with `None`, purely to stop the first rule reaching its children. `PreserveNumberFormat` stays in a plain rule next to it, because it has to keep reaching down. Over the 186 stock files carrying these sections, 184 format identically to the old pair of rules and two improve: both are gearbox objects holding an array with line comments in it, where forcing the array inline used to rewrite the comments into block comments.

Supersedes #179, which carried the same rules against a master 57 commits older and without the operator.
