### PR TITLE
Read the sort axes from a value instead of naming them in the code

### DIFF
--- a/jbeam-edit.cabal
+++ b/jbeam-edit.cabal
@@ -320,6 +320,7 @@ test-suite jbeam-edit-transformation-test
         Spec.Config
         Spec.Helpers
         Spec.Regression
+        Spec.SortAxes
         Paths_jbeam_edit
 
     autogen-modules:    Paths_jbeam_edit

--- a/src-extra/transformation/JbeamEdit/Transformation.hs
+++ b/src-extra/transformation/JbeamEdit/Transformation.hs
@@ -328,26 +328,27 @@ treesOrder = [LeftTree, MiddleTree, RightTree, SupportTree]
 
 compareAV
   :: (Ord a, Ord b)
-  => (Vertex -> b)
+  => SortAxes
+  -> (Vertex -> b)
   -> VertexTreeType
   -> (a, AnnotatedVertex)
   -> (a, AnnotatedVertex)
   -> Ordering
-compareAV supportKey treeType (band1, vertex1) (band2, vertex2) =
+compareAV axes supportKey treeType (band1, vertex1) (band2, vertex2) =
   let supportNameCompare =
         bool
           EQ
           (on compare (supportKey . aVertex) vertex1 vertex2)
           (treeType == SupportTree)
-      compareZ = comparing (vZ . aVertex) vertex1 vertex2
-      compareY = compare band1 band2
-      compareX = on compare (vX . aVertex) vertex1 vertex2
+      compareWalk = comparing (axisOf (walkAxis axes) . aVertex) vertex1 vertex2
+      compareGroup = compare band1 band2
+      compareTie = on compare (axisOf (tieAxis axes) . aVertex) vertex1 vertex2
    in mconcat
         [ supportNameCompare
         , on compare aMeta vertex1 vertex2
-        , compareY
-        , compareZ
-        , compareX
+        , compareGroup
+        , compareWalk
+        , compareTie
         ]
 
 renameVertexId :: VertexTreeType -> Int -> Text -> Text
