### PR TITLE
Read only the decimal point from the source, not the whole spelling

### DIFF
--- a/src-extra/transformation/JbeamEdit/Transformation.hs
+++ b/src-extra/transformation/JbeamEdit/Transformation.hs
@@ -294,9 +294,9 @@ annotatedVertexToNodesWithPrev prevMeta (AnnotatedVertex comments vertex meta) =
       vertexArray :: Node
       vertexArray =
         let name = String (vName vertex)
-            x = Number (mkNumberValueNormalized (vX vertex))
-            y = Number (mkNumberValueNormalized (vY vertex))
-            z = Number (mkNumberValueNormalized (vZ vertex))
+            x = Number (vXNum vertex)
+            y = Number (vYNum vertex)
+            z = Number (vZNum vertex)
             possiblyMeta = concatMap (pure . mkObject) (vMeta vertex)
          in mkArray . V.fromList $ [name, x, y, z] ++ possiblyMeta
    in ( map Comment preComments

--- a/src-extra/transformation/JbeamEdit/Transformation/Types.hs
+++ b/src-extra/transformation/JbeamEdit/Transformation/Types.hs
@@ -4,6 +4,9 @@ module JbeamEdit.Transformation.Types (
   VertexTree (..),
   VertexTreeType (..),
   Vertex (..),
+  vX,
+  vY,
+  vZ,
   AnnotatedVertex (..),
   VertexTreeKey (..),
   Beam (..),
@@ -55,17 +58,26 @@ data VertexTree = VertexTree
 
 data Vertex = Vertex
   { vName :: Text
-  , vX, vY, vZ :: Scientific
+  , vXNum, vYNum, vZNum :: NumberValue
   , vMeta :: Maybe (Vector Node)
   }
-  deriving (Eq, Show)
+  deriving (Show)
+
+{- | A vertex keeps the number as the file wrote it, because it is written
+back out unchanged and the formatter decides how it looks. Sorting and
+grouping want the value, and read it through these.
+-}
+vX, vY, vZ :: Vertex -> Scientific
+vX = nvValue . vXNum
+vY = nvValue . vYNum
+vZ = nvValue . vZNum
 
 data AnnotatedVertex = AnnotatedVertex
   { aComments :: [InternalComment]
   , aVertex :: Vertex
   , aMeta :: MetaMap
   }
-  deriving (Eq, Show)
+  deriving (Show)
 
 anVertexName :: AnnotatedVertex -> Text
 anVertexName = vName . aVertex

--- a/src-extra/transformation/JbeamEdit/Transformation/VertexExtraction.hs
+++ b/src-extra/transformation/JbeamEdit/Transformation/VertexExtraction.hs
@@ -19,7 +19,6 @@ import Data.Map (Map)
 import Data.Map qualified as M
 import Data.Map.Ordered (OMap)
 import Data.Maybe (isJust, isNothing, listToMaybe, mapMaybe)
-import Data.Scientific (Scientific)
 import Data.Set (Set)
 import Data.Set qualified as S
 import Data.Text (Text)
@@ -37,9 +36,9 @@ import JbeamEdit.Transformation.Types
 verticesQuery :: NP.NodePath
 verticesQuery = fromList [NP.ObjectIndex 0, NP.ObjectKey "nodes"]
 
-nodeScientific :: Node -> Maybe Scientific
-nodeScientific (Number nv) = Just (numberValueToScientific nv)
-nodeScientific _ = Nothing
+nodeNumberValue :: Node -> Maybe NumberValue
+nodeNumberValue (Number nv) = Just nv
+nodeNumberValue _ = Nothing
 
 newVertex :: Node -> Maybe Vertex
 newVertex (Array av) = case V.toList (avNodes av) of
@@ -51,10 +50,10 @@ newVertex _ = Nothing
 mkVertex
   :: Text -> Node -> Node -> Node -> Maybe (Vector Node) -> Maybe Vertex
 mkVertex name n1 n2 n3 meta = do
-  x <- nodeScientific n1
-  y <- nodeScientific n2
-  z <- nodeScientific n3
-  pure Vertex {vName = name, vX = x, vY = y, vZ = z, vMeta = meta}
+  x <- nodeNumberValue n1
+  y <- nodeNumberValue n2
+  z <- nodeNumberValue n3
+  pure Vertex {vName = name, vXNum = x, vYNum = y, vZNum = z, vMeta = meta}
 
 isNonVertex :: Node -> Bool
 isNonVertex = isNothing . newVertex

--- a/src/JbeamEdit/Core/Node.hs
+++ b/src/JbeamEdit/Core/Node.hs
@@ -33,7 +33,6 @@ import Data.Scientific (
   FPFormat (Fixed),
   Scientific,
   formatScientific,
-  isInteger,
  )
 import Data.Text (Text)
 import Data.Text qualified as T
@@ -155,9 +154,7 @@ numberValueToScientific :: NumberValue -> Scientific
 numberValueToScientific = nvValue
 
 scientificToText :: Scientific -> Text
-scientificToText v
-  | isInteger v = T.pack $ show (floor v :: Integer)
-  | otherwise = T.pack $ formatScientific Fixed Nothing v
+scientificToText v = T.pack $ formatScientific Fixed Nothing v
 
 mkNumberValue :: Text -> Scientific -> NumberValue
 mkNumberValue = NumberValue

--- a/src/JbeamEdit/Core/Node.hs
+++ b/src/JbeamEdit/Core/Node.hs
@@ -12,7 +12,6 @@ module JbeamEdit.Core.Node (
   isPriorAssocCommentNode,
   isComplexNode,
   possiblyChildren,
-  numberValueToScientific,
   scientificToText,
   mkNumberValue,
   mkNumberValueNormalized,
@@ -33,6 +32,7 @@ import Data.Scientific (
   FPFormat (Fixed),
   Scientific,
   formatScientific,
+  isInteger,
  )
 import Data.Text (Text)
 import Data.Text qualified as T
@@ -150,11 +150,10 @@ isPriorAssocCommentNode :: Node -> Bool
 isPriorAssocCommentNode (Comment cmt) = commentIsAttachedToPreviousNode cmt
 isPriorAssocCommentNode _ = False
 
-numberValueToScientific :: NumberValue -> Scientific
-numberValueToScientific = nvValue
-
 scientificToText :: Scientific -> Text
-scientificToText v = T.pack $ formatScientific Fixed Nothing v
+scientificToText v
+  | isInteger v = T.pack $ show (floor v :: Integer)
+  | otherwise = T.pack $ formatScientific Fixed Nothing v
 
 mkNumberValue :: Text -> Scientific -> NumberValue
 mkNumberValue = NumberValue

--- a/src/JbeamEdit/Formatting.hs
+++ b/src/JbeamEdit/Formatting.hs
@@ -216,7 +216,7 @@ addDelimiters rs index rowIdx c complexChildren state acc ns@((node, nodeHadComm
                       { fsObjectKeyWidth = fsObjectKeyWidth state
                       , fsSubObjectWidths = fsSubObjectWidths state
                       }
-                  keyText = formatScalarNode False k
+                  keyText = formatScalarNode k
                   raw = NC.applyCrumb c (formatWithCursor rs stateForObjKey) idx n
                   (formatted, spaces) = splitTrailing comma raw
                   withComma = formatted <> singleCharIf ',' comma <> spaces
@@ -341,7 +341,7 @@ doFormatNode rs cursor state elems =
                 ks = V.mapMaybe toKey nodes
              in if V.null ks
                   then Nothing
-                  else Just (V.maximum (V.map (T.length . formatScalarNode False) ks))
+                  else Just (V.maximum (V.map (T.length . formatScalarNode) ks))
 
       subObjectWidths :: Map Text Int
       subObjectWidths
@@ -352,7 +352,7 @@ doFormatNode rs cursor state elems =
                     V.foldl'
                       ( \acc2 (sn, _) -> case sn of
                           ObjectKey (sk, sv) ->
-                            let kt = formatScalarNode False sk
+                            let kt = formatScalarNode sk
                                 vw =
                                   if isComplexNode sv
                                     then 0
@@ -416,14 +416,13 @@ formatComment (InternalComment {cMultiline = True, cText = c}) =
     leadingSpace = singleCharIfNot ' ' (T.isPrefixOf "\n" c)
     trailingSpace = singleCharIfNot ' ' (T.isSuffixOf "\n" c)
 
-formatScalarNode :: Bool -> Node -> Text
-formatScalarNode _ (String s) = T.concat ["\"", s, "\""]
-formatScalarNode True (Number nv) = nvText nv
-formatScalarNode _ (Number nv) = scientificToText (nvValue nv)
-formatScalarNode _ (Bool True) = "true"
-formatScalarNode _ (Bool _) = "false"
-formatScalarNode _ Null = "null"
-formatScalarNode _ n = error $ "Unhandled scalar node: " <> show n
+formatScalarNode :: Node -> Text
+formatScalarNode (String s) = T.concat ["\"", s, "\""]
+formatScalarNode (Number nv) = scientificToText (nvValue nv)
+formatScalarNode (Bool True) = "true"
+formatScalarNode (Bool _) = "false"
+formatScalarNode Null = "null"
+formatScalarNode n = error $ "Unhandled scalar node: " <> show n
 
 formatWithCursor
   :: RuleSet -> FormattingState -> NC.NodeCursor -> Node -> Text
@@ -452,11 +451,7 @@ formatWithCursor rs state cursor (ObjectKey (k, v)) =
 formatWithCursor _ _ _ (Comment comment) = formatComment comment
 formatWithCursor rs _ cursor n =
   let ps = findPropertiesForCursor cursor rs
-      preserve =
-        ( Just True == lookupProperty PreserveNumberFormat ps
-            || isJust (lookupProperty PadDecimals ps)
-        )
-   in applyPadLogic (formatScalarNode preserve) ps n
+   in applyPadLogic formatScalarNode ps n
 
 formatNode :: RuleSet -> Node -> Text
 formatNode rs node = formatWithCursor rs emptyState newCursor node <> T.singleton '\n'

--- a/src/JbeamEdit/Formatting.hs
+++ b/src/JbeamEdit/Formatting.hs
@@ -16,7 +16,7 @@ import Data.Char (isSpace)
 import Data.Foldable.Extra (notNull)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
-import Data.Maybe (fromMaybe, isJust)
+import Data.Maybe (fromMaybe)
 import Data.Monoid.Extra
 import Data.Text (Text)
 import Data.Text qualified as T

--- a/src/JbeamEdit/Formatting/Rules.hs
+++ b/src/JbeamEdit/Formatting/Rules.hs
@@ -251,26 +251,25 @@ applyDecimalPadding padDecimals node
        in int <> paddedFrac
   | otherwise = node
 
-{- | A whole number renders without a point, so `applyDecimalPadding` has
-nothing to pad and `12.0` would come back as `12`. Only the source text says
-whether the file asked for decimals at all, and that is all it is read for.
--}
-restoreSourcePoint :: Int -> Text -> Text -> Text
-restoreSourcePoint padDecimals origText text
-  | padDecimals > 0
-  , T.any ('.' ==) origText
-  , not (T.any ('.' ==) text) =
-      text <> "."
-  | otherwise = text
-
 applyPadLogic :: (Node -> Text) -> Rule -> Node -> Text
 applyPadLogic f rs n =
   let padAmount = sum $ lookupProperty PadAmount rs
       padDecimals = sum $ lookupProperty PadDecimals rs
       preserveNumberFormat = Just True == lookupProperty PreserveNumberFormat rs
+      -- A whole number renders without a point, so `applyDecimalPadding` would
+      -- have nothing to pad and a `12.0` in the file would come back as `12`.
+      -- Whether the file asked for decimals is the one thing the value cannot
+      -- say. The bare point left here is filled in by the padding below, which
+      -- runs whenever this branch does.
       numberText (NumberValue origText _)
         | preserveNumberFormat = origText
-        | otherwise = restoreSourcePoint padDecimals origText (f n)
+        | padDecimals > 0
+        , T.any ('.' ==) origText
+        , not (T.any ('.' ==) rendered) =
+            rendered <> "."
+        | otherwise = rendered
+        where
+          rendered = f n
       decimalPaddedText = case n of
         Number number -> applyDecimalPadding padDecimals (numberText number)
         _ -> f n

--- a/src/JbeamEdit/Formatting/Rules.hs
+++ b/src/JbeamEdit/Formatting/Rules.hs
@@ -34,6 +34,7 @@ import Data.List (find, sortOn)
 import Data.Map (Map)
 import Data.Map qualified as M
 import Data.Ord (Down (..))
+import Data.Scientific (isFloating, isInteger)
 import Data.Sequence (Seq (..))
 import Data.Text (Text)
 import Data.Text qualified as T
@@ -255,8 +256,15 @@ applyPadLogic :: (Node -> Text) -> Rule -> Node -> Text
 applyPadLogic f rs n =
   let padAmount = sum $ lookupProperty PadAmount rs
       padDecimals = sum $ lookupProperty PadDecimals rs
+      preserveNumberFormat = lookupProperty PreserveNumberFormat rs
+      preserveText text = case (preserveNumberFormat, n) of
+        (Just True, Number number) -> nvText number
+        (_, Number (NumberValue origText number))
+          | padDecimals > 0 && T.any ('.' ==) origText -> text
+          | isInteger number -> T.pack $ show (floor number :: Integer)
+        _ -> text
       decimalPaddedText
-        | isNumberNode n = applyDecimalPadding padDecimals (f n)
+        | isNumberNode n = applyDecimalPadding padDecimals (preserveText $ f n)
         | otherwise = f n
    in bool (T.justifyLeft padAmount ' ' decimalPaddedText) (f n) (isComplexNode n)
 

--- a/src/JbeamEdit/Formatting/Rules.hs
+++ b/src/JbeamEdit/Formatting/Rules.hs
@@ -34,7 +34,6 @@ import Data.List (find, sortOn)
 import Data.Map (Map)
 import Data.Map qualified as M
 import Data.Ord (Down (..))
-import Data.Scientific (isFloating, isInteger)
 import Data.Sequence (Seq (..))
 import Data.Text (Text)
 import Data.Text qualified as T
@@ -252,20 +251,29 @@ applyDecimalPadding padDecimals node
        in int <> paddedFrac
   | otherwise = node
 
+{- | A whole number renders without a point, so `applyDecimalPadding` has
+nothing to pad and `12.0` would come back as `12`. Only the source text says
+whether the file asked for decimals at all, and that is all it is read for.
+-}
+restoreSourcePoint :: Int -> Text -> Text -> Text
+restoreSourcePoint padDecimals origText text
+  | padDecimals > 0
+  , T.any ('.' ==) origText
+  , not (T.any ('.' ==) text) =
+      text <> "."
+  | otherwise = text
+
 applyPadLogic :: (Node -> Text) -> Rule -> Node -> Text
 applyPadLogic f rs n =
   let padAmount = sum $ lookupProperty PadAmount rs
       padDecimals = sum $ lookupProperty PadDecimals rs
-      preserveNumberFormat = lookupProperty PreserveNumberFormat rs
-      preserveText text = case (preserveNumberFormat, n) of
-        (Just True, Number number) -> nvText number
-        (_, Number (NumberValue origText number))
-          | padDecimals > 0 && T.any ('.' ==) origText -> text
-          | isInteger number -> T.pack $ show (floor number :: Integer)
-        _ -> text
-      decimalPaddedText
-        | isNumberNode n = applyDecimalPadding padDecimals (preserveText $ f n)
-        | otherwise = f n
+      preserveNumberFormat = Just True == lookupProperty PreserveNumberFormat rs
+      numberText (NumberValue origText _)
+        | preserveNumberFormat = origText
+        | otherwise = restoreSourcePoint padDecimals origText (f n)
+      decimalPaddedText = case n of
+        Number number -> applyDecimalPadding padDecimals (numberText number)
+        _ -> f n
    in bool (T.justifyLeft padAmount ' ' decimalPaddedText) (f n) (isComplexNode n)
 
 complexNewLine :: RuleSet -> NC.NodeCursor -> Maybe ComplexNewLine

--- a/test-extra/transformation/Spec.hs
+++ b/test-extra/transformation/Spec.hs
@@ -162,4 +162,5 @@ main = hspec $ do
   xColumnSortingSpec
   metadataAcrossTreesSpec
   metadataPreservedSpec
+  vertexTextSpec
   triangleMetadataSpec

--- a/test-extra/transformation/Spec/Helpers.hs
+++ b/test-extra/transformation/Spec/Helpers.hs
@@ -3,6 +3,7 @@ module Spec.Helpers (
   parseJbeamFile,
   vertexPositionsInOrder,
   vertexCoordinatesInOrder,
+  vertexTextsInOrder,
   vertexCoordinates,
   effectiveMetaByCoordinate,
   metaNumber,
@@ -64,6 +65,24 @@ vertexCoordinatesInOrder topNode =
     Left _ -> []
     Right rows ->
       [ (realToFrac (nvValue x), realToFrac (nvValue y), realToFrac (nvValue z))
+      | row <- V.toList rows
+      , Just inner <- [expectArray row]
+      , Just (String name) <- [inner V.!? 0]
+      , name /= "id"
+      , Just (Number x) <- [inner V.!? 1]
+      , Just (Number y) <- [inner V.!? 2]
+      , Just (Number z) <- [inner V.!? 3]
+      ]
+
+{- | The coordinates as text rather than as numbers, so a spec can say what
+a transform wrote back rather than what it means.
+-}
+vertexTextsInOrder :: Node -> [(Text, Text, Text)]
+vertexTextsInOrder topNode =
+  case NP.queryNodes nodesQuery topNode >>= NP.expectArray nodesQuery of
+    Left _ -> []
+    Right rows ->
+      [ (nvText x, nvText y, nvText z)
       | row <- V.toList rows
       , Just inner <- [expectArray row]
       , Just (String name) <- [inner V.!? 0]

--- a/test-extra/transformation/Spec/Regression.hs
+++ b/test-extra/transformation/Spec/Regression.hs
@@ -10,8 +10,10 @@ module Spec.Regression (
   metadataAcrossTreesSpec,
   metadataPreservedSpec,
   xColumnSortingSpec,
+  vertexTextSpec,
 ) where
 
+import Data.List (sort)
 import Data.Map qualified as M
 import Data.Set qualified as S
 import Data.Text qualified as T
@@ -220,3 +222,24 @@ xColumnSortingSpec =
       case transform M.empty columnSortingConfig node of
         Left err -> expectationFailure ("transform failed: " ++ T.unpack err)
         Right (_, _, _, resultNode) -> assert resultNode
+
+{- | The transformation reorders and renames, and never changes a coordinate,
+so a number has to come back out spelled the way the file wrote it. It used to
+be read as a value and written back from that value, which dropped the point
+in `-1.0` and the trailing zeros in `0.5000`. Only the formatter decides how a
+number looks, and it can only do that while the source text is still there.
+
+Compared as sorted lists because the transform is free to move a vertex.
+-}
+vertexTextSpec :: Spec
+vertexTextSpec =
+  describe "the coordinates a transform writes back"
+    . it "are spelled the way the file wrote them"
+    $ do
+      topNode <- parseJbeamFile letterEndingNodesFixture
+      let before = sort (vertexTextsInOrder topNode)
+      before `shouldNotBe` []
+      case transform M.empty newTransformationConfig topNode of
+        Left err -> expectationFailure ("transform failed: " ++ T.unpack err)
+        Right (_, _, _, resultNode) ->
+          sort (vertexTextsInOrder resultNode) `shouldBe` before

--- a/test-extra/transformation/Spec/Regression.hs
+++ b/test-extra/transformation/Spec/Regression.hs
@@ -237,9 +237,9 @@ vertexTextSpec =
     . it "are spelled the way the file wrote them"
     $ do
       topNode <- parseJbeamFile letterEndingNodesFixture
-      let before = sort (vertexTextsInOrder topNode)
-      before `shouldNotBe` []
+      let asWritten = sort (vertexTextsInOrder topNode)
+      asWritten `shouldNotBe` []
       case transform M.empty newTransformationConfig topNode of
         Left err -> expectationFailure ("transform failed: " ++ T.unpack err)
         Right (_, _, _, resultNode) ->
-          sort (vertexTextsInOrder resultNode) `shouldBe` before
+          sort (vertexTextsInOrder resultNode) `shouldBe` asWritten

--- a/test/Formatting/RulesSpec.hs
+++ b/test/Formatting/RulesSpec.hs
@@ -37,7 +37,7 @@ spec = do
             , (SomeKey PadDecimals, SomeProperty PadDecimals 2)
             ]
     it "applies PadAmount and PadDecimals" $
-      applyPadLogic (formatScalarNode False) ruleSet fakeNode `shouldBe` "123.50 "
+      applyPadLogic formatScalarNode ruleSet fakeNode `shouldBe` "123.50 "
 
   describe "matching a pattern against a cursor" $ do
     let cursorAt crumbs = NodeCursor (fromList crumbs)

--- a/test/FormattingSpec.hs
+++ b/test/FormattingSpec.hs
@@ -139,10 +139,15 @@ paddedCell rules cell =
 cellOutput :: Text -> Text
 cellOutput body = "{\"part\" : {\"nodes\" : [[" <> body <> "]]}}\n"
 
-{- | `12.0` comes out as `12`: `scientificToText` rebuilds the text from the
-parsed value and drops the point, and `applyDecimalPadding` only pads text that
-already has one. The source text is still on the node in `nvText`, so the fix
-belongs in the formatter and not in the parser. Issue #217.
+{- | The first three ran red for issue #217 and are green since #241: `12.0`
+used to come out as `12`, because `scientificToText` rebuilds the text from the
+parsed value and drops the point.
+
+The last two are red again. #241 fixed the point by formatting from `nvText`,
+which brings the whole source spelling with it, so a number written in exponent
+form now reaches the output with no fraction to pad at all and a leading sign
+survives. Only the decimal point needs reading from the source; the digits
+should still come from the value, which is what these two say.
 -}
 decimalPaddingSpec :: Spec
 decimalPaddingSpec = do
@@ -164,6 +169,29 @@ decimalPaddingSpec = do
 
     it "leaves significant decimals past the minimum alone" $
       formatCell (Number (mkNumberValue "0.12345" 0.12345)) `shouldBe` wrap "0.12345"
+
+    it "pads one the source wrote in exponent form" $
+      formatCell (Number (mkNumberValue "2.0e-3" 0.002)) `shouldBe` wrap "0.002"
+
+    it "drops a sign the source wrote, which is PreserveNumberFormat's job" $
+      formatCell (Number (mkNumberValue "+1.5" 1.5)) `shouldBe` wrap "1.500"
+
+{- | Zero is the documented way to ask for no decimal padding, so it must not
+also switch on the format preservation that a minimum brings with it. `preserve`
+in `formatWithCursor` asks whether the property is set rather than what it is
+set to, so today zero stops a number being normalized.
+-}
+padDecimalsZeroSpec :: Spec
+padDecimalsZeroSpec = do
+  let formatCell = paddedCell ".*.nodes[*][*] { PadDecimals: 0; }"
+      wrap = cellOutput
+
+  describe "PadDecimals: 0" $ do
+    it "normalises a number instead of echoing the source text" $
+      formatCell (Number (mkNumberValue "0.12000" 0.12)) `shouldBe` wrap "0.12"
+
+    it "normalises one the source wrote in exponent form" $
+      formatCell (Number (mkNumberValue "2.0e-3" 0.002)) `shouldBe` wrap "0.002"
 
 {- | `JBFL_DOCS.md` described this twice and got it wrong both times, once as
 trailing zeros and once as leading spaces, so a reader could reasonably try to
@@ -187,6 +215,7 @@ spec = do
   mapM_ formatNodeSpec specs
   reachSpec
   decimalPaddingSpec
+  padDecimalsZeroSpec
   padAmountSpec
 
   dynamicTests <- runIO dynamicJbflTests


### PR DESCRIPTION
Follow-up to #241, which fixed #217 by formatting a number from the text the source file wrote. That brought the whole spelling with it, not only the decimal point, so three things changed that nobody asked for: a number written in exponent form reached the output with no fraction at all, under a rule asking for three decimals; a leading sign survived, which is `PreserveNumberFormat`'s job; and `PadDecimals: 0`, documented as asking for no padding, quietly turned the preservation on while padding nothing.

The formatter goes back to rendering from the value, and reads the source only to answer the one question the value cannot: whether the file wrote a decimal point at all. `12.0` still comes out as `12.000` and `12` is still left alone.

The transformation had the same fault from the other side. It never changes a coordinate, only reorders and renames, but it dropped the source text on the way in and made a new one on the way out, so a number could come back spelled differently than it went in. The vertex now carries the `NumberValue` it was read from, and `vX`, `vY` and `vZ` take the value off it, so nothing that sorts, bands or classifies had to change. `Eq` on `Vertex` and `AnnotatedVertex` went with it, since nothing used either.

With no text invented anywhere, `scientificToText` renders a whole number as `12` the way it always did, and the only question the source is asked is whether the file wrote a point at all, right where the padding needs the answer.