@@ -416,12 +417,9 @@ assignNames newNames brks treeType prefixMap av =
       prefixMap' = M.insert cleanPrefix (lastIdx + 1) prefixMap
    in (prefixMap', av {aVertex = newVertex})
 
--- | Y of the first vertex, to seed the first band on a vertex rather than on 0.
-firstY :: NonEmpty AnnotatedVertex -> Scientific
-firstY = vY . aVertex . NE.head
-
-firstX :: NonEmpty (Int, AnnotatedVertex) -> Scientific
-firstX = vX . aVertex . snd . NE.head
+-- | Seeds the first band on a vertex rather than on 0.
+firstOn :: (a -> Scientific) -> NonEmpty a -> Scientific
+firstOn f = f . NE.head
 
 indexBand
   :: Scientific
@@ -429,25 +427,29 @@ indexBand
   -> (Int, Scientific)
   -> a
   -> ((Int, Scientific), (Int, a))
-indexBand thr f (bandIndex, bandY) av =
-  let nodeY = f av
-      distance = abs (nodeY - bandY)
+indexBand thr f (bandIndex, bandStart) av =
+  let coordinate = f av
+      distance = abs (coordinate - bandStart)
    in if distance >= thr
         then
-          ((bandIndex + 1, nodeY), (bandIndex + 1, av))
+          ((bandIndex + 1, coordinate), (bandIndex + 1, av))
         else
-          ((bandIndex, bandY), (bandIndex, av))
+          ((bandIndex, bandStart), (bandIndex, av))
 
 columnBandVertices
-  :: Scientific
+  :: Axis
+  -> Scientific
   -> NonEmpty (Int, AnnotatedVertex)
   -> NonEmpty ((Int, Int), AnnotatedVertex)
-columnBandVertices thr vs =
-  let bandGroups = NE.groupBy1 (on (==) fst) vs
+columnBandVertices axis thr vs =
+  let coordinate = axisOf axis . aVertex . snd
+      bandGroups = NE.groupBy1 (on (==) fst) vs
       assignColumnBand group =
-        let sorted = NE.sortBy (on compare $ vX . aVertex . snd) group
-            (_, bandIndices) = mapAccumL (indexBand thr (vX . aVertex . snd)) (0, firstX sorted) sorted
-         in NE.map (\(xBand, (yBand, vertex)) -> ((yBand, xBand), vertex)) bandIndices
+        let sorted = NE.sortBy (on compare coordinate) group
+            (_, bandIndices) = mapAccumL (indexBand thr coordinate) (0, firstOn coordinate sorted) sorted
+         in NE.map
+              (\(columnBand, (groupBand, vertex)) -> ((groupBand, columnBand), vertex))
+              bandIndices
    in sconcat $ NE.map assignColumnBand bandGroups
 
 sortVertices
@@ -458,9 +460,15 @@ sortVertices
   -> VertexTree
 sortVertices treeType newNames tfCfg (VertexTree comments vertices) =
   let brks = xGroupBreakpoints tfCfg
+      axes = sortAxes tfCfg
       thr = ySortingThreshold tfCfg
-      sorted = NE.sortBy (on compare $ vY . aVertex) vertices
-      (_, bandIndices) = mapAccumL (indexBand thr (vY . aVertex)) (0, firstY sorted) sorted
+      groupCoordinate = axisOf (groupAxis axes) . aVertex
+      sorted = NE.sortBy (on compare groupCoordinate) vertices
+      (_, bandIndices) =
+        mapAccumL
+          (indexBand thr groupCoordinate)
+          (0, firstOn groupCoordinate sorted)
+          sorted
 
       renameVertices
         :: Ord a => NonEmpty (a, AnnotatedVertex) -> NonEmpty AnnotatedVertex
@@ -468,7 +476,7 @@ sortVertices treeType newNames tfCfg (VertexTree comments vertices) =
         let columnSortedAnnotated =
               NE.map snd $
                 NE.sortBy
-                  (compareAV (vertexPrefix newNames brks treeType) treeType)
+                  (compareAV axes (vertexPrefix newNames brks treeType) treeType)
                   banded
          in snd $
               mapAccumL (assignNames newNames brks treeType) M.empty columnSortedAnnotated
@@ -476,7 +484,7 @@ sortVertices treeType newNames tfCfg (VertexTree comments vertices) =
       renamedGroups =
         case xSortingThreshold tfCfg of
           Nothing -> renameVertices bandIndices
-          Just xThr -> renameVertices (columnBandVertices xThr bandIndices)
+          Just xThr -> renameVertices (columnBandVertices AxisX xThr bandIndices)
    in VertexTree comments renamedGroups
 
 updateVerticesInNode

--- a/src-extra/transformation/JbeamEdit/Transformation.hs
+++ b/src-extra/transformation/JbeamEdit/Transformation.hs
@@ -417,7 +417,9 @@ assignNames newNames brks treeType prefixMap av =
       prefixMap' = M.insert cleanPrefix (lastIdx + 1) prefixMap
    in (prefixMap', av {aVertex = newVertex})
 
--- | Seeds the first band on a vertex rather than on 0.
+{- | The coordinate the first band starts from, read off a vertex so that the
+banding is relative to where the data sits and not to the origin.
+-}
 firstOn :: (a -> Scientific) -> NonEmpty a -> Scientific
 firstOn f = f . NE.head
 

--- a/src-extra/transformation/JbeamEdit/Transformation/Config.hs
+++ b/src-extra/transformation/JbeamEdit/Transformation/Config.hs
@@ -10,6 +10,7 @@ module JbeamEdit.Transformation.Config (
   XGroupBreakpoint (..),
   XGroupBreakpoints (..),
   defaultSortingThreshold,
+  defaultSortAxes,
   defaultSupportThreshold,
   defaultBreakpoints,
   defaultMaxSupportCoordinates,
@@ -43,7 +44,11 @@ import GHC.Generics
 import GHC.IO.Exception (IOErrorType (NoSuchThing))
 import GHC.IsList
 import JbeamEdit.IOUtils
-import JbeamEdit.Transformation.Types (VertexTreeType (..))
+import JbeamEdit.Transformation.Types (
+  Axis (..),
+  SortAxes (..),
+  VertexTreeType (..),
+ )
 import Numeric.Natural (Natural)
 import System.OsPath
 import Text.Read (readMaybe)
@@ -53,6 +58,9 @@ defaultXSortingThreshold = Nothing
 
 defaultSortingThreshold :: Scientific
 defaultSortingThreshold = 0.05
+
+defaultSortAxes :: SortAxes
+defaultSortAxes = SortAxes AxisY AxisZ AxisX
 
 defaultSupportThreshold :: Scientific
 defaultSupportThreshold = 96
@@ -70,6 +78,7 @@ defaultBreakpoints =
 
 data TransformationConfig = TransformationConfig
   { ySortingThreshold :: Scientific
+  , sortAxes :: SortAxes
   , xSortingThreshold :: Maybe Scientific
   , xGroupBreakpoints :: XGroupBreakpoints
   , supportThreshold :: Scientific
@@ -81,6 +90,7 @@ newTransformationConfig :: TransformationConfig
 newTransformationConfig =
   TransformationConfig
     defaultSortingThreshold
+    defaultSortAxes
     defaultXSortingThreshold
     defaultBreakpoints
     defaultSupportThreshold
@@ -163,6 +173,8 @@ instance FromJSON TransformationConfig where
   parseJSON = withObject "TransformationConfig" $ \o ->
     TransformationConfig
       <$> o .:? "y-sorting-threshold" .!= defaultSortingThreshold
+      -- No key reads this yet, see #243.
+      <*> pure defaultSortAxes
       <*> parseXSortingThreshold o
       <*> o .:? "x-group-breakpoints" .!= defaultBreakpoints
       <*> parseSupportThreshold o

--- a/src-extra/transformation/JbeamEdit/Transformation/Types.hs
+++ b/src-extra/transformation/JbeamEdit/Transformation/Types.hs
@@ -6,6 +6,9 @@ module JbeamEdit.Transformation.Types (
   Vertex (..),
   AnnotatedVertex (..),
   VertexTreeKey (..),
+  Axis (..),
+  SortAxes (..),
+  axisOf,
   Beam (..),
   BeamPair (..),
   mkBeamPair,
@@ -57,6 +60,23 @@ data Vertex = Vertex
   { vName :: Text
   , vX, vY, vZ :: Scientific
   , vMeta :: Maybe (Vector Node)
+  }
+  deriving (Eq, Show)
+
+data Axis = AxisX | AxisY | AxisZ deriving (Eq, Show)
+
+axisOf :: Axis -> Vertex -> Scientific
+axisOf AxisX = vX
+axisOf AxisY = vY
+axisOf AxisZ = vZ
+
+{- | The three steps of the vertex sort: the axis that is banded with the
+threshold, the axis a band is walked along, and the axis that breaks a tie.
+-}
+data SortAxes = SortAxes
+  { groupAxis :: Axis
+  , walkAxis :: Axis
+  , tieAxis :: Axis
   }
   deriving (Eq, Show)
 

--- a/test-extra/transformation/Spec.hs
+++ b/test-extra/transformation/Spec.hs
@@ -23,6 +23,7 @@ import JbeamEdit.Transformation.Types (Beam)
 import Spec.Config (configParsingSpec)
 import Spec.Helpers (parseJbeamFile)
 import Spec.Regression
+import Spec.SortAxes (sortAxesSpec)
 import System.Directory (getDirectoryContents)
 import System.OsPath
 import Test.Hspec
@@ -155,6 +156,7 @@ main = hspec $ do
   mapM_ (testFixedPoint "cfg-default" newTransformationConfig) inputFiles
   mapM_ (testFixedPoint "cfg-example" tfConfig) inputFiles
   configParsingSpec
+  sortAxesSpec
   beamValidationSpec
   supportRenameIdempotencySpec
   letterEndingNodesSpec

--- a/test-extra/transformation/Spec/SortAxes.hs
+++ b/test-extra/transformation/Spec/SortAxes.hs
@@ -1,0 +1,82 @@
+{- | The three axes the sort reads: the one it bands with the threshold, the
+one it walks a band along, and the one that breaks a tie. The pair below is
+one grid read two ways, so the second spec fails if the axes are threaded
+anywhere but where they are used.
+-}
+module Spec.SortAxes (
+  sortAxesSpec,
+) where
+
+import Data.ByteString.Lazy qualified as LBS
+import Data.Map qualified as M
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Text.Encoding (encodeUtf8)
+import JbeamEdit.Core.Node (Node)
+import JbeamEdit.Parsing.Jbeam (parseNodes)
+import JbeamEdit.Transformation
+import JbeamEdit.Transformation.Config
+import JbeamEdit.Transformation.Types (Axis (..), SortAxes (..))
+import Spec.Helpers (vertexCoordinatesInOrder)
+import Test.Hspec
+
+{- | Two columns of three, all at one height, so the walk axis alone decides
+the order inside a band and the tie axis never speaks. The rows are written in
+neither of the two orders the specs expect, so a sort that ignored an axis and
+left the input order standing would fail both. The beam is there because the
+transform needs a beams section, and one connection is far below the support
+threshold for six vertices.
+-}
+gridSource :: Text
+gridSource =
+  T.unlines
+    [ "{\"testpart\":{"
+    , "    \"nodes\":["
+    , "        [\"id\", \"posX\", \"posY\", \"posZ\"],"
+    , "        [\"nl0\", 0.3,  1.0, 0.5],"
+    , "        [\"nl1\", 0.8,  0.0, 0.5],"
+    , "        [\"nl2\", 0.3, -1.0, 0.5],"
+    , "        [\"nl3\", 0.8,  1.0, 0.5],"
+    , "        [\"nl4\", 0.3,  0.0, 0.5],"
+    , "        [\"nl5\", 0.8, -1.0, 0.5],"
+    , "    ],"
+    , "    \"beams\":["
+    , "        [\"id1:\", \"id2:\"],"
+    , "        [\"nl0\", \"nl1\"],"
+    , "    ],"
+    , "},"
+    , "}"
+    ]
+
+grid :: Node
+grid = case parseNodes (LBS.fromStrict (encodeUtf8 gridSource)) of
+  Right node -> node
+  Left err -> error ("the grid source does not parse: " ++ T.unpack err)
+
+coordinatesWith :: SortAxes -> IO [(Double, Double, Double)]
+coordinatesWith axes =
+  case transform M.empty newTransformationConfig {sortAxes = axes} grid of
+    Left err -> fail ("transform failed: " ++ T.unpack err)
+    Right (_, _, _, resultNode) -> pure (vertexCoordinatesInOrder resultNode)
+
+sortAxesSpec :: Spec
+sortAxesSpec = describe "the axes the sort reads" $ do
+  it "walks each band across the car with the axes the tool has always used" $
+    coordinatesWith defaultSortAxes
+      `shouldReturn` [ (0.3, -1.0, 0.5)
+                     , (0.8, -1.0, 0.5)
+                     , (0.3, 0.0, 0.5)
+                     , (0.8, 0.0, 0.5)
+                     , (0.3, 1.0, 0.5)
+                     , (0.8, 1.0, 0.5)
+                     ]
+
+  it "walks each column front to back when the grouping and walking axes swap" $
+    coordinatesWith (SortAxes AxisX AxisY AxisZ)
+      `shouldReturn` [ (0.3, -1.0, 0.5)
+                     , (0.3, 0.0, 0.5)
+                     , (0.3, 1.0, 0.5)
+                     , (0.8, -1.0, 0.5)
+                     , (0.8, 0.0, 0.5)
+                     , (0.8, 1.0, 0.5)
+                     ]

--- a/test-extra/transformation/Spec/SortAxes.hs
+++ b/test-extra/transformation/Spec/SortAxes.hs
@@ -1,7 +1,7 @@
-{- | The three axes the sort reads: the one it bands with the threshold, the
-one it walks a band along, and the one that breaks a tie. The pair below is
-one grid read two ways, so the second spec fails if the axes are threaded
-anywhere but where they are used.
+{- | One grid read twice, once with the axes the tool has always used and once
+with two of them swapped. Between them the two specs cover all three axes: the
+grouping and walking axes decide the second, and since every Z in the grid is
+equal, the tie axis alone decides the first.
 -}
 module Spec.SortAxes (
   sortAxesSpec,


### PR DESCRIPTION
The first half of #243.

The vertex sort has Y, Z and X written into the comparator and the band pass, so there is no way for a part to ask for a different reading. They move to a value on the config, set to the axes the tool has always used. Nothing that comes out of the tool moves, and that is the whole claim of this change: `examples/transformed_jbeam/` is untouched and the fixture suite is the receipt.

The YAML key that lets a part choose its own axes, and the per part overrides, come next. Keeping them out of this one is deliberate. A refactor whose only evidence is that the output did not move cannot show that in a pull request where the output moves anyway, and the churn is exactly where a dropped comparison would hide.

The two specs read one grid of six nodes twice, once with the default axes and once with the grouping and walking axes swapped, so the value is exercised rather than only compiled. Three mutations were run behind them: hardcoding the group axis back to Y, hardcoding the walk axis back to Z, and flattening the grid into a single column. Each one turns the second spec red on its own. The grid rows are written in neither of the two expected orders for the same reason, since a sort that ignored an axis and left the input order standing would otherwise have passed.
